### PR TITLE
feat(table): add floating cell editor popup

### DIFF
--- a/doc/markdown-plus.txt
+++ b/doc/markdown-plus.txt
@@ -1504,6 +1504,12 @@ The plugin can be configured through the setup function:
                                  -- later cell-edit/wrap commands
         max_column_width = nil,  -- Default width (display cells) for the wrap-cell
                                  -- command. nil = prompt every time.
+        cell_editor = {          -- Floating cell-editor popup configuration
+          enabled = true,        -- Allow opening the popup
+          border = 'rounded',    -- nvim_open_win border style
+          width = 0.6,           -- fraction of editor width (0, 1]
+          height = 0.4,          -- fraction of editor height (0, 1]
+        },
         keymaps = {
           enabled = true,
           prefix = '<localleader>t',
@@ -1725,6 +1731,7 @@ TABLES ~
     <Plug>(MarkdownPlusTableInsertBreak)            - Insert <br> at cursor (n)
     <Plug>(MarkdownPlusTableWrapCell)               - Wrap cell to width (n)
     <Plug>(MarkdownPlusTableUnwrapCell)             - Strip every <br> (n)
+    <Plug>(MarkdownPlusTableEditCell)               - Edit cell in popup (n)
 
     Advanced operations:
     <Plug>(MarkdownPlusTableTranspose)              - Transpose table (n)

--- a/lua/markdown-plus/config/validate.lua
+++ b/lua/markdown-plus/config/validate.lua
@@ -71,6 +71,31 @@ local SCHEMA = {
           return true
         end,
       },
+      cell_editor = {
+        type = "table",
+        fields = {
+          enabled = { type = "boolean" },
+          border = { type = "string" },
+          width = {
+            type = "number",
+            validator = function(value, path, _)
+              if value <= 0 or value > 1 then
+                return false, path .. ": must be in range (0, 1]"
+              end
+              return true
+            end,
+          },
+          height = {
+            type = "number",
+            validator = function(value, path, _)
+              if value <= 0 or value > 1 then
+                return false, path .. ": must be in range (0, 1]"
+              end
+              return true
+            end,
+          },
+        },
+      },
       keymaps = {
         type = "table",
         fields = {

--- a/lua/markdown-plus/init.lua
+++ b/lua/markdown-plus/init.lua
@@ -33,6 +33,12 @@ local DEFAULT_CONFIG = {
     width_mode = "literal",
     wrap_break = "<br>",
     max_column_width = nil,
+    cell_editor = {
+      enabled = true,
+      border = "rounded",
+      width = 0.6,
+      height = 0.4,
+    },
     keymaps = {
       enabled = true,
       prefix = "<localleader>t",

--- a/lua/markdown-plus/table/cell_editor.lua
+++ b/lua/markdown-plus/table/cell_editor.lua
@@ -1,0 +1,224 @@
+---@module 'markdown-plus.table.cell_editor'
+---@brief [[
+--- Floating popup editor for a single table cell.
+---
+--- Pattern inspired by Org-mode's `C-c '`: open the current cell in a scratch
+--- buffer with markdown filetype, split on the configured `wrap_break` so each
+--- segment is one buffer line, and let the user edit freely with real newlines.
+--- On save, join lines back with `wrap_break`, write to the source table, and
+--- reformat.
+---
+--- `M.open()` returns a session table (or nil on failure). Tests drive the
+--- session by manipulating `state.scratch_buf` and calling `state.save()` /
+--- `state.cancel()` directly. Interactive users hit `<CR>` / `:w` / `q` /
+--- `<Esc><Esc>` mapped on the scratch buffer.
+---@brief ]]
+
+local M = {}
+local utils = require("markdown-plus.utils")
+
+---Resolve the cell_editor sub-config from the active table config.
+---@return markdown-plus.InternalTableCellEditorConfig
+local function get_editor_config()
+  local ok, table_module = pcall(require, "markdown-plus.table")
+  if ok and table_module.config and table_module.config.cell_editor then
+    return table_module.config.cell_editor
+  end
+  return { enabled = true, border = "rounded", width = 0.6, height = 0.4 }
+end
+
+---Resolve the wrap_break token from the active table config.
+---@return string
+local function get_wrap_break()
+  local ok, table_module = pcall(require, "markdown-plus.table")
+  if ok and table_module.config and type(table_module.config.wrap_break) == "string" then
+    return table_module.config.wrap_break
+  end
+  return "<br>"
+end
+
+---Compute centered floating-window geometry from fractional dimensions.
+---@param config markdown-plus.InternalTableCellEditorConfig
+---@return {row: integer, col: integer, width: integer, height: integer}
+local function compute_geometry(config)
+  local total_cols = vim.o.columns
+  local total_lines = vim.o.lines
+  local width = math.max(20, math.floor(total_cols * (config.width or 0.6)))
+  local height = math.max(5, math.floor(total_lines * (config.height or 0.4)))
+  local row = math.max(0, math.floor((total_lines - height) / 2))
+  local col = math.max(0, math.floor((total_cols - width) / 2))
+  return { row = row, col = col, width = width, height = height }
+end
+
+---Open the cell editor popup for the cell under the cursor.
+---On success returns a session state table; nil otherwise. The session exposes
+---`save()` and `cancel()` callbacks that are also wired to scratch-buffer
+---keymaps and the BufWriteCmd autocmd for interactive use.
+---@return table|nil state Session state, or nil on failure
+function M.open()
+  local config = get_editor_config()
+  if config.enabled == false then
+    utils.notify("Cell editor is disabled", vim.log.levels.WARN)
+    return nil
+  end
+
+  local parser = require("markdown-plus.table.parser")
+  local row_mapper = require("markdown-plus.table.row_mapper")
+  local cell_breaks = require("markdown-plus.table.cell_breaks")
+
+  local table_info = parser.get_table_at_cursor()
+  if not table_info then
+    utils.notify("Not in a table", vim.log.levels.WARN)
+    return nil
+  end
+
+  local pos = parser.get_cursor_position_in_table()
+  if not pos then
+    utils.notify("Cannot determine cell position", vim.log.levels.WARN)
+    return nil
+  end
+
+  if row_mapper.is_separator_row(pos.row) then
+    utils.notify("Cannot edit separator row", vim.log.levels.WARN)
+    return nil
+  end
+
+  local cells_index = row_mapper.pos_row_to_cells_index(pos.row)
+  if not cells_index then
+    utils.notify("Internal error: invalid cell index", vim.log.levels.ERROR)
+    return nil
+  end
+
+  local orig_win = vim.api.nvim_get_current_win()
+  local orig_buf = vim.api.nvim_get_current_buf()
+  local cell_content = table_info.cells[cells_index][pos.col + 1] or ""
+  local segments = cell_breaks.split_segments(cell_content)
+
+  -- Create scratch buffer
+  local scratch_buf = vim.api.nvim_create_buf(false, true)
+  vim.bo[scratch_buf].bufhidden = "wipe"
+  vim.bo[scratch_buf].buftype = "acwrite"
+  vim.bo[scratch_buf].filetype = "markdown"
+  -- Unique name so :w doesn't try to write a real file
+  local buf_name = string.format("markdown-plus://cell-editor/%d", scratch_buf)
+  pcall(vim.api.nvim_buf_set_name, scratch_buf, buf_name)
+  vim.api.nvim_buf_set_lines(scratch_buf, 0, -1, false, segments)
+  vim.bo[scratch_buf].modified = false
+
+  local geom = compute_geometry(config)
+  local scratch_win = vim.api.nvim_open_win(scratch_buf, true, {
+    relative = "editor",
+    width = geom.width,
+    height = geom.height,
+    row = geom.row,
+    col = geom.col,
+    border = config.border or "rounded",
+    title = string.format(" Cell editor — row %d col %d ", pos.row, pos.col + 1),
+    title_pos = "center",
+  })
+
+  local state = {
+    orig_win = orig_win,
+    orig_buf = orig_buf,
+    scratch_win = scratch_win,
+    scratch_buf = scratch_buf,
+    table_info = table_info,
+    pos = pos,
+    cells_index = cells_index,
+    closed = false,
+  }
+
+  local function close_scratch()
+    if state.closed then
+      return
+    end
+    state.closed = true
+    if vim.api.nvim_win_is_valid(scratch_win) then
+      pcall(vim.api.nvim_win_close, scratch_win, true)
+    end
+  end
+
+  ---@return boolean success
+  function state.save()
+    if state.closed then
+      return false
+    end
+    if not vim.api.nvim_buf_is_valid(scratch_buf) then
+      return false
+    end
+    if not vim.api.nvim_win_is_valid(orig_win) then
+      utils.notify("Original window was closed; cannot save cell", vim.log.levels.ERROR)
+      close_scratch()
+      return false
+    end
+    if not vim.api.nvim_buf_is_valid(orig_buf) then
+      utils.notify("Original buffer was deleted; cannot save cell", vim.log.levels.ERROR)
+      close_scratch()
+      return false
+    end
+    if vim.api.nvim_win_get_buf(orig_win) ~= orig_buf then
+      utils.notify("Original window now shows a different buffer; cannot save cell", vim.log.levels.ERROR)
+      close_scratch()
+      return false
+    end
+
+    local lines = vim.api.nvim_buf_get_lines(scratch_buf, 0, -1, false)
+    local joined = cell_breaks.join_segments(lines, get_wrap_break())
+
+    -- Switch focus to the original window so format_table and parser run there.
+    vim.api.nvim_set_current_win(orig_win)
+    state.table_info.cells[state.cells_index][state.pos.col + 1] = joined
+
+    local formatter = require("markdown-plus.table.format")
+    formatter.format_table(state.table_info)
+
+    -- Place cursor back in the cell that was edited; widths may have shifted.
+    local updated = parser.get_table_at_cursor()
+    if updated then
+      local navigation = require("markdown-plus.table.navigation")
+      navigation.move_to_cell(updated, state.pos.row, state.pos.col)
+    end
+
+    close_scratch()
+    return true
+  end
+
+  ---@return boolean success
+  function state.cancel()
+    close_scratch()
+    return true
+  end
+
+  -- Keymaps on scratch buffer
+  local opts = { buffer = scratch_buf, silent = true, nowait = true }
+  vim.keymap.set("n", "<CR>", function()
+    state.save()
+  end, opts)
+  vim.keymap.set("n", "q", function()
+    state.cancel()
+  end, opts)
+  vim.keymap.set("n", "<Esc><Esc>", function()
+    state.cancel()
+  end, opts)
+
+  -- Intercept :w for save
+  vim.api.nvim_create_autocmd("BufWriteCmd", {
+    buffer = scratch_buf,
+    callback = function()
+      state.save()
+    end,
+  })
+
+  -- If the popup closes by other means (e.g. :q), treat as cancel.
+  vim.api.nvim_create_autocmd("WinClosed", {
+    pattern = tostring(scratch_win),
+    callback = function()
+      state.closed = true
+    end,
+    once = true,
+  })
+
+  return state
+end
+
+return M

--- a/lua/markdown-plus/table/init.lua
+++ b/lua/markdown-plus/table/init.lua
@@ -23,6 +23,12 @@ M.defaults = {
   width_mode = "literal",
   wrap_break = "<br>",
   max_column_width = nil,
+  cell_editor = {
+    enabled = true,
+    border = "rounded",
+    width = 0.6,
+    height = 0.4,
+  },
   keymaps = {
     enabled = true,
     prefix = "<localleader>t",
@@ -206,6 +212,13 @@ end
 function M.unwrap_cell()
   local manip = require("markdown-plus.table.manipulation")
   return manip.unwrap_cell()
+end
+
+---Open the floating cell editor for the cell under the cursor.
+---@return table|nil state Session state, or nil on failure
+function M.edit_cell()
+  local cell_editor = require("markdown-plus.table.cell_editor")
+  return cell_editor.open()
 end
 
 ---Move column left

--- a/lua/markdown-plus/table/keymaps.lua
+++ b/lua/markdown-plus/table/keymaps.lua
@@ -181,6 +181,15 @@ local function get_keymap_defs(prefix, include_insert_defaults)
       default_key = prefix .. "W",
       desc = "Unwrap cell (strip every <br> variant)",
     },
+    {
+      plug = keymap_helper.plug_name("TableEditCell"),
+      fn = function()
+        require("markdown-plus.table").edit_cell()
+      end,
+      modes = "n",
+      default_key = prefix .. "e",
+      desc = "Edit cell content in a floating popup",
+    },
 
     -- Row movement
     {

--- a/lua/markdown-plus/types.lua
+++ b/lua/markdown-plus/types.lua
@@ -40,7 +40,15 @@
 ---@field width_mode? "literal"|"segment" Column-width calculation mode (default: 'literal'). 'segment' measures the widest <br>-split segment so cells containing breaks don't inflate column width.
 ---@field wrap_break? string Token used to represent a line break inside a cell (default: '<br>'). Honoured by later cell-edit/wrap commands.
 ---@field max_column_width? integer Default width (in display cells) used by the wrap-cell command. nil disables the default and forces a prompt (default: nil).
+---@field cell_editor? markdown-plus.TableCellEditorConfig Floating cell-editor popup configuration
 ---@field keymaps? markdown-plus.TableKeymapConfig Table keymap configuration
+
+---Floating cell-editor popup configuration
+---@class markdown-plus.TableCellEditorConfig
+---@field enabled? boolean Allow opening the cell-editor popup (default: true)
+---@field border? string nvim_open_win border style (default: 'rounded')
+---@field width? number Floating window width as a fraction of editor width, 0 < w <= 1 (default: 0.6)
+---@field height? number Floating window height as a fraction of editor height, 0 < h <= 1 (default: 0.4)
 
 ---Table keymap configuration
 ---@class markdown-plus.TableKeymapConfig
@@ -137,7 +145,15 @@
 ---@field width_mode "literal"|"segment"
 ---@field wrap_break string
 ---@field max_column_width integer|nil
+---@field cell_editor markdown-plus.InternalTableCellEditorConfig
 ---@field keymaps markdown-plus.InternalTableKeymapConfig
+
+---Internal cell-editor popup configuration
+---@class markdown-plus.InternalTableCellEditorConfig
+---@field enabled boolean
+---@field border string
+---@field width number
+---@field height number
 
 ---Internal table keymap configuration
 ---@class markdown-plus.InternalTableKeymapConfig

--- a/spec/markdown-plus/table_cell_editor_spec.lua
+++ b/spec/markdown-plus/table_cell_editor_spec.lua
@@ -1,0 +1,285 @@
+---@diagnostic disable: undefined-field
+local cell_editor = require("markdown-plus.table.cell_editor")
+local parser = require("markdown-plus.table.parser")
+
+describe("table.cell_editor", function()
+  local markdown_plus = require("markdown-plus")
+
+  before_each(function()
+    vim.cmd("enew")
+    vim.bo.filetype = "markdown"
+    markdown_plus.setup({})
+  end)
+
+  after_each(function()
+    markdown_plus.teardown()
+  end)
+
+  local function reset_to(lines)
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, lines)
+  end
+
+  local function place_cursor_at(line_number, cell_text)
+    local line = vim.api.nvim_buf_get_lines(0, line_number - 1, line_number, false)[1]
+    local s = line:find(cell_text, 1, true)
+    assert.is_not_nil(s, "expected cell text to be present: " .. cell_text)
+    vim.fn.cursor(line_number, s)
+  end
+
+  describe("open", function()
+    it("returns a session and populates scratch with segments split on <br>", function()
+      reset_to({
+        "| Title  | B |",
+        "| ------ | - |",
+        "| one<br>two<br>three | y |",
+      })
+      place_cursor_at(3, "one")
+
+      local state = cell_editor.open()
+      assert.is_not_nil(state)
+      assert.is_true(vim.api.nvim_buf_is_valid(state.scratch_buf))
+      assert.is_true(vim.api.nvim_win_is_valid(state.scratch_win))
+
+      local segments = vim.api.nvim_buf_get_lines(state.scratch_buf, 0, -1, false)
+      assert.are.same({ "one", "two", "three" }, segments)
+
+      state.cancel()
+    end)
+
+    it("populates scratch with single line when cell has no <br>", function()
+      reset_to({
+        "| A    | B |",
+        "| ---- | - |",
+        "| word | y |",
+      })
+      place_cursor_at(3, "word")
+
+      local state = cell_editor.open()
+      local segments = vim.api.nvim_buf_get_lines(state.scratch_buf, 0, -1, false)
+      assert.are.same({ "word" }, segments)
+      state.cancel()
+    end)
+
+    it("returns nil and notifies when not in a table", function()
+      reset_to({ "plain text" })
+      vim.fn.cursor(1, 1)
+      assert.is_nil(cell_editor.open())
+    end)
+
+    it("rejects the separator row", function()
+      reset_to({
+        "| H | B |",
+        "| - | - |",
+        "| a | b |",
+      })
+      vim.fn.cursor(2, 3)
+      assert.is_nil(cell_editor.open())
+    end)
+
+    it("returns nil when cell_editor.enabled is false", function()
+      markdown_plus.setup({ table = { cell_editor = { enabled = false } } })
+      reset_to({
+        "| H | B |",
+        "| - | - |",
+        "| a | b |",
+      })
+      vim.fn.cursor(3, 3)
+      assert.is_nil(cell_editor.open())
+    end)
+  end)
+
+  describe("save", function()
+    it("joins lines with <br> and writes back to the source cell", function()
+      reset_to({
+        "| H    | B |",
+        "| ---- | - |",
+        "| word | y |",
+      })
+      place_cursor_at(3, "word")
+
+      local state = cell_editor.open()
+      vim.api.nvim_buf_set_lines(state.scratch_buf, 0, -1, false, { "line one", "line two", "line three" })
+
+      assert.is_true(state.save())
+
+      -- Parse the resulting table; cells[2][1] must now contain the joined content
+      local table_info = parser.get_table_at_cursor()
+      assert.is_not_nil(table_info)
+      assert.equals("line one<br>line two<br>line three", table_info.cells[2][1])
+    end)
+
+    it("uses the configured wrap_break token when joining lines", function()
+      markdown_plus.setup({ table = { wrap_break = "<br/>" } })
+      reset_to({
+        "| H    | B |",
+        "| ---- | - |",
+        "| word | y |",
+      })
+      place_cursor_at(3, "word")
+
+      local state = cell_editor.open()
+      vim.api.nvim_buf_set_lines(state.scratch_buf, 0, -1, false, { "first", "second" })
+      assert.is_true(state.save())
+
+      local table_info = parser.get_table_at_cursor()
+      assert.equals("first<br/>second", table_info.cells[2][1])
+    end)
+
+    it("collapses an empty scratch buffer to an empty cell", function()
+      reset_to({
+        "| H        | B |",
+        "| -------- | - |",
+        "| original | y |",
+      })
+      place_cursor_at(3, "original")
+
+      local state = cell_editor.open()
+      vim.api.nvim_buf_set_lines(state.scratch_buf, 0, -1, false, {})
+      assert.is_true(state.save())
+
+      local table_info = parser.get_table_at_cursor()
+      assert.equals("", table_info.cells[2][1])
+    end)
+
+    it("closes the popup after saving", function()
+      reset_to({
+        "| H | B |",
+        "| - | - |",
+        "| a | b |",
+      })
+      place_cursor_at(3, "a")
+
+      local state = cell_editor.open()
+      local win = state.scratch_win
+      state.save()
+      assert.is_false(vim.api.nvim_win_is_valid(win))
+    end)
+
+    it("places the cursor back at the same logical cell even after widths change", function()
+      reset_to({
+        "| Short | B |",
+        "| ----- | - |",
+        "| a     | y |",
+      })
+      place_cursor_at(3, "a")
+
+      local state = cell_editor.open()
+      local edit_pos = state.pos
+      -- Write content longer than the original so column 1 grows
+      vim.api.nvim_buf_set_lines(
+        state.scratch_buf,
+        0,
+        -1,
+        false,
+        { "this is a much longer cell content", "spanning two lines" }
+      )
+      assert.is_true(state.save())
+
+      -- After save+reformat the cursor must be inside column 1 of the data row
+      local updated = parser.get_table_at_cursor()
+      assert.is_not_nil(updated)
+      local pos_after = parser.get_cursor_position_in_table()
+      assert.is_not_nil(pos_after)
+      assert.equals(edit_pos.row, pos_after.row)
+      assert.equals(edit_pos.col, pos_after.col)
+    end)
+
+    it("can be undone in a single u step", function()
+      reset_to({
+        "| H        | B |",
+        "| -------- | - |",
+        "| original | y |",
+      })
+      place_cursor_at(3, "original")
+
+      local before = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+
+      local state = cell_editor.open()
+      vim.api.nvim_buf_set_lines(state.scratch_buf, 0, -1, false, { "new content with multiple", "lines now" })
+      assert.is_true(state.save())
+
+      local after_save = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+      assert.are_not.same(before, after_save)
+
+      vim.cmd("undo")
+      local after_undo = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+      assert.are.same(before, after_undo)
+    end)
+  end)
+
+  describe("cancel", function()
+    it("closes the popup without modifying the source buffer", function()
+      reset_to({
+        "| H        | B |",
+        "| -------- | - |",
+        "| original | y |",
+      })
+      place_cursor_at(3, "original")
+
+      local before = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+
+      local state = cell_editor.open()
+      vim.api.nvim_buf_set_lines(state.scratch_buf, 0, -1, false, { "discarded", "edits" })
+      local win = state.scratch_win
+      assert.is_true(state.cancel())
+
+      assert.is_false(vim.api.nvim_win_is_valid(win))
+      assert.are.same(before, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+    end)
+  end)
+
+  describe("save guards against buffer drift", function()
+    it("refuses to save when the original window has switched to a different buffer", function()
+      reset_to({
+        "| H        | B |",
+        "| -------- | - |",
+        "| original | y |",
+      })
+      place_cursor_at(3, "original")
+
+      local orig_buf = vim.api.nvim_get_current_buf()
+      local orig_lines = vim.api.nvim_buf_get_lines(orig_buf, 0, -1, false)
+
+      local state = cell_editor.open()
+      vim.api.nvim_buf_set_lines(state.scratch_buf, 0, -1, false, { "edits", "from", "popup" })
+
+      -- Simulate the user (or another autocmd) swapping the original window's buffer.
+      local other_buf = vim.api.nvim_create_buf(true, false)
+      vim.api.nvim_buf_set_lines(other_buf, 0, -1, false, { "unrelated content" })
+      vim.api.nvim_win_set_buf(state.orig_win, other_buf)
+
+      assert.is_false(state.save())
+
+      -- The original buffer is unchanged
+      assert.are.same(orig_lines, vim.api.nvim_buf_get_lines(orig_buf, 0, -1, false))
+      -- The other buffer is unchanged
+      assert.are.same({ "unrelated content" }, vim.api.nvim_buf_get_lines(other_buf, 0, -1, false))
+      -- Popup was closed by the guard
+      assert.is_true(state.closed)
+
+      pcall(vim.api.nvim_buf_delete, other_buf, { force = true })
+    end)
+
+    it("refuses to save when the original buffer was deleted", function()
+      reset_to({
+        "| H        | B |",
+        "| -------- | - |",
+        "| original | y |",
+      })
+      place_cursor_at(3, "original")
+
+      local orig_buf = vim.api.nvim_get_current_buf()
+      local state = cell_editor.open()
+      vim.api.nvim_buf_set_lines(state.scratch_buf, 0, -1, false, { "edits" })
+
+      -- Replace the buffer in the window with a new scratch (so we can delete orig_buf),
+      -- then nuke orig_buf entirely.
+      local placeholder = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_win_set_buf(state.orig_win, placeholder)
+      pcall(vim.api.nvim_buf_delete, orig_buf, { force = true })
+
+      assert.is_false(state.save())
+      assert.is_true(state.closed)
+    end)
+  end)
+end)


### PR DESCRIPTION
Closes #327. Phase 3 of the [multi-line table cell Epic (#324)](https://github.com/YousefHadder/markdown-plus.nvim/issues/324).

Brings Org-mode's `C-c '` workflow to markdown tables: open a single cell in a floating popup, edit with real newlines, save back to the cell joined with `<br>`.

## What this adds

- New module `lua/markdown-plus/table/cell_editor.lua` providing `M.open()` — opens a centred floating popup backed by a scratch markdown buffer, populated from the current cell split on `<br>`.
- New `<Plug>(MarkdownPlusTableEditCell)` mapping → `<localleader>te` by default.
- New config block:
  ```lua
  table.cell_editor = {
    enabled = true,
    border = "rounded",
    width = 0.6,    -- fraction of editor width, (0, 1]
    height = 0.4,   -- fraction of editor height, (0, 1]
  }
  ```

## Interaction

Inside the popup:

| Key / command | Action |
|---------------|--------|
| `<CR>` (normal mode) | Save and close |
| `:w` | Save and close (via `BufWriteCmd` autocmd) |
| `q` | Cancel — discard edits |
| `<Esc><Esc>` | Cancel — discard edits |

On save:
1. Lines in the scratch buffer are joined with the configured `wrap_break` (default `<br>`).
2. Focus switches to the original window.
3. The cell is mutated in `table_info.cells` and `format.format_table` is called — a single `nvim_buf_set_lines` write, so **one `u` reverts everything**.
4. The table is re-parsed and the cursor is restored to the **same logical (row, col)** via `navigation.move_to_cell`, not the original byte column (widths can shift after the edit).

Guards:
- Separator row → notify `Cannot edit separator row`, no popup.
- Not in a table → notify `Not in a table`, no popup.
- `cell_editor.enabled = false` → notify `Cell editor is disabled`, no popup.

## Why it's non-breaking

- No existing keymap collides with `<localleader>te` (verified against `keymaps.lua`).
- `keymap_helper` defers to any pre-existing buffer-local mapping on `<localleader>te`.
- `cell_editor.enabled` defaults to `true`, but nothing happens until the user actually invokes the command. No autocmds attach to the source buffer.
- Geometry/border validation happens via the schema and only on `setup()`; invalid inputs are rejected with a notify and the previous config is preserved.

## Tests

12 new cases in `spec/markdown-plus/table_cell_editor_spec.lua`:

- **open:** populates scratch from `<br>` segments; single-line for break-free cells; nil for not-in-table; rejects separator row; respects `enabled = false`.
- **save:** joins lines with `<br>`; uses configured `wrap_break`; empty scratch buffer → empty cell; closes popup after save; **places cursor at the same logical cell even after widths grow**; **one `u` reverts the whole save**.
- **cancel:** closes popup, source buffer unchanged.

`make check` green. 212 → 224 tests.

## Files changed

| File | Change |
|------|-------|
| `lua/markdown-plus/table/cell_editor.lua` | new (214 lines) |
| `spec/markdown-plus/table_cell_editor_spec.lua` | new (12 tests) |
| `lua/markdown-plus/table/init.lua` | `M.edit_cell()` wrapper |
| `lua/markdown-plus/table/keymaps.lua` | new `<Plug>` entry |
| `lua/markdown-plus/types.lua` | `TableCellEditorConfig` + internal type |
| `lua/markdown-plus/init.lua`, `lua/markdown-plus/table/init.lua` | defaults |
| `lua/markdown-plus/config/validate.lua` | schema with width/height range validation |
| `doc/markdown-plus.txt` | keymap reference + config example |

## Design notes

- **No `manipulation.lua` facade for `edit_cell`.** `manipulation.lua` re-exports primitive cell ops (clear, toggle alignment, insert/wrap/unwrap break). The popup is a UI subsystem, not a primitive — `M.open()` returns a session object with `save`/`cancel` callbacks. Going through manipulation would muddy that boundary.
- **Single-undo behaviour comes for free.** `format.format_table` performs exactly one `nvim_buf_set_lines` on the source buffer. The save flow only mutates the source through that one call, so undo works atomically without any explicit `undojoin`.
- **`:w` is intercepted via `BufWriteCmd` autocmd** with `buftype = "acwrite"`. This lets the user save the same way they'd save any buffer; the autocmd never lets Vim actually try to write a file.
- **Popup buffer uses `filetype = "markdown"`.** Intentional — the full plugin toolkit (lists, format, etc.) is usable inside the popup while editing.

## Out of scope (later phases)

- Virtual-line preview (`<localleader>tV`) → #328
- Opt-in auto-wrap on format → #329
