### PR TITLE
feat(format): add smart format toggle with treesitter detection

### DIFF
--- a/lua/markdown-plus/format/init.lua
+++ b/lua/markdown-plus/format/init.lua
@@ -133,7 +133,7 @@ end
 ---@field start_row number Start row (1-indexed)
 ---@field start_col number Start column (1-indexed)
 ---@field end_row number End row (1-indexed)
----@field end_col number End column (exclusive, 1-indexed)
+---@field end_col number End column (inclusive, 1-indexed)
 
 ---Get the formatting node at cursor position using treesitter
 ---Returns the node and its range if cursor is inside a formatted region
@@ -182,7 +182,7 @@ function M.get_formatting_node_at_cursor(format_type)
       start_row = start_row + 1, -- Convert to 1-indexed
       start_col = start_col + 1, -- Convert to 1-indexed
       end_row = end_row + 1, -- Convert to 1-indexed
-      end_col = end_col, -- Exclusive in 0-indexed, same value works as exclusive in 1-indexed
+      end_col = end_col, -- 0-indexed exclusive becomes 1-indexed inclusive (no increment needed)
     }
   end
 

--- a/spec/markdown-plus/format_spec.lua
+++ b/spec/markdown-plus/format_spec.lua
@@ -818,10 +818,8 @@ describe("markdown-plus format", function()
       format.toggle_format_word("bold")
 
       local line = vim.api.nvim_buf_get_lines(0, 0, 1, false)[1]
-      -- If treesitter is available, entire bold range should be removed
-      -- Otherwise, it falls back to word-based behavior
-      -- Either way, "bold" or the range should be modified
-      assert.is_not_nil(line)
+      -- Treesitter removes entire bold range, result should be unformatted
+      assert.equals("Some bold text here", line)
     end)
 
     it("adds formatting when cursor is on unformatted word", function()


### PR DESCRIPTION
## Summary

Implements smart format toggle using treesitter to detect if cursor is inside an existing formatted range. When toggling the same format type, removes formatting from the entire range instead of adding more markers.

## Changes

### New Features
- **Treesitter-based format detection**: Detects `strong_emphasis`, `emphasis`, `strikethrough`, and `code_span` nodes
- **Smart toggle**: Removes formatting from entire range when cursor is inside formatted text
- **Nested formatting support**: Adding italic to bold text produces `***text***` instead of corrupting formatting
- **Visual mode enhancement**: Detects if selection is inside a formatted range and removes the containing formatting
- **Cursor position preservation**: Cursor stays on the same logical character after adding/removing formatting

### Code Quality
- Added `strip_all_formatting()` helper to reduce ~40 lines of code duplication
- Added `get_any_format_at_cursor()` for optimized single-pass format detection (reduces 4 parser calls to 1)
- Added `ESC` constant for consistency
- Added LuaCATS annotations for all public functions
- Graceful fallback when treesitter is unavailable

### Tests
- 16 new tests for treesitter integration
- Tests for cursor position preservation
- Tests for nested formatting scenarios
- Tests for visual mode smart toggle
- All 108 tests pass

## Behavior Examples

| Before | Action | After |
|--------|--------|-------|
| `Some **bold text** here` (cursor on 'bold') | Toggle bold | `Some bold text here` |
| `Some text here` (cursor on 'text') | Toggle bold | `Some **text** here` |
| `**bold**` (cursor on 'bold') | Toggle italic | `***bold***` |
| Visual select 'bold text' inside `**bold text**` | Toggle bold | `bold text` |

Closes #150