### PR TITLE
feat(table): add insert/wrap/unwrap break commands

### DIFF
--- a/doc/markdown-plus.txt
+++ b/doc/markdown-plus.txt
@@ -1502,6 +1502,8 @@ The plugin can be configured through the setup function:
                                  -- so cells containing <br> don't inflate column width)
         wrap_break = '<br>',     -- Token used for in-cell line breaks; honoured by
                                  -- later cell-edit/wrap commands
+        max_column_width = nil,  -- Default width (display cells) for the wrap-cell
+                                 -- command. nil = prompt every time.
         keymaps = {
           enabled = true,
           prefix = '<localleader>t',
@@ -1720,6 +1722,9 @@ TABLES ~
     Cell operations:
     <Plug>(MarkdownPlusTableToggleCellAlignment)    - Toggle alignment (n)
     <Plug>(MarkdownPlusTableClearCell)              - Clear cell (n)
+    <Plug>(MarkdownPlusTableInsertBreak)            - Insert <br> at cursor (n)
+    <Plug>(MarkdownPlusTableWrapCell)               - Wrap cell to width (n)
+    <Plug>(MarkdownPlusTableUnwrapCell)             - Strip every <br> (n)
 
     Advanced operations:
     <Plug>(MarkdownPlusTableTranspose)              - Transpose table (n)

--- a/lua/markdown-plus/config/validate.lua
+++ b/lua/markdown-plus/config/validate.lua
@@ -59,6 +59,18 @@ local SCHEMA = {
       confirm_destructive = { type = "boolean" },
       width_mode = { type = "string", enum = { literal = true, segment = true } },
       wrap_break = { type = "string" },
+      max_column_width = {
+        type = "number",
+        validator = function(value, path, _)
+          if value < 1 then
+            return false, path .. ": must be at least 1"
+          end
+          if value ~= math.floor(value) then
+            return false, path .. ": must be an integer"
+          end
+          return true
+        end,
+      },
       keymaps = {
         type = "table",
         fields = {

--- a/lua/markdown-plus/init.lua
+++ b/lua/markdown-plus/init.lua
@@ -32,6 +32,7 @@ local DEFAULT_CONFIG = {
     confirm_destructive = true,
     width_mode = "literal",
     wrap_break = "<br>",
+    max_column_width = nil,
     keymaps = {
       enabled = true,
       prefix = "<localleader>t",

--- a/lua/markdown-plus/table/cell_ops.lua
+++ b/lua/markdown-plus/table/cell_ops.lua
@@ -5,10 +5,59 @@
 --- Provides in-place cell content and alignment modifications:
 --- - clear_cell: Clear the content of the current cell
 --- - toggle_cell_alignment: Cycle column alignment (left → center → right)
+--- - insert_break: Insert the configured wrap_break token at cursor inside a cell
+--- - wrap_cell: Re-flow the current cell content to a maximum width using <br>
+--- - unwrap_cell: Strip every <br> variant from the current cell
 ---@brief ]]
 
 local M = {}
 local utils = require("markdown-plus.utils")
+
+---Resolve the wrap_break token from the active table config.
+---@return string
+local function get_wrap_break()
+  local ok, table_module = pcall(require, "markdown-plus.table")
+  if ok and table_module.config and type(table_module.config.wrap_break) == "string" then
+    return table_module.config.wrap_break
+  end
+  return "<br>"
+end
+
+---Resolve the default max_column_width from the active table config (or nil).
+---@return integer|nil
+local function get_default_width()
+  local ok, table_module = pcall(require, "markdown-plus.table")
+  if ok and table_module.config then
+    return table_module.config.max_column_width
+  end
+  return nil
+end
+
+---Greedy word-wrap a single line of text to a width, preserving long words.
+---@param words string[]
+---@param width integer
+---@return string[]
+local function wrap_words(words, width)
+  if #words == 0 then
+    return {}
+  end
+  local lines = {}
+  local current = ""
+  for _, word in ipairs(words) do
+    if current == "" then
+      current = word
+    elseif #current + 1 + #word <= width then
+      current = current .. " " .. word
+    else
+      lines[#lines + 1] = current
+      current = word
+    end
+  end
+  if current ~= "" then
+    lines[#lines + 1] = current
+  end
+  return lines
+end
 
 ---Clear content of the current cell
 ---@return boolean success True if cell was cleared
@@ -67,6 +116,129 @@ function M.toggle_cell_alignment()
   formatter.format_table(table_info)
 
   utils.notify(string.format("Column alignment: %s", next_alignment), vim.log.levels.INFO)
+  return true
+end
+
+---Insert the configured wrap_break token at the cursor position inside a table cell.
+---This is a pure text edit; it does NOT reformat the table.
+---@return boolean success True if the break was inserted
+function M.insert_break()
+  local parser = require("markdown-plus.table.parser")
+  local row_mapper = require("markdown-plus.table.row_mapper")
+
+  local pos = parser.get_cursor_position_in_table()
+  if not pos then
+    utils.notify("Not in a table", vim.log.levels.WARN)
+    return false
+  end
+
+  if row_mapper.is_separator_row(pos.row) then
+    utils.notify("Cannot insert break in separator row", vim.log.levels.WARN)
+    return false
+  end
+
+  local wrap_break = get_wrap_break()
+  local cursor = vim.api.nvim_win_get_cursor(0)
+  local row = cursor[1]
+  local col = cursor[2]
+  local line = vim.api.nvim_buf_get_lines(0, row - 1, row, false)[1] or ""
+
+  local new_line = line:sub(1, col) .. wrap_break .. line:sub(col + 1)
+  vim.api.nvim_buf_set_lines(0, row - 1, row, false, { new_line })
+  vim.api.nvim_win_set_cursor(0, { row, col + #wrap_break })
+  return true
+end
+
+---Re-flow the content of the current cell to a maximum width, inserting
+---wrap_break at word boundaries. Existing breaks in the cell are flattened
+---first so the result is idempotent (re-running with the same width is a no-op).
+---
+---Width resolution order: explicit `width` argument → config.max_column_width
+---→ interactive prompt.
+---@param width? integer Target width in display cells (must be >= 1)
+---@return boolean success True if the cell was wrapped
+function M.wrap_cell(width)
+  local helpers = require("markdown-plus.table.helpers")
+  local row_mapper = require("markdown-plus.table.row_mapper")
+  local cell_breaks = require("markdown-plus.table.cell_breaks")
+
+  local table_info, pos = helpers.get_table_and_pos()
+  if not table_info or not pos then
+    return false
+  end
+
+  if row_mapper.is_separator_row(pos.row) then
+    utils.notify("Cannot wrap separator row", vim.log.levels.WARN)
+    return false
+  end
+
+  if width == nil then
+    width = get_default_width()
+  end
+  if width == nil then
+    local input = vim.fn.input("Wrap width: ")
+    if input == "" then
+      return false
+    end
+    width = tonumber(input)
+  end
+  if type(width) ~= "number" or width < 1 or width ~= math.floor(width) then
+    utils.notify("Wrap width must be a positive integer", vim.log.levels.ERROR)
+    return false
+  end
+
+  local cells_index = row_mapper.pos_row_to_cells_index(pos.row)
+  if not cells_index then
+    return false
+  end
+
+  local cell = table_info.cells[cells_index][pos.col + 1] or ""
+  local segments = cell_breaks.split_segments(cell)
+
+  local words = {}
+  for _, seg in ipairs(segments) do
+    for word in seg:gmatch("%S+") do
+      words[#words + 1] = word
+    end
+  end
+
+  local new_lines = wrap_words(words, width)
+  local new_content = cell_breaks.join_segments(new_lines, get_wrap_break())
+  table_info.cells[cells_index][pos.col + 1] = new_content
+
+  local formatter = require("markdown-plus.table.format")
+  formatter.format_table(table_info)
+  return true
+end
+
+---Strip every <br> variant from the current cell, collapsing the content to a
+---single line. Whitespace runs are collapsed to single spaces and trimmed.
+---@return boolean success True if the cell was unwrapped
+function M.unwrap_cell()
+  local helpers = require("markdown-plus.table.helpers")
+  local row_mapper = require("markdown-plus.table.row_mapper")
+  local cell_breaks = require("markdown-plus.table.cell_breaks")
+
+  local table_info, pos = helpers.get_table_and_pos()
+  if not table_info or not pos then
+    return false
+  end
+
+  if row_mapper.is_separator_row(pos.row) then
+    utils.notify("Cannot unwrap separator row", vim.log.levels.WARN)
+    return false
+  end
+
+  local cells_index = row_mapper.pos_row_to_cells_index(pos.row)
+  if not cells_index then
+    return false
+  end
+
+  local cell = table_info.cells[cells_index][pos.col + 1] or ""
+  table_info.cells[cells_index][pos.col + 1] = cell_breaks.unwrap(cell)
+
+  local formatter = require("markdown-plus.table.format")
+  formatter.format_table(table_info)
   return true
 end
 

--- a/lua/markdown-plus/table/init.lua
+++ b/lua/markdown-plus/table/init.lua
@@ -22,6 +22,7 @@ M.defaults = {
   confirm_destructive = true,
   width_mode = "literal",
   wrap_break = "<br>",
+  max_column_width = nil,
   keymaps = {
     enabled = true,
     prefix = "<localleader>t",
@@ -181,6 +182,30 @@ end
 function M.clear_cell()
   local manip = require("markdown-plus.table.manipulation")
   return manip.clear_cell()
+end
+
+---Insert the configured wrap_break token at the cursor position inside a cell.
+---Pure text edit; does not reformat the table.
+---@return boolean success True if the break was inserted
+function M.insert_break()
+  local manip = require("markdown-plus.table.manipulation")
+  return manip.insert_break()
+end
+
+---Re-flow the current cell content using <br> at word boundaries.
+---Width comes from: explicit arg > config.max_column_width > interactive prompt.
+---@param width? integer Target width in display cells (must be >= 1)
+---@return boolean success True if the cell was wrapped
+function M.wrap_cell(width)
+  local manip = require("markdown-plus.table.manipulation")
+  return manip.wrap_cell(width)
+end
+
+---Strip every <br> variant from the current cell, collapsing to a single line.
+---@return boolean success True if the cell was unwrapped
+function M.unwrap_cell()
+  local manip = require("markdown-plus.table.manipulation")
+  return manip.unwrap_cell()
 end
 
 ---Move column left

--- a/lua/markdown-plus/table/keymaps.lua
+++ b/lua/markdown-plus/table/keymaps.lua
@@ -154,6 +154,33 @@ local function get_keymap_defs(prefix, include_insert_defaults)
       default_key = prefix .. "x",
       desc = "Clear cell content",
     },
+    {
+      plug = keymap_helper.plug_name("TableInsertBreak"),
+      fn = function()
+        require("markdown-plus.table").insert_break()
+      end,
+      modes = "n",
+      default_key = prefix .. "b",
+      desc = "Insert <br> line break at cursor inside cell",
+    },
+    {
+      plug = keymap_helper.plug_name("TableWrapCell"),
+      fn = function()
+        require("markdown-plus.table").wrap_cell()
+      end,
+      modes = "n",
+      default_key = prefix .. "w",
+      desc = "Wrap cell content at word boundaries using <br>",
+    },
+    {
+      plug = keymap_helper.plug_name("TableUnwrapCell"),
+      fn = function()
+        require("markdown-plus.table").unwrap_cell()
+      end,
+      modes = "n",
+      default_key = prefix .. "W",
+      desc = "Unwrap cell (strip every <br> variant)",
+    },
 
     -- Row movement
     {

--- a/lua/markdown-plus/table/manipulation.lua
+++ b/lua/markdown-plus/table/manipulation.lua
@@ -31,5 +31,8 @@ M.move_column_right = column_ops.move_column_right
 -- Cell operations
 M.clear_cell = cell_ops.clear_cell
 M.toggle_cell_alignment = cell_ops.toggle_cell_alignment
+M.insert_break = cell_ops.insert_break
+M.wrap_cell = cell_ops.wrap_cell
+M.unwrap_cell = cell_ops.unwrap_cell
 
 return M

--- a/lua/markdown-plus/types.lua
+++ b/lua/markdown-plus/types.lua
@@ -39,6 +39,7 @@
 ---@field confirm_destructive? boolean Confirm before destructive operations like transpose/sort (default: true)
 ---@field width_mode? "literal"|"segment" Column-width calculation mode (default: 'literal'). 'segment' measures the widest <br>-split segment so cells containing breaks don't inflate column width.
 ---@field wrap_break? string Token used to represent a line break inside a cell (default: '<br>'). Honoured by later cell-edit/wrap commands.
+---@field max_column_width? integer Default width (in display cells) used by the wrap-cell command. nil disables the default and forces a prompt (default: nil).
 ---@field keymaps? markdown-plus.TableKeymapConfig Table keymap configuration
 
 ---Table keymap configuration
@@ -135,6 +136,7 @@
 ---@field confirm_destructive boolean
 ---@field width_mode "literal"|"segment"
 ---@field wrap_break string
+---@field max_column_width integer|nil
 ---@field keymaps markdown-plus.InternalTableKeymapConfig
 
 ---Internal table keymap configuration

--- a/spec/markdown-plus/table_cell_ops_spec.lua
+++ b/spec/markdown-plus/table_cell_ops_spec.lua
@@ -183,4 +183,258 @@ describe("table.cell_ops", function()
       assert.is_false(success)
     end)
   end)
+
+  describe("insert_break", function()
+    local markdown_plus = require("markdown-plus")
+
+    before_each(function()
+      markdown_plus.setup({})
+    end)
+
+    after_each(function()
+      markdown_plus.teardown()
+    end)
+
+    it("inserts <br> at the cursor position inside a data cell", function()
+      local lines = {
+        "| H1   | H2 |",
+        "| ---- | -- |",
+        "| word | y  |",
+      }
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, lines)
+      -- 0-indexed col 4 = byte position right after "| wo" (between 'o' and 'r')
+      vim.api.nvim_win_set_cursor(0, { 3, 4 })
+
+      assert.is_true(cell_ops.insert_break())
+
+      local line = vim.api.nvim_buf_get_lines(0, 2, 3, false)[1]
+      assert.equals("| wo<br>rd | y  |", line)
+
+      local cursor = vim.api.nvim_win_get_cursor(0)
+      assert.equals(3, cursor[1])
+      assert.equals(4 + #"<br>", cursor[2])
+    end)
+
+    it("inserts the configured custom wrap_break", function()
+      markdown_plus.setup({ table = { wrap_break = "|BRK|" } })
+
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {
+        "| H |",
+        "| - |",
+        "| a |",
+      })
+      -- 0-indexed col 3 = byte position right after "| a" (between 'a' and ' ')
+      vim.api.nvim_win_set_cursor(0, { 3, 3 })
+
+      assert.is_true(cell_ops.insert_break())
+
+      local line = vim.api.nvim_buf_get_lines(0, 2, 3, false)[1]
+      assert.equals("| a|BRK| |", line)
+    end)
+
+    it("rejects the separator row", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {
+        "| H | I |",
+        "| - | - |",
+        "| a | b |",
+      })
+      vim.fn.cursor(2, 3)
+
+      assert.is_false(cell_ops.insert_break())
+    end)
+
+    it("returns false when not in a table", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "plain text" })
+      vim.fn.cursor(1, 1)
+      assert.is_false(cell_ops.insert_break())
+    end)
+  end)
+
+  describe("wrap_cell", function()
+    local markdown_plus = require("markdown-plus")
+
+    before_each(function()
+      markdown_plus.setup({})
+    end)
+
+    after_each(function()
+      markdown_plus.teardown()
+    end)
+
+    local function place_cursor_at_cell(content_line, cell_text)
+      -- Find a column inside the target cell on the given line.
+      local line = vim.api.nvim_buf_get_lines(0, content_line - 1, content_line, false)[1]
+      local s = line:find(cell_text, 1, true)
+      assert.is_not_nil(s, "expected cell text to be present")
+      vim.fn.cursor(content_line, s)
+    end
+
+    it("wraps a long cell at the explicit width using <br>", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {
+        "| H | B |",
+        "| - | - |",
+        "| the quick brown fox | y |",
+      })
+      place_cursor_at_cell(3, "the")
+
+      assert.is_true(cell_ops.wrap_cell(9))
+
+      local table_info = parser.get_table_at_cursor()
+      -- "the quick" (9) | "brown fox" (9)
+      assert.equals("the quick<br>brown fox", table_info.cells[2][1])
+    end)
+
+    it("re-flows an already-broken cell when re-wrapped (idempotent at same width)", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {
+        "| H | B |",
+        "| - | - |",
+        "| the quick brown fox | y |",
+      })
+      place_cursor_at_cell(3, "the")
+
+      assert.is_true(cell_ops.wrap_cell(9))
+      local first = parser.get_table_at_cursor().cells[2][1]
+
+      -- Find the cell again after potential layout shift
+      place_cursor_at_cell(3, "the")
+      assert.is_true(cell_ops.wrap_cell(9))
+      local second = parser.get_table_at_cursor().cells[2][1]
+
+      assert.equals(first, second)
+    end)
+
+    it("respects word boundaries (does not split a single long word)", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {
+        "| H | B |",
+        "| - | - |",
+        "| supercalifragilistic short | y |",
+      })
+      place_cursor_at_cell(3, "supercalifragilistic")
+
+      assert.is_true(cell_ops.wrap_cell(8))
+
+      local table_info = parser.get_table_at_cursor()
+      -- The long word stays intact on its own line
+      assert.is_truthy(table_info.cells[2][1]:find("supercalifragilistic", 1, true))
+      -- And the short word ends up on a separate line via <br>
+      assert.is_truthy(table_info.cells[2][1]:find("<br>", 1, true))
+    end)
+
+    it("uses config.max_column_width when no explicit width is given", function()
+      markdown_plus.setup({ table = { max_column_width = 9 } })
+
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {
+        "| H | B |",
+        "| - | - |",
+        "| the quick brown fox | y |",
+      })
+      place_cursor_at_cell(3, "the")
+
+      assert.is_true(cell_ops.wrap_cell())
+
+      local table_info = parser.get_table_at_cursor()
+      assert.equals("the quick<br>brown fox", table_info.cells[2][1])
+    end)
+
+    it("rejects the separator row", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {
+        "| H | B |",
+        "| - | - |",
+        "| a | b |",
+      })
+      vim.fn.cursor(2, 3)
+      assert.is_false(cell_ops.wrap_cell(10))
+    end)
+
+    it("returns false when not in a table", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "plain text" })
+      vim.fn.cursor(1, 1)
+      assert.is_false(cell_ops.wrap_cell(10))
+    end)
+
+    it("rejects non-positive widths", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {
+        "| H |",
+        "| - |",
+        "| a |",
+      })
+      vim.fn.cursor(3, 3)
+      assert.is_false(cell_ops.wrap_cell(0))
+      assert.is_false(cell_ops.wrap_cell(-3))
+    end)
+  end)
+
+  describe("unwrap_cell", function()
+    local markdown_plus = require("markdown-plus")
+
+    before_each(function()
+      markdown_plus.setup({})
+    end)
+
+    after_each(function()
+      markdown_plus.teardown()
+    end)
+
+    it("strips a single <br>", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {
+        "| H        | B |",
+        "| -------- | - |",
+        "| aa<br>bb | y |",
+      })
+      vim.fn.cursor(3, 4)
+
+      assert.is_true(cell_ops.unwrap_cell())
+
+      local table_info = parser.get_table_at_cursor()
+      assert.equals("aa bb", table_info.cells[2][1])
+    end)
+
+    it("strips mixed <br>, <br/>, <br /> variants", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {
+        "| H                            | B |",
+        "| ---------------------------- | - |",
+        "| one<br>two<br/>three<br />four | y |",
+      })
+      vim.fn.cursor(3, 4)
+
+      assert.is_true(cell_ops.unwrap_cell())
+
+      local table_info = parser.get_table_at_cursor()
+      assert.equals("one two three four", table_info.cells[2][1])
+    end)
+
+    it("is idempotent (no <br> left → second run is a no-op)", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {
+        "| H        | B |",
+        "| -------- | - |",
+        "| aa<br>bb | y |",
+      })
+      vim.fn.cursor(3, 4)
+
+      assert.is_true(cell_ops.unwrap_cell())
+      local first = parser.get_table_at_cursor().cells[2][1]
+
+      vim.fn.cursor(3, 4)
+      assert.is_true(cell_ops.unwrap_cell())
+      local second = parser.get_table_at_cursor().cells[2][1]
+
+      assert.equals(first, second)
+    end)
+
+    it("rejects the separator row", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {
+        "| H | B |",
+        "| - | - |",
+        "| a | b |",
+      })
+      vim.fn.cursor(2, 3)
+      assert.is_false(cell_ops.unwrap_cell())
+    end)
+
+    it("returns false when not in a table", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "plain text" })
+      vim.fn.cursor(1, 1)
+      assert.is_false(cell_ops.unwrap_cell())
+    end)
+  end)
 end)


### PR DESCRIPTION
Closes #326. Phase 2 of the [multi-line table cell Epic (#324)](https://github.com/YousefHadder/markdown-plus.nvim/issues/324).

Builds on Phase 1 (#330): now that the formatter and `cell_breaks` helper know about `<br>`, this PR adds three explicit cell commands so users can actually put `<br>` into cells without typing the tag by hand.

## What this adds

Three new `<Plug>` mappings with buffer-local default bindings:

| `<Plug>` | Default | What it does |
|----------|---------|--------------|
| `<Plug>(MarkdownPlusTableInsertBreak)` | `<localleader>tb` | Insert the configured `wrap_break` token at cursor inside a cell. Pure text edit; does not reformat. |
| `<Plug>(MarkdownPlusTableWrapCell)` | `<localleader>tw` | Re-flow the current cell at word boundaries using `<br>`. Width comes from explicit arg → `table.max_column_width` → interactive prompt. Idempotent at the same width. |
| `<Plug>(MarkdownPlusTableUnwrapCell)` | `<localleader>tW` | Strip every `<br>` / `<br/>` / `<br />` variant from the current cell and collapse to one line. |

Plus a new config key:

- `table.max_column_width` (integer ≥ 1, default `nil`) — when set, `wrap_cell` uses this width and skips the prompt.

All three commands:
- Reject the separator row with a notify
- Return `false` outside a table
- Re-use `cell_breaks` from Phase 1 (no duplicated `<br>` parsing)

## Why it's non-breaking

- No existing keymap collides with `<localleader>tb`, `tw`, or `tW` (verified against `keymaps.lua`).
- `keymap_helper` defers to any pre-existing buffer-local mapping at those keys, so users who've already bound them keep their bindings.
- `max_column_width` defaults to `nil` (preserves current behaviour — `wrap_cell` simply prompts).
- No autocmds, no format-time auto-wrap (that's Phase 5).

## Tests

15 new cases in `spec/markdown-plus/table_cell_ops_spec.lua`:

- `insert_break`: cursor-position insertion, custom `wrap_break` honoured, separator-row rejection, not-in-table.
- `wrap_cell`: explicit width, config-driven width, word-boundary preservation (long word stays intact), idempotency at same width, separator-row rejection, not-in-table, rejects non-positive widths.
- `unwrap_cell`: single break, mixed `<br>` / `<br/>` / `<br />` variants, idempotency, separator-row rejection, not-in-table.

Config-validation tests for `max_column_width` are covered manually (Test 12 in `manual-testing-phase-2.md`); the schema validator runs through the existing config_spec harness for any setup call that passes the key.

`make check` green. 197 → 212 tests total.

## Files changed

| File | Change |
|------|-------|
| `lua/markdown-plus/table/cell_ops.lua` | +`insert_break`, `wrap_cell`, `unwrap_cell` |
| `lua/markdown-plus/table/manipulation.lua` | re-export facade |
| `lua/markdown-plus/table/init.lua` | public API wrappers |
| `lua/markdown-plus/table/keymaps.lua` | three new `<Plug>` mappings + default bindings |
| `lua/markdown-plus/types.lua` | `max_column_width` on `TableConfig` + internal type |
| `lua/markdown-plus/init.lua`, `lua/markdown-plus/table/init.lua` | default `max_column_width = nil` |
| `lua/markdown-plus/config/validate.lua` | positive-integer schema for `max_column_width` |
| `doc/markdown-plus.txt` | keymap reference + config example updated |
| `spec/markdown-plus/table_cell_ops_spec.lua` | +15 tests |

## Out of scope (later phases)

- Cell-editor popup (`<localleader>te`) → #327
- Virtual-line preview (`<localleader>tV`) → #328
- Opt-in auto-wrap on format → #329
