### PR TITLE
fix(ci): improve contributor recognition detection

### DIFF
--- a/.github/workflows/ci-bot.yml
+++ b/.github/workflows/ci-bot.yml
@@ -1,9 +1,10 @@
 name: CI (Bot PRs)
 
-# Runs CI on PRs created by agentic workflows.
+# Runs CI and required checks on PRs created by agentic workflows.
 # GitHub does not trigger pull_request workflows for PRs created by
 # github-actions[bot] using the default GITHUB_TOKEN, so this workflow
-# listens for agentic workflow completions and runs the same checks.
+# listens for agentic workflow completions and reports the required
+# branch-protection contexts on the generated PR commit.
 
 on:
   workflow_run:
@@ -119,9 +120,44 @@ jobs:
       - name: Run tests
         run: ./scripts/test
 
+  dependency-security:
+    name: Dependency Security Check
+    needs: find-pr
+    if: needs.find-pr.outputs.pr_number
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.find-pr.outputs.head_ref }}
+      - name: Check for known vulnerabilities
+        run: |
+          echo "Checking for common security issues in dependencies..."
+          if compgen -G "*.rockspec" > /dev/null; then
+            echo "Rockspec found - review dependencies manually"
+            cat *.rockspec
+          else
+            echo "No rockspec file found - minimal dependencies"
+          fi
+
+  secret-scanning:
+    name: Secret Scanning
+    needs: find-pr
+    if: needs.find-pr.outputs.pr_number
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.find-pr.outputs.head_ref }}
+          fetch-depth: 0
+      - name: Scan for secrets using gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+
   report-status:
     name: Report Status
-    needs: [find-pr, stylua, luacheck, tests]
+    needs: [find-pr, stylua, luacheck, tests, dependency-security, secret-scanning]
     if: always() && needs.find-pr.outputs.head_sha
     runs-on: ubuntu-latest
     permissions:
@@ -130,25 +166,86 @@ jobs:
       - name: Determine overall result
         id: result
         run: |
+          if [[ "${{ needs.tests.result }}" == "success" ]]; then
+            echo "tests_state=success" >> "$GITHUB_OUTPUT"
+            echo "tests_description=Tests passed" >> "$GITHUB_OUTPUT"
+          else
+            echo "tests_state=failure" >> "$GITHUB_OUTPUT"
+            echo "tests_description=Tests failed" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [[ "${{ needs.dependency-security.result }}" == "success" ]]; then
+            echo "dependency_state=success" >> "$GITHUB_OUTPUT"
+            echo "dependency_description=Dependency security check passed" >> "$GITHUB_OUTPUT"
+          else
+            echo "dependency_state=failure" >> "$GITHUB_OUTPUT"
+            echo "dependency_description=Dependency security check failed" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [[ "${{ needs.secret-scanning.result }}" == "success" ]]; then
+            echo "secrets_state=success" >> "$GITHUB_OUTPUT"
+            echo "secrets_description=Secret scanning passed" >> "$GITHUB_OUTPUT"
+          else
+            echo "secrets_state=failure" >> "$GITHUB_OUTPUT"
+            echo "secrets_description=Secret scanning failed" >> "$GITHUB_OUTPUT"
+          fi
+
           if [[ "${{ needs.stylua.result }}" == "success" && \
                 "${{ needs.luacheck.result }}" == "success" && \
-                "${{ needs.tests.result }}" == "success" ]]; then
+                "${{ needs.tests.result }}" == "success" && \
+                "${{ needs.dependency-security.result }}" == "success" && \
+                "${{ needs.secret-scanning.result }}" == "success" ]]; then
             echo "state=success" >> "$GITHUB_OUTPUT"
-            echo "description=All CI checks passed" >> "$GITHUB_OUTPUT"
+            echo "description=All bot PR checks passed" >> "$GITHUB_OUTPUT"
           else
             echo "state=failure" >> "$GITHUB_OUTPUT"
-            echo "description=CI checks failed (stylua=${{ needs.stylua.result }}, luacheck=${{ needs.luacheck.result }}, tests=${{ needs.tests.result }})" >> "$GITHUB_OUTPUT"
+            echo "description=Bot PR checks failed" >> "$GITHUB_OUTPUT"
           fi
-      - name: Set commit status on PR
+      - name: Set required commit statuses on PR
         uses: actions/github-script@v9.0.0
+        env:
+          TESTS_STATE: ${{ steps.result.outputs.tests_state }}
+          TESTS_DESCRIPTION: ${{ steps.result.outputs.tests_description }}
+          DEPENDENCY_STATE: ${{ steps.result.outputs.dependency_state }}
+          DEPENDENCY_DESCRIPTION: ${{ steps.result.outputs.dependency_description }}
+          SECRETS_STATE: ${{ steps.result.outputs.secrets_state }}
+          SECRETS_DESCRIPTION: ${{ steps.result.outputs.secrets_description }}
+          OVERALL_STATE: ${{ steps.result.outputs.state }}
+          OVERALL_DESCRIPTION: ${{ steps.result.outputs.description }}
         with:
           script: |
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: "${{ needs.find-pr.outputs.head_sha }}",
-              state: "${{ steps.result.outputs.state }}",
-              description: "${{ steps.result.outputs.description }}",
-              context: "CI (Bot PRs)",
-              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-            });
+            const targetUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const statuses = [
+              {
+                context: "ci / tests",
+                state: process.env.TESTS_STATE,
+                description: process.env.TESTS_DESCRIPTION,
+              },
+              {
+                context: "Dependency Security Check",
+                state: process.env.DEPENDENCY_STATE,
+                description: process.env.DEPENDENCY_DESCRIPTION,
+              },
+              {
+                context: "Secret Scanning",
+                state: process.env.SECRETS_STATE,
+                description: process.env.SECRETS_DESCRIPTION,
+              },
+              {
+                context: "CI (Bot PRs)",
+                state: process.env.OVERALL_STATE,
+                description: process.env.OVERALL_DESCRIPTION,
+              },
+            ];
+
+            for (const status of statuses) {
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha: "${{ needs.find-pr.outputs.head_sha }}",
+                state: status.state,
+                description: status.description,
+                context: status.context,
+                target_url: targetUrl,
+              });
+            }

--- a/.github/workflows/ci-bot.yml
+++ b/.github/workflows/ci-bot.yml
@@ -33,7 +33,7 @@ jobs:
             const prefixMap = {
               "Code Simplifier": "[code-simplifier]",
               "Daily Documentation Updater": "[docs]",
-              "Contributor Recognition": "[contributors]",
+              "Contributor Recognition": "docs(contributors):",
             };
             const workflowName = context.payload.workflow_run?.name || "";
             const expectedPrefix = prefixMap[workflowName];

--- a/.github/workflows/contributor-recognition.lock.yml
+++ b/.github/workflows/contributor-recognition.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c45507434541ebb58b1edf1fdc8908c6802a48856853497e8bfecf633f4d82e0","compiler_version":"v0.71.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e8503a4ded73add7c13fcdd7a0bfac13443cf7adde48d389549446317d66fd3b","compiler_version":"v0.71.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"239aec45b78c8799417efdd5bc6d8cc036629ec1","version":"v0.71.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28","digest":"sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28","digest":"sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28","digest":"sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.0"},{"image":"ghcr.io/github/github-mcp-server:v1.0.2"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -57,7 +57,7 @@ name: "Contributor Recognition"
   schedule:
   - cron: "50 10 * * 4"
     # Friendly format: weekly (scattered)
-  # skip-if-match: is:open in:title "[contributors]" # Skip-if-match processed as search check in pre-activation job
+  # skip-if-match: "is:open in:title \"docs(contributors): add recent contributors\"" # Skip-if-match processed as search check in pre-activation job
   workflow_dispatch:
     inputs:
       aw_context:
@@ -187,19 +187,19 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_ca54f5680f614bee_EOF'
+          cat << 'GH_AW_PROMPT_9ef4ff403faa216c_EOF'
           <system>
-          GH_AW_PROMPT_ca54f5680f614bee_EOF
+          GH_AW_PROMPT_9ef4ff403faa216c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_ca54f5680f614bee_EOF'
+          cat << 'GH_AW_PROMPT_9ef4ff403faa216c_EOF'
           <safe-output-tools>
           Tools: create_issue, create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_ca54f5680f614bee_EOF
+          GH_AW_PROMPT_9ef4ff403faa216c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_ca54f5680f614bee_EOF'
+          cat << 'GH_AW_PROMPT_9ef4ff403faa216c_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -229,14 +229,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_ca54f5680f614bee_EOF
+          GH_AW_PROMPT_9ef4ff403faa216c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_ca54f5680f614bee_EOF'
+          cat << 'GH_AW_PROMPT_9ef4ff403faa216c_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/shared/safe-output-app.md}}
           {{#runtime-import .github/workflows/contributor-recognition.md}}
-          GH_AW_PROMPT_ca54f5680f614bee_EOF
+          GH_AW_PROMPT_9ef4ff403faa216c_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -423,16 +423,16 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_11d1acce950af88e_EOF'
-          {"create_issue":{"expires":168,"labels":["documentation","automation","contributors"],"max":1,"title_prefix":"[contributors] "},"create_pull_request":{"auto_merge":false,"draft":true,"expires":168,"labels":["documentation","automation","contributors"],"max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_path_prefixes":[".github/",".agents/",".githooks/",".husky/"],"reviewers":["YousefHadder"],"title_prefix":"[contributors] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_11d1acce950af88e_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_173225880c4534c9_EOF'
+          {"create_issue":{"expires":168,"labels":["documentation","automation","contributors"],"max":1,"title_prefix":"[contributors] "},"create_pull_request":{"auto_merge":false,"draft":true,"expires":168,"labels":["documentation","automation","contributors"],"max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_path_prefixes":[".github/",".agents/",".githooks/",".husky/"],"reviewers":["YousefHadder"],"title_prefix":"docs(contributors): "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_173225880c4534c9_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
                 "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[contributors] \". Labels [\"documentation\" \"automation\" \"contributors\"] will be automatically added.",
-                "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[contributors] \". Labels [\"documentation\" \"automation\" \"contributors\"] will be automatically added. PRs will be created as drafts. Reviewers [\"YousefHadder\"] will be assigned."
+                "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"docs(contributors): \". Labels [\"documentation\" \"automation\" \"contributors\"] will be automatically added. PRs will be created as drafts. Reviewers [\"YousefHadder\"] will be assigned."
               },
               "repo_params": {},
               "dynamic_tools": []
@@ -666,7 +666,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_8980648214b4e3bb_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_1302ad5843e2cb48_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -707,7 +707,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_8980648214b4e3bb_EOF
+          GH_AW_MCP_CONFIG_1302ad5843e2cb48_EOF
       - name: Clean git credentials
         continue-on-error: true
         run: bash "${RUNNER_TEMP}/gh-aw/actions/clean_git_credentials.sh"
@@ -1262,7 +1262,7 @@ jobs:
         id: check_skip_if_match
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
-          GH_AW_SKIP_QUERY: "is:open in:title \"[contributors]\""
+          GH_AW_SKIP_QUERY: "is:open in:title \"docs(contributors): add recent contributors\""
           GH_AW_WORKFLOW_NAME: "Contributor Recognition"
           GH_AW_SKIP_MAX_MATCHES: "1"
         with:
@@ -1373,7 +1373,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.npms.io,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,bun.sh,cdn.jsdelivr.net,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,deb.nodesource.com,deno.land,docs.github.com,esm.sh,get.pnpm.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,googleapis.deno.dev,googlechromelabs.github.io,host.docker.internal,json-schema.org,json.schemastore.org,jsr.io,keyserver.ubuntu.com,lfs.github.com,nodejs.org,npm.pkg.github.com,npmjs.com,npmjs.org,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.bower.io,registry.npmjs.com,registry.npmjs.org,registry.yarnpkg.com,repo.yarnpkg.com,s.symcb.com,s.symcd.com,security.ubuntu.com,skimdb.npmjs.com,storage.googleapis.com,telemetry.enterprise.githubcopilot.com,telemetry.vercel.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com,www.npmjs.com,www.npmjs.org,yarnpkg.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"expires\":168,\"labels\":[\"documentation\",\"automation\",\"contributors\"],\"max\":1,\"title_prefix\":\"[contributors] \"},\"create_pull_request\":{\"auto_merge\":false,\"draft\":true,\"expires\":168,\"labels\":[\"documentation\",\"automation\",\"contributors\"],\"max\":1,\"max_patch_size\":1024,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_path_prefixes\":[\".github/\",\".agents/\",\".githooks/\",\".husky/\"],\"reviewers\":[\"YousefHadder\"],\"title_prefix\":\"[contributors] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"expires\":168,\"labels\":[\"documentation\",\"automation\",\"contributors\"],\"max\":1,\"title_prefix\":\"[contributors] \"},\"create_pull_request\":{\"auto_merge\":false,\"draft\":true,\"expires\":168,\"labels\":[\"documentation\",\"automation\",\"contributors\"],\"max\":1,\"max_patch_size\":1024,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_path_prefixes\":[\".github/\",\".agents/\",\".githooks/\",\".husky/\"],\"reviewers\":[\"YousefHadder\"],\"title_prefix\":\"docs(contributors): \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/contributor-recognition.lock.yml
+++ b/.github/workflows/contributor-recognition.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"22a6d4c16646a672dcb60e8416d27a16ce19a02063d4dc0a9a841e7cadde5f32","compiler_version":"v0.71.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c45507434541ebb58b1edf1fdc8908c6802a48856853497e8bfecf633f4d82e0","compiler_version":"v0.71.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"239aec45b78c8799417efdd5bc6d8cc036629ec1","version":"v0.71.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28","digest":"sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28","digest":"sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28","digest":"sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.0"},{"image":"ghcr.io/github/github-mcp-server:v1.0.2"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -187,19 +187,19 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_ce8e228fdce17bb7_EOF'
+          cat << 'GH_AW_PROMPT_ca54f5680f614bee_EOF'
           <system>
-          GH_AW_PROMPT_ce8e228fdce17bb7_EOF
+          GH_AW_PROMPT_ca54f5680f614bee_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_ce8e228fdce17bb7_EOF'
+          cat << 'GH_AW_PROMPT_ca54f5680f614bee_EOF'
           <safe-output-tools>
           Tools: create_issue, create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_ce8e228fdce17bb7_EOF
+          GH_AW_PROMPT_ca54f5680f614bee_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_ce8e228fdce17bb7_EOF'
+          cat << 'GH_AW_PROMPT_ca54f5680f614bee_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -229,14 +229,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_ce8e228fdce17bb7_EOF
+          GH_AW_PROMPT_ca54f5680f614bee_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_ce8e228fdce17bb7_EOF'
+          cat << 'GH_AW_PROMPT_ca54f5680f614bee_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/shared/safe-output-app.md}}
           {{#runtime-import .github/workflows/contributor-recognition.md}}
-          GH_AW_PROMPT_ce8e228fdce17bb7_EOF
+          GH_AW_PROMPT_ca54f5680f614bee_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -423,9 +423,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_0ab8995207ed9f38_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_11d1acce950af88e_EOF'
           {"create_issue":{"expires":168,"labels":["documentation","automation","contributors"],"max":1,"title_prefix":"[contributors] "},"create_pull_request":{"auto_merge":false,"draft":true,"expires":168,"labels":["documentation","automation","contributors"],"max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_path_prefixes":[".github/",".agents/",".githooks/",".husky/"],"reviewers":["YousefHadder"],"title_prefix":"[contributors] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_0ab8995207ed9f38_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_11d1acce950af88e_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -666,7 +666,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_8f5fc0b4b7ca29d0_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_8980648214b4e3bb_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -707,7 +707,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_8f5fc0b4b7ca29d0_EOF
+          GH_AW_MCP_CONFIG_8980648214b4e3bb_EOF
       - name: Clean git credentials
         continue-on-error: true
         run: bash "${RUNNER_TEMP}/gh-aw/actions/clean_git_credentials.sh"
@@ -733,6 +733,7 @@ jobs:
         # --allow-tool shell(grep -n 'ALL-CONTRIBUTORS' README.md)
         # --allow-tool shell(grep)
         # --allow-tool shell(head)
+        # --allow-tool shell(jq)
         # --allow-tool shell(ls)
         # --allow-tool shell(npx -y all-contributors-cli add)
         # --allow-tool shell(npx -y all-contributors-cli generate)
@@ -752,7 +753,7 @@ jobs:
           (umask 177 && touch /tmp/gh-aw/agent-stdio.log)
           # shellcheck disable=SC1003
           sudo -E awf --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" --env-all --exclude-env COPILOT_GITHUB_TOKEN --exclude-env GITHUB_MCP_SERVER_TOKEN --exclude-env MCP_GATEWAY_API_KEY --allow-domains '*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.npms.io,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,bun.sh,cdn.jsdelivr.net,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,deb.nodesource.com,deno.land,docs.github.com,esm.sh,get.pnpm.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,googleapis.deno.dev,googlechromelabs.github.io,host.docker.internal,json-schema.org,json.schemastore.org,jsr.io,keyserver.ubuntu.com,lfs.github.com,nodejs.org,npm.pkg.github.com,npmjs.com,npmjs.org,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.bower.io,registry.npmjs.com,registry.npmjs.org,registry.yarnpkg.com,repo.yarnpkg.com,s.symcb.com,s.symcd.com,security.ubuntu.com,skimdb.npmjs.com,storage.googleapis.com,telemetry.enterprise.githubcopilot.com,telemetry.vercel.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com,www.npmjs.com,www.npmjs.org,yarnpkg.com' --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --audit-dir /tmp/gh-aw/sandbox/firewall/audit --enable-host-access --allow-host-ports 80,443,8080 --image-tag 0.25.28,squid=sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474,agent=sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a,api-proxy=sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb,cli-proxy=sha256:fdf310e4678ce58d248c466b89399e9680a3003038fd19322c388559016aaac7 --skip-pull --enable-api-proxy \
-            -- /bin/bash -c 'GH_AW_NODE_EXEC="${GH_AW_NODE_BIN:-}"; if [ -z "$GH_AW_NODE_EXEC" ] || [ ! -x "$GH_AW_NODE_EXEC" ]; then GH_AW_NODE_EXEC="$(command -v node 2>/dev/null || echo node)"; fi; "$GH_AW_NODE_EXEC" ${RUNNER_TEMP}/gh-aw/actions/copilot_driver.cjs /usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --disable-builtin-mcps --no-ask-user --allow-tool github --allow-tool safeoutputs --allow-tool '\''shell(cat .all-contributorsrc)'\'' --allow-tool '\''shell(cat README.md)'\'' --allow-tool '\''shell(cat)'\'' --allow-tool '\''shell(date)'\'' --allow-tool '\''shell(echo)'\'' --allow-tool '\''shell(git add:*)'\'' --allow-tool '\''shell(git branch:*)'\'' --allow-tool '\''shell(git checkout:*)'\'' --allow-tool '\''shell(git commit:*)'\'' --allow-tool '\''shell(git merge:*)'\'' --allow-tool '\''shell(git rm:*)'\'' --allow-tool '\''shell(git status)'\'' --allow-tool '\''shell(git switch:*)'\'' --allow-tool '\''shell(git:*)'\'' --allow-tool '\''shell(grep -n '\''\'\'''\''ALL-CONTRIBUTORS'\''\'\'''\'' README.md)'\'' --allow-tool '\''shell(grep)'\'' --allow-tool '\''shell(head)'\'' --allow-tool '\''shell(ls)'\'' --allow-tool '\''shell(npx -y all-contributors-cli add)'\'' --allow-tool '\''shell(npx -y all-contributors-cli generate)'\'' --allow-tool '\''shell(pwd)'\'' --allow-tool '\''shell(sort)'\'' --allow-tool '\''shell(tail)'\'' --allow-tool '\''shell(uniq)'\'' --allow-tool '\''shell(wc)'\'' --allow-tool '\''shell(yq)'\'' --allow-tool write --allow-all-paths --add-dir "${GITHUB_WORKSPACE}" --prompt-file /tmp/gh-aw/aw-prompts/prompt.txt' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
+            -- /bin/bash -c 'GH_AW_NODE_EXEC="${GH_AW_NODE_BIN:-}"; if [ -z "$GH_AW_NODE_EXEC" ] || [ ! -x "$GH_AW_NODE_EXEC" ]; then GH_AW_NODE_EXEC="$(command -v node 2>/dev/null || echo node)"; fi; "$GH_AW_NODE_EXEC" ${RUNNER_TEMP}/gh-aw/actions/copilot_driver.cjs /usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --disable-builtin-mcps --no-ask-user --allow-tool github --allow-tool safeoutputs --allow-tool '\''shell(cat .all-contributorsrc)'\'' --allow-tool '\''shell(cat README.md)'\'' --allow-tool '\''shell(cat)'\'' --allow-tool '\''shell(date)'\'' --allow-tool '\''shell(echo)'\'' --allow-tool '\''shell(git add:*)'\'' --allow-tool '\''shell(git branch:*)'\'' --allow-tool '\''shell(git checkout:*)'\'' --allow-tool '\''shell(git commit:*)'\'' --allow-tool '\''shell(git merge:*)'\'' --allow-tool '\''shell(git rm:*)'\'' --allow-tool '\''shell(git status)'\'' --allow-tool '\''shell(git switch:*)'\'' --allow-tool '\''shell(git:*)'\'' --allow-tool '\''shell(grep -n '\''\'\'''\''ALL-CONTRIBUTORS'\''\'\'''\'' README.md)'\'' --allow-tool '\''shell(grep)'\'' --allow-tool '\''shell(head)'\'' --allow-tool '\''shell(jq)'\'' --allow-tool '\''shell(ls)'\'' --allow-tool '\''shell(npx -y all-contributors-cli add)'\'' --allow-tool '\''shell(npx -y all-contributors-cli generate)'\'' --allow-tool '\''shell(pwd)'\'' --allow-tool '\''shell(sort)'\'' --allow-tool '\''shell(tail)'\'' --allow-tool '\''shell(uniq)'\'' --allow-tool '\''shell(wc)'\'' --allow-tool '\''shell(yq)'\'' --allow-tool write --allow-all-paths --add-dir "${GITHUB_WORKSPACE}" --prompt-file /tmp/gh-aw/aw-prompts/prompt.txt' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_API_KEY: dummy-byok-key-for-offline-mode

--- a/.github/workflows/contributor-recognition.lock.yml
+++ b/.github/workflows/contributor-recognition.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e8503a4ded73add7c13fcdd7a0bfac13443cf7adde48d389549446317d66fd3b","compiler_version":"v0.71.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"302c78ae0152dcb98657e3f5c6cb71f8bbc15122554141b38ceab66eaeb68591","compiler_version":"v0.71.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"239aec45b78c8799417efdd5bc6d8cc036629ec1","version":"v0.71.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28","digest":"sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28","digest":"sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28","digest":"sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.0"},{"image":"ghcr.io/github/github-mcp-server:v1.0.2"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -57,7 +57,7 @@ name: "Contributor Recognition"
   schedule:
   - cron: "50 10 * * 4"
     # Friendly format: weekly (scattered)
-  # skip-if-match: "is:open in:title \"docs(contributors): add recent contributors\"" # Skip-if-match processed as search check in pre-activation job
+  # skip-if-match: is:open in:title "docs(contributors):" # Skip-if-match processed as search check in pre-activation job
   workflow_dispatch:
     inputs:
       aw_context:
@@ -187,19 +187,19 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_9ef4ff403faa216c_EOF'
+          cat << 'GH_AW_PROMPT_6f1a7a1c0d64c653_EOF'
           <system>
-          GH_AW_PROMPT_9ef4ff403faa216c_EOF
+          GH_AW_PROMPT_6f1a7a1c0d64c653_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_9ef4ff403faa216c_EOF'
+          cat << 'GH_AW_PROMPT_6f1a7a1c0d64c653_EOF'
           <safe-output-tools>
           Tools: create_issue, create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_9ef4ff403faa216c_EOF
+          GH_AW_PROMPT_6f1a7a1c0d64c653_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_9ef4ff403faa216c_EOF'
+          cat << 'GH_AW_PROMPT_6f1a7a1c0d64c653_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -229,14 +229,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_9ef4ff403faa216c_EOF
+          GH_AW_PROMPT_6f1a7a1c0d64c653_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_9ef4ff403faa216c_EOF'
+          cat << 'GH_AW_PROMPT_6f1a7a1c0d64c653_EOF'
           </system>
           {{#runtime-import .github/workflows/shared/reporting.md}}
           {{#runtime-import .github/workflows/shared/safe-output-app.md}}
           {{#runtime-import .github/workflows/contributor-recognition.md}}
-          GH_AW_PROMPT_9ef4ff403faa216c_EOF
+          GH_AW_PROMPT_6f1a7a1c0d64c653_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -423,15 +423,15 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_173225880c4534c9_EOF'
-          {"create_issue":{"expires":168,"labels":["documentation","automation","contributors"],"max":1,"title_prefix":"[contributors] "},"create_pull_request":{"auto_merge":false,"draft":true,"expires":168,"labels":["documentation","automation","contributors"],"max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_path_prefixes":[".github/",".agents/",".githooks/",".husky/"],"reviewers":["YousefHadder"],"title_prefix":"docs(contributors): "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_173225880c4534c9_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_88355aa5219479ba_EOF'
+          {"create_issue":{"expires":168,"labels":["documentation","automation","contributors"],"max":1,"title_prefix":"docs(contributors): "},"create_pull_request":{"auto_merge":false,"draft":true,"expires":168,"labels":["documentation","automation","contributors"],"max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_path_prefixes":[".github/",".agents/",".githooks/",".husky/"],"reviewers":["YousefHadder"],"title_prefix":"docs(contributors): "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_88355aa5219479ba_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
-                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[contributors] \". Labels [\"documentation\" \"automation\" \"contributors\"] will be automatically added.",
+                "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"docs(contributors): \". Labels [\"documentation\" \"automation\" \"contributors\"] will be automatically added.",
                 "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"docs(contributors): \". Labels [\"documentation\" \"automation\" \"contributors\"] will be automatically added. PRs will be created as drafts. Reviewers [\"YousefHadder\"] will be assigned."
               },
               "repo_params": {},
@@ -666,7 +666,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_1302ad5843e2cb48_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_624ddafc3b186dca_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -707,7 +707,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_1302ad5843e2cb48_EOF
+          GH_AW_MCP_CONFIG_624ddafc3b186dca_EOF
       - name: Clean git credentials
         continue-on-error: true
         run: bash "${RUNNER_TEMP}/gh-aw/actions/clean_git_credentials.sh"
@@ -1262,7 +1262,7 @@ jobs:
         id: check_skip_if_match
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
-          GH_AW_SKIP_QUERY: "is:open in:title \"docs(contributors): add recent contributors\""
+          GH_AW_SKIP_QUERY: "is:open in:title \"docs(contributors):\""
           GH_AW_WORKFLOW_NAME: "Contributor Recognition"
           GH_AW_SKIP_MAX_MATCHES: "1"
         with:
@@ -1373,7 +1373,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.npms.io,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,bun.sh,cdn.jsdelivr.net,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,deb.nodesource.com,deno.land,docs.github.com,esm.sh,get.pnpm.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,googleapis.deno.dev,googlechromelabs.github.io,host.docker.internal,json-schema.org,json.schemastore.org,jsr.io,keyserver.ubuntu.com,lfs.github.com,nodejs.org,npm.pkg.github.com,npmjs.com,npmjs.org,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.bower.io,registry.npmjs.com,registry.npmjs.org,registry.yarnpkg.com,repo.yarnpkg.com,s.symcb.com,s.symcd.com,security.ubuntu.com,skimdb.npmjs.com,storage.googleapis.com,telemetry.enterprise.githubcopilot.com,telemetry.vercel.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com,www.npmjs.com,www.npmjs.org,yarnpkg.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"expires\":168,\"labels\":[\"documentation\",\"automation\",\"contributors\"],\"max\":1,\"title_prefix\":\"[contributors] \"},\"create_pull_request\":{\"auto_merge\":false,\"draft\":true,\"expires\":168,\"labels\":[\"documentation\",\"automation\",\"contributors\"],\"max\":1,\"max_patch_size\":1024,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_path_prefixes\":[\".github/\",\".agents/\",\".githooks/\",\".husky/\"],\"reviewers\":[\"YousefHadder\"],\"title_prefix\":\"docs(contributors): \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"expires\":168,\"labels\":[\"documentation\",\"automation\",\"contributors\"],\"max\":1,\"title_prefix\":\"docs(contributors): \"},\"create_pull_request\":{\"auto_merge\":false,\"draft\":true,\"expires\":168,\"labels\":[\"documentation\",\"automation\",\"contributors\"],\"max\":1,\"max_patch_size\":1024,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_path_prefixes\":[\".github/\",\".agents/\",\".githooks/\",\".husky/\"],\"reviewers\":[\"YousefHadder\"],\"title_prefix\":\"docs(contributors): \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/contributor-recognition.md
+++ b/.github/workflows/contributor-recognition.md
@@ -44,6 +44,7 @@ tools:
     - "cat .all-contributorsrc"
     - "cat README.md"
     - "grep -n 'ALL-CONTRIBUTORS' README.md"
+    - "jq"
     - "git"
     - "npx -y all-contributors-cli add"
     - "npx -y all-contributors-cli generate"
@@ -122,20 +123,25 @@ Extract the existing contributor logins from `.all-contributorsrc`. Do not add a
 Use GitHub tools to inspect recent project activity:
 
 1. Search merged PRs from the last 30 days:
-   - Query pattern: `repo:${{ github.repository }} is:pr is:merged merged:>=YYYY-MM-DD`
+   - Use `search_pull_requests` with `owner` and `repo` parameters set; query only: `is:merged merged:>=YYYY-MM-DD`
    - For each PR, read details and changed files.
    - For each PR, fetch reviews and review comments (`get_reviews` and `get_review_comments`) to identify substantive human review contributions.
-2. Search recently closed bug and feature issues from the last 30 days:
-   - Query pattern: `repo:${{ github.repository }} is:issue closed:>=YYYY-MM-DD label:bug`
-   - Query pattern: `repo:${{ github.repository }} is:issue closed:>=YYYY-MM-DD label:enhancement`
-   - Also check `feature`, `idea`, or similar labels if present.
-3. Cross-reference external issue authors before deciding there are no updates:
+   - **Mandatory linked-issue pass**: For every merged PR, inspect the title, body, and commits for issue references (`#123`) and closing keywords (`Fixes`, `Closes`, `Resolves`, `implements`, `fixed in`). For each referenced issue, call `issue_read` and evaluate the issue author as a possible `bug` or `ideas` contributor. This pass is required even if every merged PR author is the repo owner or a bot.
+2. Search recently closed bug and feature issues from the last 30 days with narrow, label-specific queries:
+   - Use `search_issues` with `owner` and `repo` parameters set; query only: `closed:>=YYYY-MM-DD label:bug`
+   - Use `search_issues` with `owner` and `repo` parameters set; query only: `closed:>=YYYY-MM-DD label:enhancement`
+   - Repeat for `label:feature` and `label:idea` if those labels exist.
+   - Do **not** rely on one broad `closed:>=YYYY-MM-DD` issue search as the only source; broad output can be truncated or too large to inspect accurately.
+3. Parse GitHub search results accurately:
+   - GitHub MCP search responses are objects with an `items` array. If a response is saved to a temporary file because it is large, parse `.items[]` with `jq`; do not grep for logins or assume the root JSON value is an array.
+   - If a search result is too large to inspect, narrow the query by label or date and retry. Do not conclude there are zero external issue authors from truncated or unparsed output.
+4. Cross-reference external issue authors before deciding there are no updates:
    - For every recently closed bug/enhancement/feature/idea issue authored by a non-bot external user, read the issue and comments.
    - Check whether the issue was closed as completed, confirmed by the reporter, or referenced by a merged PR/commit in the same 30-day window.
    - Search merged PR titles/bodies for closing keywords and issue references (`#ISSUE_NUMBER`, `Fixes`, `Closes`, `Resolves`, `implements`, `fixed in`).
    - Add the issue author as a `bug` candidate for fixed bug reports and an `ideas` candidate for implemented feature/UX requests.
    - Do not discard these candidates just because the implementing PR author is the repo owner.
-4. For each candidate, gather direct evidence:
+5. For each candidate, gather direct evidence:
    - Login
    - Contribution type(s)
    - Source PR/issue number

--- a/.github/workflows/contributor-recognition.md
+++ b/.github/workflows/contributor-recognition.md
@@ -104,6 +104,15 @@ Do not add `maintenance`, `infra`, `tool`, or other less common types unless the
 
 For `bug` and `ideas`, the issue author is the contributor even when the merged fix PR was opened by the repo owner. Treat these as direct evidence when the issue is closed as completed and a merged PR body, title, commit message, or maintainer comment references the issue with language like `Fixes #123`, `Closes #123`, `Resolves #123`, "fixed in #123", or "implemented in #123".
 
+## Maintainer-Provided Backfill Candidates
+
+Some historical issue records may be filtered by workflow integrity policy even when their linked merged PRs are visible. Use this table only for the listed issue/PR pairs, and only when the linked PR is merged, references the issue, and the login is not already listed with the contribution type.
+
+| Login | Type | Issue | Linked merged PR | Rationale |
+|-------|------|-------|------------------|-----------|
+| `jototland` | `bug` | #282 | #285 | Reported a bug that was fixed by the linked PR. |
+| `edvinsyk` | `ideas` | #302 | #303 | Suggested an enhancement that was implemented by the linked PR. |
+
 ## Workflow
 
 ### 1. Load Current Contributor State
@@ -135,13 +144,18 @@ Use GitHub tools to inspect recent project activity:
 3. Parse GitHub search results accurately:
    - GitHub MCP search responses are objects with an `items` array. If a response is saved to a temporary file because it is large, parse `.items[]` with `jq`; do not grep for logins or assume the root JSON value is an array.
    - If a search result is too large to inspect, narrow the query by label or date and retry. Do not conclude there are zero external issue authors from truncated or unparsed output.
-4. Cross-reference external issue authors before deciding there are no updates:
+4. Apply the maintainer-provided backfill table when issue metadata is filtered:
+   - If `issue_read` or `search_issues` returns filtered data for one of the listed issue numbers, do not noop solely because the issue author cannot be re-read through GitHub tools.
+   - Verify the linked PR is merged and references the issue number with closing or implementation language.
+   - Treat the listed login and type as an approved candidate when the contributor is not already listed with that type.
+   - Do not extrapolate from the table to other issue numbers. Unlisted filtered issues should go under "Needs maintainer review" or into the review issue fallback.
+5. Cross-reference external issue authors before deciding there are no updates:
    - For every recently closed bug/enhancement/feature/idea issue authored by a non-bot external user, read the issue and comments.
    - Check whether the issue was closed as completed, confirmed by the reporter, or referenced by a merged PR/commit in the same 30-day window.
    - Search merged PR titles/bodies for closing keywords and issue references (`#ISSUE_NUMBER`, `Fixes`, `Closes`, `Resolves`, `implements`, `fixed in`).
    - Add the issue author as a `bug` candidate for fixed bug reports and an `ideas` candidate for implemented feature/UX requests.
    - Do not discard these candidates just because the implementing PR author is the repo owner.
-5. For each candidate, gather direct evidence:
+6. For each candidate, gather direct evidence:
    - Login
    - Contribution type(s)
    - Source PR/issue number

--- a/.github/workflows/contributor-recognition.md
+++ b/.github/workflows/contributor-recognition.md
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: weekly
-  skip-if-match: 'is:open in:title "docs(contributors): add recent contributors"'
+  skip-if-match: 'is:open in:title "docs(contributors):"'
 
 permissions:
   contents: read
@@ -32,7 +32,7 @@ safe-outputs:
     auto-merge: false
   create-issue:
     expires: 7d
-    title-prefix: "[contributors] "
+    title-prefix: "docs(contributors): "
     labels: [documentation, automation, contributors]
     max: 1
 
@@ -250,7 +250,7 @@ If there are ambiguous candidates but no `.all-contributorsrc` or `README.md` ch
 **Issue title**:
 
 ```text
-[contributors] Review possible contributor recognition
+docs(contributors): review possible contributor recognition
 ```
 
 **Issue body**:

--- a/.github/workflows/contributor-recognition.md
+++ b/.github/workflows/contributor-recognition.md
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: weekly
-  skip-if-match: 'is:open in:title "[contributors]"'
+  skip-if-match: 'is:open in:title "docs(contributors): add recent contributors"'
 
 permissions:
   contents: read
@@ -25,7 +25,7 @@ network:
 safe-outputs:
   create-pull-request:
     expires: 7d
-    title-prefix: "[contributors] "
+    title-prefix: "docs(contributors): "
     labels: [documentation, automation, contributors]
     reviewers: [YousefHadder]
     draft: true
@@ -215,7 +215,7 @@ If `.all-contributorsrc` or `README.md` changed, create a draft PR using the saf
 **PR title**:
 
 ```text
-[contributors] Add recent contributors
+docs(contributors): add recent contributors
 ```
 
 **PR body**:


### PR DESCRIPTION
Fixes the contributor-recognition workflow after it nooped even though recent external issue reporters should have been recognized.

- Allows `jq` so saved MCP search output can be parsed as JSON instead of grepped
- Requires linked-issue checks from merged PR bodies before nooping
- Uses narrow label-specific issue searches for bug and enhancement recognition

Tested by running `gh aw compile contributor-recognition --validate`.