### PR TITLE
refactor: deprecate is_markdown_buffer and remove dead-code callers

### DIFF
--- a/lua/markdown-plus/callouts/init.lua
+++ b/lua/markdown-plus/callouts/init.lua
@@ -45,9 +45,6 @@ end
 --- Enable callouts features for current buffer
 ---@return nil
 function M.enable()
-  if not utils.is_markdown_buffer() then
-    return
-  end
   M.setup_keymaps()
 end
 

--- a/lua/markdown-plus/footnotes/init.lua
+++ b/lua/markdown-plus/footnotes/init.lua
@@ -7,7 +7,6 @@ local insertion = require("markdown-plus.footnotes.insertion")
 local navigation = require("markdown-plus.footnotes.navigation")
 local window = require("markdown-plus.footnotes.window")
 local keymap_helper = require("markdown-plus.keymap_helper")
-local utils = require("markdown-plus.utils")
 
 local M = {}
 
@@ -108,9 +107,6 @@ end
 --- Enable footnotes functionality for current buffer
 ---@return nil
 function M.enable()
-  if not utils.is_markdown_buffer() then
-    return
-  end
   M.setup_keymaps()
 end
 

--- a/lua/markdown-plus/format/init.lua
+++ b/lua/markdown-plus/format/init.lua
@@ -1,7 +1,6 @@
 -- Text formatting module for markdown-plus.nvim
 -- This is the main entry point that orchestrates all format sub-modules
 
-local utils = require("markdown-plus.utils")
 local keymap_helper = require("markdown-plus.keymap_helper")
 
 -- Import sub-modules
@@ -93,10 +92,6 @@ end
 ---Enable formatting features for current buffer
 ---@return nil
 function M.enable()
-  if not utils.is_markdown_buffer() then
-    return
-  end
-
   -- Set up keymaps
   M.setup_keymaps()
 end

--- a/lua/markdown-plus/headers/init.lua
+++ b/lua/markdown-plus/headers/init.lua
@@ -1,5 +1,4 @@
 -- Headers & TOC module for markdown-plus.nvim
-local utils = require("markdown-plus.utils")
 local keymap_helper = require("markdown-plus.keymap_helper")
 
 -- Load sub-modules
@@ -30,10 +29,6 @@ end
 ---Enable headers features for current buffer
 ---@return nil
 function M.enable()
-  if not utils.is_markdown_buffer() then
-    return
-  end
-
   -- Set up keymaps
   M.setup_keymaps()
 end

--- a/lua/markdown-plus/images/init.lua
+++ b/lua/markdown-plus/images/init.lua
@@ -75,10 +75,6 @@ end
 ---Enable images features for current buffer
 ---@return nil
 function M.enable()
-  if not utils.is_markdown_buffer() then
-    return
-  end
-
   -- Set up keymaps
   M.setup_keymaps()
 end

--- a/lua/markdown-plus/links/init.lua
+++ b/lua/markdown-plus/links/init.lua
@@ -49,10 +49,6 @@ end
 ---Enable links features for current buffer
 ---@return nil
 function M.enable()
-  if not utils.is_markdown_buffer() then
-    return
-  end
-
   -- Set up keymaps
   M.setup_keymaps()
 end

--- a/lua/markdown-plus/list/init.lua
+++ b/lua/markdown-plus/list/init.lua
@@ -1,5 +1,4 @@
 -- List management module for markdown-plus.nvim
-local utils = require("markdown-plus.utils")
 local keymap_helper = require("markdown-plus.keymap_helper")
 
 -- Load sub-modules
@@ -26,10 +25,6 @@ end
 
 ---Enable list features for current buffer
 function M.enable()
-  if not utils.is_markdown_buffer() then
-    return
-  end
-
   -- Set up keymaps
   M.setup_keymaps()
 end

--- a/lua/markdown-plus/quote/init.lua
+++ b/lua/markdown-plus/quote/init.lua
@@ -16,9 +16,6 @@ end
 --- Enable quote features for current buffer
 ---@return nil
 function M.enable()
-  if not utils.is_markdown_buffer() then
-    return
-  end
   M.setup_keymaps()
 end
 

--- a/lua/markdown-plus/utils.lua
+++ b/lua/markdown-plus/utils.lua
@@ -71,10 +71,11 @@ function M.get_indent_string(level)
   end
 end
 
--- Check if current buffer is markdown (deprecated, kept for compatibility)
--- Note: This check is now redundant as the autocmd pattern already filters by filetype
----@return boolean True if buffer filetype is markdown
+---Check if current buffer is markdown
+---@deprecated Use filetype autocmd filtering instead. Will be removed in 2.0.0.
+---@return boolean Always returns true
 function M.is_markdown_buffer()
+  vim.deprecate("is_markdown_buffer()", "filetype autocmd filtering", "2.0.0", "markdown-plus.nvim")
   return true
 end
 

--- a/spec/markdown-plus/utils_spec.lua
+++ b/spec/markdown-plus/utils_spec.lua
@@ -4,31 +4,6 @@
 local utils = require("markdown-plus.utils")
 
 describe("markdown-plus utils", function()
-  describe("is_markdown_buffer", function()
-    it("returns true for markdown buffers", function()
-      local buf = vim.api.nvim_create_buf(false, true)
-      vim.bo[buf].filetype = "markdown"
-      vim.api.nvim_set_current_buf(buf)
-
-      assert.is_true(utils.is_markdown_buffer())
-
-      vim.api.nvim_buf_delete(buf, { force = true })
-    end)
-
-    it("always returns true (filetype filtering done by autocmd)", function()
-      -- Note: is_markdown_buffer() always returns true because filetype
-      -- filtering is handled by the autocmd pattern in init.lua.
-      -- This allows the plugin to work with any configured filetype.
-      local buf = vim.api.nvim_create_buf(false, true)
-      vim.bo[buf].filetype = "lua"
-      vim.api.nvim_set_current_buf(buf)
-
-      assert.is_true(utils.is_markdown_buffer())
-
-      vim.api.nvim_buf_delete(buf, { force = true })
-    end)
-  end)
-
   describe("set_cursor", function()
     it("sets cursor to specified position", function()
       local buf = vim.api.nvim_create_buf(false, true)


### PR DESCRIPTION
## Summary

Deprecate `utils.is_markdown_buffer()` (which always returns `true`) with a `vim.deprecate()` warning targeting removal in 2.0.0. Filetype filtering is handled by the autocmd pattern in `init.lua`, making this check redundant.

The function is preserved with a deprecation notice so any external callers get a clear warning instead of a hard break.

## Changes
- Add `vim.deprecate()` call to `is_markdown_buffer()` in `utils.lua`
- Remove dead-code guard blocks from 8 module `enable()` functions: callouts, format, footnotes, list, links, images, quote, headers
- Remove unused `utils` imports from 4 modules that only used it for this function
- Remove corresponding tests from `utils_spec.lua` (the function is deprecated, not tested)