### PR TITLE
refactor(utils): add shared element utilities and refactor links/images modules

### DIFF
--- a/lua/markdown-plus/images/init.lua
+++ b/lua/markdown-plus/images/init.lua
@@ -169,7 +169,7 @@ function M.insert_image()
   local title = utils.input("Title (optional): ", "")
 
   local image = build_image(alt, url, title)
-  utils.insert_at_cursor(image)
+  utils.insert_after_cursor(image)
   utils.notify("Image inserted")
 end
 

--- a/lua/markdown-plus/links/init.lua
+++ b/lua/markdown-plus/links/init.lua
@@ -9,7 +9,7 @@ M.config = {}
 ---Link patterns for detection
 ---@type table<string, string>
 M.patterns = {
-  inline_link = "%[(.-)]%((.-)%)", -- [text](url)
+  inline_link = "%[(.-)%]%((.-)%)", -- [text](url)
   reference_link = "%[(.-)%]%[(.-)%]", -- [text][ref]
   reference_def = "^%[(.-)%]:%s*(.+)$", -- [ref]: url
   url = "https?://[%w-_%.%?%.:/%#%[%]@!%$&'%(%)%*%+,;=]+", -- URL pattern
@@ -143,7 +143,7 @@ function M.insert_link()
   end
 
   local link = build_link(text, url)
-  utils.insert_at_cursor(link)
+  utils.insert_after_cursor(link)
   utils.notify("Link inserted")
 end
 

--- a/lua/markdown-plus/utils.lua
+++ b/lua/markdown-plus/utils.lua
@@ -398,7 +398,7 @@ end
 
 ---Find all matches of a pattern in the current line and return the one under cursor
 ---@param pattern string Lua pattern to search for
----@param extractor? fun(match: string, start_pos: number, end_pos: number): table|nil Optional function to extract data from match
+---@param extractor? fun(match: string, match_start: number, match_end: number): table|nil Optional function to extract data from match
 ---@return table|nil result The extracted data from extractor, or basic match info, or nil if no match at cursor
 function M.find_pattern_at_cursor(pattern, extractor)
   local cursor = M.get_cursor()
@@ -517,10 +517,10 @@ function M.replace_in_line(line_num, start_pos, end_pos, new_content)
   M.set_line(line_num, new_line)
 end
 
----Insert content at cursor position and move cursor after inserted content
+---Insert content after cursor position and move cursor after inserted content
 ---@param content string Content to insert
 ---@return nil
-function M.insert_at_cursor(content)
+function M.insert_after_cursor(content)
   local cursor = M.get_cursor()
   local line = M.get_current_line()
   local col = cursor[2]

--- a/spec/markdown-plus/utils_spec.lua
+++ b/spec/markdown-plus/utils_spec.lua
@@ -577,7 +577,7 @@ describe("markdown-plus utils", function()
     end)
   end)
 
-  describe("insert_at_cursor", function()
+  describe("insert_after_cursor", function()
     local buf
 
     before_each(function()
@@ -591,11 +591,11 @@ describe("markdown-plus utils", function()
       end
     end)
 
-    it("inserts content at cursor position", function()
+    it("inserts content after cursor position", function()
       vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "hello world" })
-      vim.api.nvim_win_set_cursor(0, { 1, 4 }) -- after 'hello' (on 'o')
+      vim.api.nvim_win_set_cursor(0, { 1, 4 }) -- on 'o' of 'hello'
 
-      utils.insert_at_cursor(" beautiful")
+      utils.insert_after_cursor(" beautiful")
 
       assert.are.equal("hello beautiful world", utils.get_line(1))
     end)
@@ -604,18 +604,18 @@ describe("markdown-plus utils", function()
       vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "hello world" })
       vim.api.nvim_win_set_cursor(0, { 1, 4 })
 
-      utils.insert_at_cursor("!!!")
+      utils.insert_after_cursor("!!!")
 
       local cursor = vim.api.nvim_win_get_cursor(0)
       assert.are.equal(1, cursor[1])
       assert.are.equal(8, cursor[2]) -- after "hello!!!"
     end)
 
-    it("inserts at start of line", function()
+    it("inserts after first character when cursor at start", function()
       vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "world" })
-      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 }) -- on 'w'
 
-      utils.insert_at_cursor("hello ")
+      utils.insert_after_cursor("hello ")
 
       assert.are.equal("whello orld", utils.get_line(1))
     end)
@@ -624,7 +624,7 @@ describe("markdown-plus utils", function()
       vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "hello" })
       vim.api.nvim_win_set_cursor(0, { 1, 4 }) -- on last char
 
-      utils.insert_at_cursor(" world")
+      utils.insert_after_cursor(" world")
 
       assert.are.equal("hello world", utils.get_line(1))
     end)
@@ -633,7 +633,7 @@ describe("markdown-plus utils", function()
       vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "你好" })
       vim.api.nvim_win_set_cursor(0, { 1, 0 }) -- on first char
 
-      utils.insert_at_cursor("世界")
+      utils.insert_after_cursor("世界")
 
       assert.are.equal("你世界好", utils.get_line(1))
     end)


### PR DESCRIPTION
## Summary

- Add shared element utility functions to `utils.lua` for cursor-based pattern matching and text manipulation
- Refactor `links/init.lua` and `images/init.lua` to use the new shared utilities
- Add capture groups to link patterns for backward compatibility with direct `match()` calls

## Changes

### New shared utilities in `utils.lua`:
- `find_pattern_at_cursor()` - Find pattern match at cursor position with optional data extraction
- `find_patterns_at_cursor()` - Try multiple patterns and return first match
- `get_single_line_selection()` - Get visual selection for single-line elements
- `replace_in_line()` - Replace a range in a line with new content
- `insert_at_cursor()` - Insert content at cursor and move cursor after

### Module refactoring:
- `links/init.lua`: 486 → 367 lines (24% reduction)
- `images/init.lua`: 388 → 251 lines (35% reduction)

### Tests:
- Added 24 tests for new utility functions in `utils_spec.lua`
- All existing tests pass (links: 21, images: 39, utils: 55)

## Test plan

- [x] Run `make test` - all tests pass
- [x] Verify links module functionality unchanged
- [x] Verify images module functionality unchanged