### PR TITLE
fix(list): require trailing space for list marker recognition

### DIFF
--- a/lua/markdown-plus/list/group_scanner.lua
+++ b/lua/markdown-plus/list/group_scanner.lua
@@ -5,6 +5,7 @@ local shared = require("markdown-plus.list.shared")
 local code_block_parser = require("markdown-plus.code_block.parser")
 local M = {}
 
+local SKIP_EMPTY_OPTS = { skip_empty_patterns = true }
 local html_awareness = true
 
 ---Set HTML block awareness state
@@ -102,7 +103,7 @@ function M.is_list_breaking_line(line, line_num, lines)
 
   -- Skip empty-marker patterns so bare markers (e.g. "E.", "1.") without
   -- trailing space are treated as non-list lines that break group continuity
-  if parser.parse_list_line(line, line_num, { skip_empty_patterns = true }) then
+  if parser.parse_list_line(line, line_num, SKIP_EMPTY_OPTS) then
     return false
   end
 
@@ -124,7 +125,7 @@ local function can_merge_between(lines, start_line, end_line, parent_indent)
   for line_num = start_line + 1, end_line - 1 do
     local line = lines[line_num] or ""
     if not line:match("^%s*$") then
-      local list_info = parser.parse_list_line(line, line_num, { skip_empty_patterns = true })
+      local list_info = parser.parse_list_line(line, line_num, SKIP_EMPTY_OPTS)
       if list_info then
         if #list_info.indent <= parent_indent then
           return false
@@ -199,7 +200,7 @@ function M.find_list_groups(lines)
       end
       goto continue
     end
-    local list_info = parser.parse_list_line(line, nil, { skip_empty_patterns = true })
+    local list_info = parser.parse_list_line(line, nil, SKIP_EMPTY_OPTS)
     if list_info and shared.is_orderable_type(list_info.type) then
       local indent_level = #list_info.indent
       local list_type = list_info.type

--- a/lua/markdown-plus/list/group_scanner.lua
+++ b/lua/markdown-plus/list/group_scanner.lua
@@ -100,7 +100,9 @@ function M.is_list_breaking_line(line, line_num, lines)
     return true
   end
 
-  if parser.parse_list_line(line, line_num) then
+  -- Skip empty-marker patterns so bare markers (e.g. "E.", "1.") without
+  -- trailing space are treated as non-list lines that break group continuity
+  if parser.parse_list_line(line, line_num, { skip_empty_patterns = true }) then
     return false
   end
 
@@ -122,7 +124,7 @@ local function can_merge_between(lines, start_line, end_line, parent_indent)
   for line_num = start_line + 1, end_line - 1 do
     local line = lines[line_num] or ""
     if not line:match("^%s*$") then
-      local list_info = parser.parse_list_line(line, line_num)
+      local list_info = parser.parse_list_line(line, line_num, { skip_empty_patterns = true })
       if list_info then
         if #list_info.indent <= parent_indent then
           return false
@@ -197,7 +199,7 @@ function M.find_list_groups(lines)
       end
       goto continue
     end
-    local list_info = parser.parse_list_line(line)
+    local list_info = parser.parse_list_line(line, nil, { skip_empty_patterns = true })
     if list_info and shared.is_orderable_type(list_info.type) then
       local indent_level = #list_info.indent
       local list_type = list_info.type

--- a/lua/markdown-plus/list/parser.lua
+++ b/lua/markdown-plus/list/parser.lua
@@ -101,23 +101,50 @@ local PATTERN_CONFIG = {
   { pattern = "unordered", type = "unordered", delimiter = "", has_checkbox = false },
   -- Empty item patterns (marker at EOL without trailing space)
   -- These are checked last to prefer matching with content when possible
-  { pattern = "ordered_empty", type = "ordered", delimiter = DELIMITER_DOT, has_checkbox = false },
-  { pattern = "letter_lower_empty", type = "letter_lower", delimiter = DELIMITER_DOT, has_checkbox = false },
-  { pattern = "letter_upper_empty", type = "letter_upper", delimiter = DELIMITER_DOT, has_checkbox = false },
-  { pattern = "ordered_paren_empty", type = "ordered_paren", delimiter = DELIMITER_PAREN, has_checkbox = false },
+  -- is_empty allows callers to skip these when scanning for group membership
+  {
+    pattern = "ordered_empty",
+    type = "ordered",
+    delimiter = DELIMITER_DOT,
+    has_checkbox = false,
+    is_empty = true,
+  },
+  {
+    pattern = "letter_lower_empty",
+    type = "letter_lower",
+    delimiter = DELIMITER_DOT,
+    has_checkbox = false,
+    is_empty = true,
+  },
+  {
+    pattern = "letter_upper_empty",
+    type = "letter_upper",
+    delimiter = DELIMITER_DOT,
+    has_checkbox = false,
+    is_empty = true,
+  },
+  {
+    pattern = "ordered_paren_empty",
+    type = "ordered_paren",
+    delimiter = DELIMITER_PAREN,
+    has_checkbox = false,
+    is_empty = true,
+  },
   {
     pattern = "letter_lower_paren_empty",
     type = "letter_lower_paren",
     delimiter = DELIMITER_PAREN,
     has_checkbox = false,
+    is_empty = true,
   },
   {
     pattern = "letter_upper_paren_empty",
     type = "letter_upper_paren",
     delimiter = DELIMITER_PAREN,
     has_checkbox = false,
+    is_empty = true,
   },
-  { pattern = "unordered_empty", type = "unordered", delimiter = "", has_checkbox = false },
+  { pattern = "unordered_empty", type = "unordered", delimiter = "", has_checkbox = false, is_empty = true },
 }
 
 ---Build list info object from parsed components
@@ -226,13 +253,21 @@ local function parse_list_line_ts(row)
   })
 end
 
+---@class markdown-plus.list.ParseOpts
+---@field skip_empty_patterns? boolean When true, skip empty-marker patterns (marker at EOL without trailing space)
+
 ---Parse list info using regex patterns
 ---Used as fallback when treesitter is unavailable or for letter lists
 ---@param line string Line to parse
+---@param opts? markdown-plus.list.ParseOpts Optional parsing options
 ---@return markdown-plus.ListInfo|nil
-local function parse_list_line_regex(line)
+local function parse_list_line_regex(line, opts)
+  local skip_empty = opts and opts.skip_empty_patterns
   -- Try each pattern in order (checkbox variants first, then regular)
   for _, config in ipairs(PATTERN_CONFIG) do
+    if skip_empty and config.is_empty then
+      goto next_pattern
+    end
     local pattern = M.patterns[config.pattern]
     if config.has_checkbox then
       local indent, marker, checkbox = line:match(pattern)
@@ -245,24 +280,41 @@ local function parse_list_line_regex(line)
         return build_list_info(indent, marker, nil, config)
       end
     end
+    ::next_pattern::
   end
 
   return nil
+end
+
+---Check whether a parsed list item is an empty marker (marker at EOL, no trailing content)
+---@param line string The line text
+---@param list_info markdown-plus.ListInfo The parsed list info
+---@return boolean True if the line contains only the marker with no trailing content
+local function is_empty_marker(line, list_info)
+  local after_marker = line:sub(#list_info.indent + #list_info.full_marker + 1)
+  return after_marker:match("^%s*$") ~= nil
 end
 
 ---Parse a line to detect list information
 ---Uses treesitter when row is provided and available, falls back to regex
 ---@param line string Line to parse
 ---@param row? number Optional 1-indexed row for treesitter
+---@param opts? markdown-plus.list.ParseOpts Optional parsing options (e.g., skip_empty_patterns)
 ---@return markdown-plus.ListInfo|nil List info or nil if not a list
-function M.parse_list_line(line, row)
+function M.parse_list_line(line, row, opts)
   if not line then
     return nil
   end
 
+  local skip_empty = opts and opts.skip_empty_patterns
+
   -- Try treesitter first (if row provided)
   local ts_result = row and parse_list_line_ts(row) or nil
   if ts_result then
+    -- When skipping empty patterns, reject markers at EOL with no trailing content
+    if skip_empty and is_empty_marker(line, ts_result) then
+      return nil
+    end
     return ts_result
   end
 
@@ -270,7 +322,7 @@ function M.parse_list_line(line, row)
   -- (handles letter lists, ts unavailable, continuation lines, etc.)
 
   -- Fallback to regex
-  return parse_list_line_regex(line)
+  return parse_list_line_regex(line, opts)
 end
 
 ---Check if a list item is empty (only contains marker)

--- a/lua/markdown-plus/list/parser.lua
+++ b/lua/markdown-plus/list/parser.lua
@@ -292,7 +292,7 @@ end
 ---@return boolean True if the line contains only the marker with no trailing content
 local function is_empty_marker(line, list_info)
   local after_marker = line:sub(#list_info.indent + #list_info.full_marker + 1)
-  return after_marker:match("^%s*$") ~= nil
+  return after_marker == ""
 end
 
 ---Parse a line to detect list information

--- a/spec/markdown-plus/list_group_scanner_spec.lua
+++ b/spec/markdown-plus/list_group_scanner_spec.lua
@@ -2,6 +2,7 @@
 ---Tests list breaking line detection and list group discovery
 ---@diagnostic disable: undefined-field
 local group_scanner = require("markdown-plus.list.group_scanner")
+local parser = require("markdown-plus.list.parser")
 
 describe("markdown-plus list group scanner", function()
   local buf
@@ -159,6 +160,111 @@ describe("markdown-plus list group scanner", function()
       assert.are.equal(2, #groups)
       assert.are.equal(2, #groups[1].items) -- 1. First, 2. Second
       assert.are.equal(1, #groups[2].items) -- 3. Third
+    end)
+  end)
+
+  describe("empty marker exclusion from groups", function()
+    it("does not include standalone empty alpha marker in any group", function()
+      local lines = {
+        "E.",
+      }
+      local groups = group_scanner.find_list_groups(lines)
+      assert.are.equal(0, #groups)
+    end)
+
+    it("does not include standalone empty numeric marker in any group", function()
+      local lines = {
+        "1.",
+      }
+      local groups = group_scanner.find_list_groups(lines)
+      assert.are.equal(0, #groups)
+    end)
+
+    it("does not include standalone empty unordered marker in any group", function()
+      local lines = {
+        "-",
+      }
+      local groups = group_scanner.find_list_groups(lines)
+      assert.are.equal(0, #groups)
+    end)
+
+    it("includes marker with trailing space and content in groups", function()
+      local lines = {
+        "E. text",
+      }
+      local groups = group_scanner.find_list_groups(lines)
+      assert.are.equal(1, #groups)
+      assert.are.equal(1, #groups[1].items)
+      assert.are.equal("letter_upper", groups[1].list_type)
+    end)
+
+    it("groups multi-item alpha list correctly", function()
+      local lines = {
+        "A. first",
+        "B. second",
+      }
+      local groups = group_scanner.find_list_groups(lines)
+      assert.are.equal(1, #groups)
+      assert.are.equal(2, #groups[1].items)
+      assert.are.equal("letter_upper", groups[1].list_type)
+    end)
+
+    it("treats empty marker as list-breaking between real list items", function()
+      local lines = {
+        "A. first",
+        "E.",
+        "B. third",
+      }
+      local groups = group_scanner.find_list_groups(lines)
+      -- E. without trailing space is not a list item and breaks the group
+      assert.are.equal(2, #groups)
+      assert.are.equal(1, #groups[1].items)
+      assert.are.equal(1, #groups[2].items)
+    end)
+
+    it("treats empty numeric marker as list-breaking", function()
+      local lines = {
+        "1. first",
+        "2.",
+        "3. third",
+      }
+      local groups = group_scanner.find_list_groups(lines)
+      -- 2. without trailing space breaks the group
+      assert.are.equal(2, #groups)
+      assert.are.equal(1, #groups[1].items)
+      assert.are.equal(1, #groups[2].items)
+    end)
+
+    it("treats empty paren marker as list-breaking", function()
+      local lines = {
+        "1) first",
+        "2)",
+        "3) third",
+      }
+      local groups = group_scanner.find_list_groups(lines)
+      assert.are.equal(2, #groups)
+      assert.are.equal(1, #groups[1].items)
+      assert.are.equal(1, #groups[2].items)
+    end)
+
+    it("still recognizes empty markers via parse_list_line without opts", function()
+      -- The enter handler path calls parse_list_line without opts,
+      -- so empty markers should still parse for break-out-of-list behavior
+      local info = parser.parse_list_line("B.", nil)
+      assert.is_not_nil(info)
+      assert.are.equal("letter_upper", info.type)
+    end)
+
+    it("does not recognize empty markers when skip_empty_patterns is set", function()
+      local info = parser.parse_list_line("B.", nil, { skip_empty_patterns = true })
+      assert.is_nil(info)
+    end)
+
+    it("is_list_breaking_line treats empty markers as breaking", function()
+      -- Empty markers without trailing space should break list continuity
+      assert.is_true(group_scanner.is_list_breaking_line("E."))
+      assert.is_true(group_scanner.is_list_breaking_line("1."))
+      assert.is_true(group_scanner.is_list_breaking_line("-"))
     end)
   end)
 

--- a/spec/markdown-plus/list_spec.lua
+++ b/spec/markdown-plus/list_spec.lua
@@ -652,12 +652,11 @@ describe("markdown-plus list management", function()
         '   echo "Hello"',
         "   ```",
         "3. Hello",
-        "4.",
       }
       local groups = list.find_list_groups(lines)
 
       assert.are.equal(1, #groups)
-      assert.are.equal(4, #groups[1].items)
+      assert.are.equal(3, #groups[1].items)
     end)
 
     it("handles indented code block without surrounding blank lines", function()
@@ -1014,9 +1013,10 @@ describe("markdown-plus list management", function()
       assert.are.equal("3. [x] Task 3", result[4]) -- Should remain as 3
     end)
 
-    it("keeps empty list items without trailing space in same group", function()
-      -- This tests the fix for issue #17
-      -- Empty items like "3." (without trailing space) should still be in the same group
+    it("treats empty list items without trailing space as group-breaking", function()
+      -- Fix for issue #282: bare markers like "3." (no trailing space)
+      -- should NOT be recognized as list items in group scanning,
+      -- preventing false renumbering when typing "E." or "I." at SOL
       local lines = {
         "1. A",
         "2. b",
@@ -1029,12 +1029,14 @@ describe("markdown-plus list management", function()
       list.renumber_ordered_lists()
 
       local result = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-      -- Numbers should stay sequential (not restart at 1 after empty item)
-      assert.is_not_nil(result[1]:match("^1%."))
-      assert.is_not_nil(result[2]:match("^2%."))
-      assert.is_not_nil(result[3]:match("^3%."))
-      assert.is_not_nil(result[4]:match("^4%."))
-      assert.is_not_nil(result[5]:match("^5%."))
+      -- "3." and "5." break groups, so we get 3 separate groups:
+      -- Group 1: items 1-2, Group 2: item 4 (renumbered to 1)
+      -- "3." and "5." are unchanged (not recognized as list items)
+      assert.are.equal("1. A", result[1])
+      assert.are.equal("2. b", result[2])
+      assert.are.equal("3.", result[3]) -- Unchanged, not a list item
+      assert.are.equal("1. c", result[4]) -- Renumbered: new group starts at 1
+      assert.are.equal("5.", result[5]) -- Unchanged, not a list item
     end)
 
     it("does not reset numbering across indented fenced code block", function()


### PR DESCRIPTION
## Summary

Closes #282.

- List markers without trailing space (e.g., `E.`, `1.`, `-`) are no longer treated as list items by the group scanner, preventing common abbreviations like `E.g.` and `I.e.` from being falsely renumbered as alphabetical list items
- Added `skip_empty_patterns` option to `parse_list_line` so callers can opt out of matching bare markers at EOL
- Enter handler break-out-of-list behavior is preserved — empty markers still recognized when pressing Enter on an empty list item

## Test plan

- [x] `make check` passes (146 tests, 0 failures, lint clean, format clean)
- [x] Typing `E.g.` or `I.e.` at start of line does not trigger renumbering
- [x] Typing `E.` alone and leaving insert mode does not convert to `A.`
- [x] `A. first` + Enter still creates `B. ` continuation
- [x] Empty list item break-out still works (Enter on `B. ` without content)
- [x] Multi-item alpha lists (`A. first`, `B. second`) still renumber correctly
- [x] Numeric and unordered list continuation unaffected