### PR TITLE
feat(health): add treesitter markdown parser check

### DIFF
--- a/lua/markdown-plus/health.lua
+++ b/lua/markdown-plus/health.lua
@@ -137,9 +137,18 @@ function M.check()
     end
 
     -- Check treesitter markdown parser
-    local ts_ok = pcall(vim.treesitter.get_parser, 0, "markdown")
-    if ts_ok then
-      health.ok("Treesitter markdown parser is available (used for smart format detection)")
+    if vim.treesitter and vim.treesitter.get_parser then
+      local ts_ok = pcall(function()
+        return vim.treesitter.get_parser(0, "markdown")
+      end)
+      if ts_ok then
+        health.ok("Treesitter markdown parser is available (used for smart format detection)")
+      else
+        health.info(
+          "Treesitter markdown parser not available (format detection will use regex fallback)",
+          { "Install with :TSInstall markdown for improved format detection accuracy" }
+        )
+      end
     else
       health.info(
         "Treesitter markdown parser not available (format detection will use regex fallback)",

--- a/spec/markdown-plus/health_spec.lua
+++ b/spec/markdown-plus/health_spec.lua
@@ -92,6 +92,34 @@ describe("health check", function()
       vim.health = saved_health
       assert.is_true(success, "Should handle missing vim.health")
     end)
+
+    it("handles missing vim.treesitter gracefully", function()
+      local saved_ts = vim.treesitter
+      vim.treesitter = nil
+
+      local success = pcall(function()
+        health_module.check()
+      end)
+
+      vim.treesitter = saved_ts
+      assert.is_true(success, "Should handle missing vim.treesitter without throwing")
+    end)
+
+    it("handles treesitter get_parser error gracefully", function()
+      local saved_ts = vim.treesitter
+      vim.treesitter = {
+        get_parser = function()
+          error("no parser for markdown")
+        end,
+      }
+
+      local success = pcall(function()
+        health_module.check()
+      end)
+
+      vim.treesitter = saved_ts
+      assert.is_true(success, "Should handle treesitter parser error without throwing")
+    end)
   end)
 
   describe("module accessibility", function()


### PR DESCRIPTION
Add a treesitter markdown parser availability check to `:checkhealth markdown-plus`.

The `format/treesitter.lua` module uses treesitter for smart format detection (e.g., detecting bold/italic nodes). If the markdown parser isn't installed, it silently falls back to regex. This health check informs users about the status and suggests installing the parser for improved accuracy.