### PR TITLE
fix(bug): basic lazy-loading setup

### DIFF
--- a/lua/markdown-plus/init.lua
+++ b/lua/markdown-plus/init.lua
@@ -157,6 +157,37 @@ function M.setup(opts)
 
   -- Set up autocommands for markdown files
   M.setup_autocmds()
+
+  -- If we're already in a markdown buffer, enable features immediately
+  -- This handles the case where setup() is called via lazy-loading after FileType event
+  if vim.tbl_contains(M.config.filetypes, vim.bo.filetype) then
+    -- Trigger enable for all loaded modules (same as the autocmd callback)
+    if M.list then
+      M.list.enable()
+    end
+    if M.format then
+      M.format.enable()
+    end
+    if M.headers then
+      M.headers.enable()
+    end
+    if M.links then
+      M.links.enable()
+    end
+    if M.images then
+      M.images.enable()
+    end
+    if M.quotes then
+      M.quotes.enable()
+    end
+    if M.callouts then
+      M.callouts.enable()
+    end
+    if M.table then
+      -- Set up buffer-local table keymaps
+      require("markdown-plus.table.keymaps").setup_buffer_keymaps(M.config.table or M.table.config)
+    end
+  end
 end
 
 ---Set up autocommands for markdown files


### PR DESCRIPTION
## Description
Fix a bug where using the basic setup is not actually loading the plugin config.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Related Issues
Fixes #127 

## Testing
- [x] Tested manually
- [ ] Added/updated tests (if applicable)

## Checklist
- [ ] Code follows project style
- [ ] Self-reviewed my code
- [ ] Commented complex logic
- [ ] Updated documentation (if needed)
- [ ] No new warnings generated
