### PR TITLE
docs(ai context): update instruction files with correct file and test counts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,12 +12,12 @@
 - **Link management:** Insert, edit, convert inline/reference, auto-link URLs
 
 ### Architecture
-- `lua/markdown-plus/` - Core modules (70 Lua files across 14 directories):
+- `lua/markdown-plus/` - Core modules (74 Lua files across 14 directories):
   - Feature modules: list/, format/, headers/, links/, table/, footnotes/, callouts/, quote/, images/, code_block/, thematic_break/
   - Shared: utils/ (buffer, text, selection, element, html), treesitter/, config/
   - Root: init.lua, types.lua, utils.lua, keymap_helper.lua, health.lua
 - `plugin/markdown-plus.lua` - Entry point with lazy initialization guard
-- `spec/` - 26 Busted test suites
+- `spec/` - 38 Busted test suites
 - `doc/` - Vimdoc help files
 - `rockspecs/` - LuaRocks package specifications
 
@@ -26,7 +26,7 @@
 - **Linting:** .luacheckrc
 - **Formatting:** .stylua.toml
 - **Type checking:** .luarc.json (Lua 5.1 runtime)
-- **Testing:** Busted + Plenary (26 spec files, ~85% coverage)
+- **Testing:** Busted + Plenary (38 spec files, ~85% coverage)
 
 ---
 
@@ -84,6 +84,7 @@
 ```bash
 # Testing
 make test              # Run all tests
+make test-coverage     # Run tests with coverage enforcement (85% overall, 80% critical)
 make test-file         # Run tests for a specific file (set FILE=path/to/spec.lua)
 make test-watch        # Run tests in watch mode
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,15 +3,16 @@
 ## Project
 
 **Stack**: Lua 5.1 / Neovim 0.11+ / Zero dependencies
-**Architecture**: Feature-based modular plugin — 13 feature modules under `lua/markdown-plus/`
+**Architecture**: Feature-based modular plugin — 11 feature modules under `lua/markdown-plus/`
 **Entry points**: `plugin/markdown-plus.lua` (load guard) → `lua/markdown-plus/init.lua` (setup + orchestration)
-**Test command**: `make test` (Busted + plenary.nvim, 26 spec files)
+**Test command**: `make test` (Busted + plenary.nvim, 38 spec files)
 **Build command**: `make check` (lint + format-check + test)
 
 ## Commands
 
 ```bash
 make test              # Run all tests (plenary.nvim harness)
+make test-coverage     # Run tests with coverage enforcement (85% overall, 80% critical)
 make test-file FILE=spec/markdown-plus/list_spec.lua
 make lint              # luacheck
 make format            # stylua (120 col, 2-space indent, double quotes)
@@ -21,12 +22,12 @@ make check             # Full CI: lint + format-check + test
 
 ## Key Directories
 
-- `lua/markdown-plus/` — Core plugin code (70 Lua files across 14 module directories)
+- `lua/markdown-plus/` — Core plugin code (74 Lua files across 14 module directories)
 - `lua/markdown-plus/types.lua` — LuaCATS type definitions (update FIRST for new types)
 - `lua/markdown-plus/config/validate.lua` — Schema-based config validation
 - `lua/markdown-plus/utils.lua` — Shared utilities (cursor, line, buffer ops)
 - `lua/markdown-plus/keymap_helper.lua` — Centralized `<Plug>` + default keymap registration
-- `spec/markdown-plus/` — 26 Busted test suites
+- `spec/markdown-plus/` — 38 Busted test suites
 - `doc/markdown-plus.txt` — Vimdoc help file
 - `plugin/markdown-plus.lua` — Load guard (no logic here)
 
@@ -63,7 +64,7 @@ require("markdown-plus").setup(opts)
 
 - Framework: Busted via plenary.nvim (`spec/minimal_init.lua` bootstraps)
 - Pattern: `describe()`/`it()` blocks, buffer fixtures in `before_each`
-- 26 test files covering: config, utils, list, format (2 files: main + escape), headers (4 files: main + toc actions/render/state), links, table (5 files: main + cell_ops/column_ops/row_ops/row_mapper), footnotes (4 files: main + line_parser/query/scanner), callouts, health, treesitter, images, code_block, thematic_break, quote
+- 38 test files covering: config, utils, list (4 files: main + parser/normal_handler/group_scanner), format (3 files: main + escape/repeat), headers (6 files: main + navigation/manipulation/toc actions/render/state), links, smart_paste, table (6 files: main + cell_ops/column_ops/row_ops/row_mapper/creator), footnotes (7 files: main + line_parser/query/scanner/window/navigation/insertion), callouts, health, treesitter, images (2 files: main + insertion), code_block, thematic_break, quote
 
 ## Don't
 


### PR DESCRIPTION
CLAUDE.md and copilot-instructions.md had stale counts:
- Lua files: 70 → 74
- Test specs: 26 → 38
- Feature modules: 13 → 11

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>