### PR TITLE
fix(keymaps): shorten keymap descriptions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,12 +12,12 @@
 - **Link management:** Insert, edit, convert inline/reference, auto-link URLs
 
 ### Architecture
-- `lua/markdown-plus/` - Core modules (70 Lua files across 14 directories):
+- `lua/markdown-plus/` - Core modules (74 Lua files across 14 directories):
   - Feature modules: list/, format/, headers/, links/, table/, footnotes/, callouts/, quote/, images/, code_block/, thematic_break/
   - Shared: utils/ (buffer, text, selection, element, html), treesitter/, config/
   - Root: init.lua, types.lua, utils.lua, keymap_helper.lua, health.lua
 - `plugin/markdown-plus.lua` - Entry point with lazy initialization guard
-- `spec/` - 26 Busted test suites
+- `spec/` - 38 Busted test suites
 - `doc/` - Vimdoc help files
 - `rockspecs/` - LuaRocks package specifications
 
@@ -26,7 +26,7 @@
 - **Linting:** .luacheckrc
 - **Formatting:** .stylua.toml
 - **Type checking:** .luarc.json (Lua 5.1 runtime)
-- **Testing:** Busted + Plenary (26 spec files, ~85% coverage)
+- **Testing:** Busted + Plenary (38 spec files, ~85% coverage)
 
 ---
 
@@ -49,13 +49,13 @@
 
 2. **Configuration Changes**
    - New config keys must be added to: `types.lua`, `config/validate.lua`, README, vimdoc, and tests
-   - Use `vim.validate()` wrapped with `pcall` for validation
+   - Extend the schema in `config/validate.lua`; it rejects unknown fields and returns user-facing error messages
    - Use `require('markdown-plus').setup(opts)` (v2.0 removed `vim.g.markdown_plus`)
    - Provide helpful error messages for invalid configurations
 
 3. **Keymaps**
    - Expose ALL functionality through `<Plug>` mappings
-   - Use `hasmapto()` before setting default keymaps
+   - Use `keymap_helper.lua` for defaults; it checks existing buffer-local mappings with `maparg()` before setting them
    - Never create global normal-mode maps that conflict with common user mappings
    - Keep keymaps buffer-local and properly scoped
 
@@ -84,6 +84,7 @@
 ```bash
 # Testing
 make test              # Run all tests
+make test-coverage     # Run tests with coverage threshold checks (85% overall, 80% critical)
 make test-file         # Run tests for a specific file (set FILE=path/to/spec.lua)
 make test-watch        # Run tests in watch mode
 
@@ -104,14 +105,14 @@ make check             # Run lint + format-check + test
 - [ ] Verify Lua 5.1 compatibility (no LuaJIT-only code)
 
 #### Configuration
-- [ ] Validate all user input with `vim.validate()`
-- [ ] Add unknown field warnings
+- [ ] Extend `config/validate.lua` schema for all user-facing options
+- [ ] Preserve unknown-field rejection and clear validation messages
 - [ ] Update config schema in multiple files (types, validate, docs, tests)
 - [ ] Provide sensible defaults
 
 #### Keymaps
 - [ ] Create `<Plug>` mappings for new interactive features
-- [ ] Check `hasmapto()` before setting defaults
+- [ ] Use `keymap_helper.lua` so defaults respect existing buffer-local mappings
 - [ ] Use buffer-local keymaps
 - [ ] Document all keymaps in vimdoc
 
@@ -182,6 +183,7 @@ make check             # Run lint + format-check + test
 - Use buffer-local autocmd groups with clear names
 - Avoid excessive regex scans on every keypress
 - Clear autocmds properly when disabling features
+- Table is special: `init.lua` passes `config.table` to `table.setup()` and installs table keymaps directly without `table.enable()`
 
 ### Versioning (SemVer)
 - **Patch:** Bug fixes, test improvements, internal refactors (no API changes)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,11 @@
-# markdown-plus.nvim
+# CLAUDE.md
 
 ## Project
 
 **Stack**: Lua 5.1 / Neovim 0.11+ / Zero dependencies
-**Architecture**: Feature-based modular plugin — 13 feature modules under `lua/markdown-plus/`
+**Architecture**: Feature-based modular plugin — 11 user-facing feature modules plus shared config/utils/treesitter infrastructure under `lua/markdown-plus/`
 **Entry points**: `plugin/markdown-plus.lua` (load guard) → `lua/markdown-plus/init.lua` (setup + orchestration)
-**Test command**: `make test` (Busted + plenary.nvim, 26 spec files)
+**Test command**: `make test` (Busted + plenary.nvim, 38 spec files)
 **Build command**: `make check` (lint + format-check + test)
 
 ## Commands
@@ -21,20 +21,22 @@ make check             # Full CI: lint + format-check + test
 
 ## Key Directories
 
-- `lua/markdown-plus/` — Core plugin code (70 Lua files across 14 module directories)
+- `lua/markdown-plus/` — Core plugin code (74 Lua files across 14 module directories)
 - `lua/markdown-plus/types.lua` — LuaCATS type definitions (update FIRST for new types)
 - `lua/markdown-plus/config/validate.lua` — Schema-based config validation
 - `lua/markdown-plus/utils.lua` — Shared utilities (cursor, line, buffer ops)
 - `lua/markdown-plus/keymap_helper.lua` — Centralized `<Plug>` + default keymap registration
-- `spec/markdown-plus/` — 26 Busted test suites
+- `spec/markdown-plus/` — 38 Busted test suites
 - `doc/markdown-plus.txt` — Vimdoc help file
 - `plugin/markdown-plus.lua` — Load guard (no logic here)
 
 ## Feature Module Pattern
 
-Every feature follows: `setup(config)` → `enable()` (per-buffer via FileType autocmd) → `setup_keymaps()`.
+Most interactive features follow: `setup(config)` → `enable()` (per-buffer via FileType autocmd) → `setup_keymaps()`.
 Features are conditionally loaded based on `config.features.*` flags in `init.lua`.
-No cross-feature dependencies; all depend on `utils.lua` and `keymap_helper.lua`.
+Features are mostly isolated; all depend on `utils.lua` and `keymap_helper.lua`.
+Note: `utils/element.lua` has a soft cross-reference into `treesitter` and `code_block.parser`.
+Table is the main special case: `init.lua` passes `config.table` to `table.setup()` and wires table keymaps directly without a `table.enable()` call.
 
 ## Conventions
 
@@ -63,7 +65,7 @@ require("markdown-plus").setup(opts)
 
 - Framework: Busted via plenary.nvim (`spec/minimal_init.lua` bootstraps)
 - Pattern: `describe()`/`it()` blocks, buffer fixtures in `before_each`
-- 26 test files covering: config, utils, list, format (2 files: main + escape), headers (4 files: main + toc actions/render/state), links, table (5 files: main + cell_ops/column_ops/row_ops/row_mapper), footnotes (4 files: main + line_parser/query/scanner), callouts, health, treesitter, images, code_block, thematic_break, quote
+- 38 test files covering: config, utils, list (4 files: main + group_scanner/normal_handler/parser), format (3 files: main + escape/repeat), headers (5 files: main + manipulation/navigation + toc actions/render/state), links, smart_paste, table (6 files: main + creator/cell_ops/column_ops/row_ops/row_mapper), footnotes (7 files: main + insertion/navigation/window/line_parser/query/scanner), callouts, health, treesitter, images (2 files: main + insertion), code_block, thematic_break, quote
 
 ## Don't
 

--- a/lua/markdown-plus/init.lua
+++ b/lua/markdown-plus/init.lua
@@ -117,10 +117,12 @@ local function disable_feature_for_loaded_buffers(feature_module)
 end
 
 ---Clear buffer-local keymaps created by markdown-plus default mappings.
----Only mappings tagged with the "markdown-plus: " description prefix are removed,
----preserving any user-defined custom mappings to <Plug>(MarkdownPlus...) targets.
+---Tracked defaults are removed through keymap_helper. Legacy description-tagged
+---maps are also cleaned up for compatibility with older runtime state.
 ---@return nil
 local function clear_plugin_default_keymaps()
+  require("markdown-plus.keymap_helper").clear_default_keymaps()
+
   local modes = { "n", "i", "x", "v" }
   for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
     if vim.api.nvim_buf_is_valid(bufnr) then

--- a/lua/markdown-plus/keymap_helper.lua
+++ b/lua/markdown-plus/keymap_helper.lua
@@ -4,6 +4,42 @@ local M = {}
 
 -- Track which <Plug> mappings have been registered to avoid redundant global re-registration
 local registered_plugs = {}
+local DEFAULT_KEYMAPS_VAR = "markdown_plus_default_keymaps"
+
+---@class markdown-plus.DefaultKeymapRecord
+---@field mode string Keymap mode
+---@field lhs string Default keymap left-hand side
+---@field rhs string Default keymap right-hand side
+---@field desc string Default keymap description
+
+---Get default keymap records tracked on a buffer.
+---@param bufnr integer Buffer handle
+---@return markdown-plus.DefaultKeymapRecord[]
+local function get_default_keymap_records(bufnr)
+  local ok, records = pcall(vim.api.nvim_buf_get_var, bufnr, DEFAULT_KEYMAPS_VAR)
+  if ok and type(records) == "table" then
+    return records
+  end
+  return {}
+end
+
+---Remember a buffer-local default keymap so teardown does not depend on the visible description text.
+---@param mode string Keymap mode
+---@param lhs string Default keymap left-hand side
+---@param rhs string Default keymap right-hand side
+---@param desc string Default keymap description
+---@return nil
+local function track_default_keymap(mode, lhs, rhs, desc)
+  local bufnr = vim.api.nvim_get_current_buf()
+  local records = get_default_keymap_records(bufnr)
+  table.insert(records, {
+    mode = mode,
+    lhs = lhs,
+    rhs = rhs,
+    desc = desc,
+  })
+  vim.api.nvim_buf_set_var(bufnr, DEFAULT_KEYMAPS_VAR, records)
+end
 
 ---Keymap definition
 ---@class markdown-plus.KeymapDef
@@ -73,11 +109,41 @@ function M.setup_keymaps(config, keymaps)
         if not has_buffer_mapping then
           local default_opts = vim.tbl_extend("force", {
             buffer = true,
-            desc = "markdown-plus: " .. keymap.desc,
+            desc = keymap.desc,
           }, keymap.default_opts or {})
 
           vim.keymap.set(mode, default_keys[idx], plug_name, default_opts)
+          track_default_keymap(mode, default_keys[idx], plug_name, default_opts.desc)
         end
+      end
+    end
+  end
+end
+
+---Clear buffer-local default keymaps created through this helper.
+---User mappings to <Plug>(MarkdownPlus...) targets are preserved because only tracked defaults are removed.
+---@return nil
+function M.clear_default_keymaps()
+  for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+    if vim.api.nvim_buf_is_valid(bufnr) then
+      local records = get_default_keymap_records(bufnr)
+      if #records > 0 then
+        vim.api.nvim_buf_call(bufnr, function()
+          for _, record in ipairs(records) do
+            if type(record.lhs) == "string" and type(record.mode) == "string" then
+              local existing = vim.fn.maparg(record.lhs, record.mode, false, true)
+              local is_same_default = type(existing) == "table"
+                and next(existing) ~= nil
+                and existing.buffer == 1
+                and existing.rhs == record.rhs
+                and existing.desc == record.desc
+              if is_same_default then
+                pcall(vim.keymap.del, record.mode, record.lhs, { buffer = bufnr })
+              end
+            end
+          end
+        end)
+        pcall(vim.api.nvim_buf_del_var, bufnr, DEFAULT_KEYMAPS_VAR)
       end
     end
   end

--- a/spec/markdown-plus/config_spec.lua
+++ b/spec/markdown-plus/config_spec.lua
@@ -180,6 +180,25 @@ describe("markdown-plus configuration", function()
       assert.is_false(markdown_plus.config.keymaps.enabled)
     end)
 
+    it("uses short default keymap descriptions and clears them on teardown", function()
+      local buf = vim.api.nvim_create_buf(false, true)
+      vim.bo[buf].filetype = "markdown"
+      vim.api.nvim_set_current_buf(buf)
+
+      markdown_plus.setup({})
+
+      local mapping = vim.fn.maparg("<localleader>mb", "n", false, true)
+      assert.are.equal("<Plug>(MarkdownPlusBold)", mapping.rhs)
+      assert.are.equal("Toggle bold formatting", mapping.desc)
+
+      markdown_plus.teardown()
+
+      local cleared_mapping = vim.fn.maparg("<localleader>mb", "n", false, true)
+      assert.is_true(next(cleared_mapping) == nil)
+
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end)
+
     it("disables ALL keymaps including table keymaps when keymaps.enabled = false", function()
       -- Create a markdown buffer
       local buf = vim.api.nvim_create_buf(false, true)
@@ -243,6 +262,7 @@ describe("markdown-plus configuration", function()
     end)
 
     after_each(function()
+      keymap_helper.clear_default_keymaps()
       if vim.api.nvim_buf_is_valid(buf) then
         vim.api.nvim_buf_delete(buf, { force = true })
       end
@@ -267,6 +287,7 @@ describe("markdown-plus configuration", function()
       local mapping = vim.fn.maparg("<C-x>", "i", false, true)
       assert.is_not_nil(mapping)
       assert.are.equal(1, mapping.buffer)
+      assert.are.equal("Test action", mapping.desc)
     end)
 
     it("does not create default keymaps when buffer-local mappings already exist", function()
@@ -317,6 +338,34 @@ describe("markdown-plus configuration", function()
       local mapping = vim.fn.maparg("<C-z>", "i", false, true)
       assert.is_not_nil(mapping)
       assert.are.equal(1, mapping.buffer)
+    end)
+
+    it("clears tracked default keymaps while preserving user mappings", function()
+      local test_config = {
+        keymaps = { enabled = true },
+      }
+
+      keymap_helper.setup_keymaps(test_config, {
+        {
+          plug = "MarkdownPlusTrackedDefault",
+          fn = function() end,
+          modes = "n",
+          default_key = "<localleader>td",
+          desc = "Tracked default",
+        },
+      })
+      vim.keymap.set("n", "<localleader>tu", "<Plug>(MarkdownPlusUserMapping)", {
+        buffer = true,
+        desc = "User mapping",
+      })
+
+      keymap_helper.clear_default_keymaps()
+
+      local default_mapping = vim.fn.maparg("<localleader>td", "n", false, true)
+      local user_mapping = vim.fn.maparg("<localleader>tu", "n", false, true)
+      assert.is_true(next(default_mapping) == nil)
+      assert.are.equal("<Plug>(MarkdownPlusUserMapping)", user_mapping.rhs)
+      assert.are.equal("User mapping", user_mapping.desc)
     end)
   end)
 


### PR DESCRIPTION
Shortens default keymap descriptions so keymap discovery UIs show the action names directly instead of repeating `markdown-plus:` everywhere.

- Tracks plugin-created default mappings internally so teardown still removes them safely.
- Keeps legacy cleanup for old `markdown-plus:`-prefixed mappings.
- Refreshes repo instruction files with current counts and keymap/config guidance.

Fixes #302

Tested by `make check`.
