### PR TITLE
fix(bug): get_visual_selection return the first byte of the last char

### DIFF
--- a/lua/markdown-plus/utils.lua
+++ b/lua/markdown-plus/utils.lua
@@ -113,6 +113,21 @@ function M.get_visual_selection(include_col)
 
   local mode = vim.fn.mode()
 
+  ---Get last byte index for given end_col
+  ---@param end_row number
+  ---@param end_col number the first byte index of the last character
+  local function get_real_end_col(end_row, end_col)
+    local end_line = vim.api.nvim_buf_get_lines(0, end_row - 1, end_row, false)[1] or ""
+    if end_col > 0 and #end_line > 0 then
+      local charidx = vim.fn.strchars(end_line:sub(1, end_col - 1))
+      local char = vim.fn.strcharpart(end_line, charidx, 1)
+      local char_len = #char
+      return end_col + char_len - 1
+    else
+      return end_col
+    end
+  end
+
   -- If in visual mode, use current selection
   if mode:match("[vV\22]") then
     local start_pos = vim.fn.getpos("v")
@@ -141,7 +156,7 @@ function M.get_visual_selection(include_col)
         start_row = start_row,
         start_col = start_col,
         end_row = end_row,
-        end_col = end_col,
+        end_col = get_real_end_col(end_row, end_col),
       }
     else
       return {
@@ -159,7 +174,7 @@ function M.get_visual_selection(include_col)
         start_row = start_pos[2],
         start_col = start_pos[3],
         end_row = end_pos[2],
-        end_col = end_pos[3],
+        end_col = get_real_end_col(end_pos[2], end_pos[3]),
       }
     else
       return {


### PR DESCRIPTION
## Description
Origin, `get_visual_selection` will return the first byte of the last char. Now, it return the last byte of the last char.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Related Issues
Fixes #124

## Testing
- [X] Tested manually
- [ ] Added/updated tests (if applicable)

## Checklist
- [x] Code follows project style
- [x] Self-reviewed my code
- [x] Commented complex logic
- [x] Updated documentation (if needed)
- [x] No new warnings generated
