### PR TITLE
fix: Recognize empty list items and prevent insert mode interference (#17)

### DIFF
--- a/lua/markdown-plus/list/init.lua
+++ b/lua/markdown-plus/list/init.lua
@@ -112,8 +112,18 @@ end
 function M.setup_renumber_autocmds()
   local group = vim.api.nvim_create_augroup("MarkdownPlusListRenumber", { clear = true })
 
-  -- Renumber on text changes
-  vim.api.nvim_create_autocmd({ "TextChanged", "TextChangedI" }, {
+  -- Renumber on text changes in normal mode only
+  -- Don't renumber during insert mode to avoid interfering with typing
+  vim.api.nvim_create_autocmd("TextChanged", {
+    group = group,
+    buffer = 0,
+    callback = function()
+      renumber.renumber_ordered_lists()
+    end,
+  })
+
+  -- Also renumber when leaving insert mode
+  vim.api.nvim_create_autocmd("InsertLeave", {
     group = group,
     buffer = 0,
     callback = function()

--- a/lua/markdown-plus/list/parser.lua
+++ b/lua/markdown-plus/list/parser.lua
@@ -26,23 +26,50 @@ local DELIMITER_PAREN = ")"
 ---@type markdown-plus.list.Patterns
 M.patterns = {
   unordered = "^(%s*)([%-%+%*])%s+",
+  unordered_empty = "^(%s*)([%-%+%*])%s*$",
   ordered = "^(%s*)(%d+)%.%s+",
+  ordered_empty = "^(%s*)(%d+)%.%s*$",
   checkbox = "^(%s*)([%-%+%*])%s+%[(.?)%]%s+",
   ordered_checkbox = "^(%s*)(%d+)%.%s+%[(.?)%]%s+",
   letter_lower = "^(%s*)([a-z])%.%s+",
+  letter_lower_empty = "^(%s*)([a-z])%.%s*$",
   letter_upper = "^(%s*)([A-Z])%.%s+",
+  letter_upper_empty = "^(%s*)([A-Z])%.%s*$",
   letter_lower_checkbox = "^(%s*)([a-z])%.%s+%[(.?)%]%s+",
   letter_upper_checkbox = "^(%s*)([A-Z])%.%s+%[(.?)%]%s+",
   ordered_paren = "^(%s*)(%d+)%)%s+",
+  ordered_paren_empty = "^(%s*)(%d+)%)%s*$",
   letter_lower_paren = "^(%s*)([a-z])%)%s+",
+  letter_lower_paren_empty = "^(%s*)([a-z])%)%s*$",
   letter_upper_paren = "^(%s*)([A-Z])%)%s+",
+  letter_upper_paren_empty = "^(%s*)([A-Z])%)%s*$",
   ordered_paren_checkbox = "^(%s*)(%d+)%)%s+%[(.?)%]%s+",
   letter_lower_paren_checkbox = "^(%s*)([a-z])%)%s+%[(.?)%]%s+",
   letter_upper_paren_checkbox = "^(%s*)([A-Z])%)%s+%[(.?)%]%s+",
 }
 
 -- Pattern configuration: defines order and metadata for pattern matching
+-- Empty patterns are tried FIRST to avoid matching partial input like "3.H"
 local PATTERN_CONFIG = {
+  -- Empty item patterns (must come before ALL other patterns)
+  { pattern = "ordered_empty", type = "ordered", delimiter = DELIMITER_DOT, has_checkbox = false },
+  { pattern = "letter_lower_empty", type = "letter_lower", delimiter = DELIMITER_DOT, has_checkbox = false },
+  { pattern = "letter_upper_empty", type = "letter_upper", delimiter = DELIMITER_DOT, has_checkbox = false },
+  { pattern = "ordered_paren_empty", type = "ordered_paren", delimiter = DELIMITER_PAREN, has_checkbox = false },
+  {
+    pattern = "letter_lower_paren_empty",
+    type = "letter_lower_paren",
+    delimiter = DELIMITER_PAREN,
+    has_checkbox = false,
+  },
+  {
+    pattern = "letter_upper_paren_empty",
+    type = "letter_upper_paren",
+    delimiter = DELIMITER_PAREN,
+    has_checkbox = false,
+  },
+  { pattern = "unordered_empty", type = "unordered", delimiter = "", has_checkbox = false },
+  -- Checkbox patterns
   { pattern = "ordered_checkbox", type = "ordered", delimiter = DELIMITER_DOT, has_checkbox = true },
   { pattern = "letter_lower_checkbox", type = "letter_lower", delimiter = DELIMITER_DOT, has_checkbox = true },
   { pattern = "letter_upper_checkbox", type = "letter_upper", delimiter = DELIMITER_DOT, has_checkbox = true },
@@ -60,6 +87,7 @@ local PATTERN_CONFIG = {
     delimiter = DELIMITER_PAREN,
     has_checkbox = true,
   },
+  -- Regular patterns with content
   { pattern = "ordered", type = "ordered", delimiter = DELIMITER_DOT, has_checkbox = false },
   { pattern = "letter_lower", type = "letter_lower", delimiter = DELIMITER_DOT, has_checkbox = false },
   { pattern = "letter_upper", type = "letter_upper", delimiter = DELIMITER_DOT, has_checkbox = false },

--- a/lua/markdown-plus/list/renumber.lua
+++ b/lua/markdown-plus/list/renumber.lua
@@ -137,7 +137,12 @@ function M.renumber_list_group(group)
       expected_marker = parser.index_to_letter(idx, true) .. DELIMITER_PAREN
     end
 
-    local expected_line = item.indent .. expected_marker .. checkbox_part .. " " .. item.content
+    local expected_line
+    if item.content == "" then
+      expected_line = item.indent .. expected_marker .. checkbox_part
+    else
+      expected_line = item.indent .. expected_marker .. checkbox_part .. " " .. item.content
+    end
 
     -- Only create change if line is different
     if expected_line ~= item.original_line then


### PR DESCRIPTION
## Description

This PR fixes issue #17 where auto-formatting would incorrectly split lists when encountering empty list items without trailing whitespace.

## Problem

The bug had two root causes:

1. **List parsing didn't recognize empty items without trailing space**: Patterns required `%s+` (1+ spaces), so "3." wasn't recognized as a list item, breaking list continuity during renumbering.

2. **Auto-renumbering ran on every keystroke in insert mode**: The `TextChangedI` autocmd triggered renumbering after every character typed, which interfered with typing by modifying the buffer.

## Solution

### 1. Enhanced List Parsing (parser.lua)
- Added separate patterns for empty list items: `ordered_empty`, `letter_lower_empty`, etc.
- Empty patterns use `%s*$` (zero or more spaces at end of line)
- Regular patterns keep `%s+` (require space before content)
- Empty patterns checked FIRST to prevent false matches like "3.Hello"

### 2. Fixed Empty Content Handling (renumber.lua)
- Don't add trailing space when content is empty
- Preserves "3." instead of converting to "3. "

### 3. Fixed Auto-Renumbering Timing (list/init.lua)
- **Removed `TextChangedI` trigger** - no more renumbering during insert mode
- **Kept `TextChanged`** - renumbers after normal mode edits
- **Added `InsertLeave`** - renumbers when exiting insert mode
- This prevents interference with typing while maintaining auto-renumbering

### 4. Added Regression Tests (list_spec.lua)
- Test for empty items without trailing space
- Test for empty items with trailing space

## Testing

✅ All 65 list tests pass  
✅ All 153 total tests pass  
✅ Linting passes (0 warnings/errors)  
✅ Formatting passes  

## Behavior Changes

| Scenario | Before Fix | After Fix |
|----------|------------|-----------|
| Empty item "3." | ❌ Not recognized, breaks list | ✅ Recognized, maintains continuity |
| Typing "3. " then "H" | ❌ Space deleted immediately | ✅ Space preserved while typing |
| Save file with "3." | ❌ List splits into groups | ✅ Single continuous list |
| Normal mode edit | ✅ Renumbers | ✅ Renumbers |
| Exit insert mode | ❌ No renumber | ✅ Renumbers |

Closes #17