### PR TITLE
ci: create PR for rockspec instead of direct push

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -91,11 +91,10 @@ jobs:
             chore
             rockspec
 
-      - name: Link rockspec PR to summary
+      - name: Log rockspec PR creation
         if: steps.create_pr.outputs.pull-request-number != ''
         run: |
           PR_NUMBER="${{ steps.create_pr.outputs.pull-request-number }}"
-          echo "rockspec_pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
           echo "✓ Created PR #$PR_NUMBER for rockspec"
       
       - name: Summary

--- a/.github/workflows/release-to-luarocks.yml
+++ b/.github/workflows/release-to-luarocks.yml
@@ -38,12 +38,16 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             # Extract version from rockspec filename
-            ROCKSPEC_FILE=$(git diff --name-only HEAD~1 HEAD | grep 'rockspecs/markdown-plus.nvim-.*\.rockspec' | head -1)
+            ROCKSPEC_FILE=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep 'rockspecs/markdown-plus.nvim-.*\.rockspec' | head -1)
             if [ -z "$ROCKSPEC_FILE" ]; then
               echo "Error: No rockspec file found in PR"
               exit 1
             fi
             VERSION=$(echo "$ROCKSPEC_FILE" | sed -n 's/.*markdown-plus\.nvim-\([0-9.]*\)-[0-9]\.rockspec/\1/p')
+            if [ -z "$VERSION" ]; then
+              echo "Error: Failed to extract version from rockspec filename: $ROCKSPEC_FILE"
+              exit 1
+            fi
             echo "version=$VERSION" >> $GITHUB_OUTPUT
             echo "✓ Detected version from rockspec: $VERSION"
           else


### PR DESCRIPTION
## 🔧 Workflow Improvement

This PR fixes the workflow failure issue where rockspec commits were being pushed directly to `main`, violating the branch protection rules.

## Changes

### 1. **release-please.yml** 
- **Before:** Directly pushed rockspec commit to main (violates PR requirement)
- **After:** Creates a PR using `peter-evans/create-pull-request@v7`
- Includes nice PR body with release info and links
- Updates workflow summary to link to the rockspec PR

### 2. **release-to-luarocks.yml**
- Added trigger on PR merge for rockspec files
- Auto-detects version from rockspec filename when triggered by PR
- Maintains backward compatibility with manual `workflow_dispatch` trigger

## Benefits

✅ Respects branch protection rules (all changes via PR)  
✅ Provides visibility - reviewers can see what rockspec is being added  
✅ Maintains audit trail through PR reviews  
✅ Auto-triggers LuaRocks publish after rockspec PR is merged  
✅ No need to add bypass actors or weaken security

## Testing

The next release will create a rockspec PR instead of failing. The workflow:
1. Release PR merged → Creates GitHub release + tag
2. Post-release job creates a PR with the rockspec file
3. After reviewing/merging the rockspec PR → LuaRocks publish automatically triggers

---

**Fixes:** Workflow failure from run [#18927938634](https://github.com/YousefHadder/markdown-plus.nvim/actions/runs/18927938634)