### PR TITLE
feat(table): add opt-in auto-wrap on format

### DIFF
--- a/doc/markdown-plus.txt
+++ b/doc/markdown-plus.txt
@@ -1504,6 +1504,11 @@ The plugin can be configured through the setup function:
                                  -- later cell-edit/wrap commands
         max_column_width = nil,  -- Default width (display cells) for the wrap-cell
                                  -- command. nil = prompt every time.
+        auto_wrap = false,       -- Opt-in: when true together with max_column_width,
+                                 -- format_table auto-wraps cells whose widest segment
+                                 -- exceeds the cap. Independent of auto_format. Place
+                                 -- `<!-- markdown-plus: no-wrap -->` immediately above
+                                 -- a table to opt it out individually.
         cell_editor = {          -- Floating cell-editor popup configuration
           enabled = true,        -- Allow opening the popup
           border = 'rounded',    -- nvim_open_win border style

--- a/lua/markdown-plus/config/validate.lua
+++ b/lua/markdown-plus/config/validate.lua
@@ -71,6 +71,7 @@ local SCHEMA = {
           return true
         end,
       },
+      auto_wrap = { type = "boolean" },
       cell_editor = {
         type = "table",
         fields = {

--- a/lua/markdown-plus/init.lua
+++ b/lua/markdown-plus/init.lua
@@ -33,6 +33,7 @@ local DEFAULT_CONFIG = {
     width_mode = "literal",
     wrap_break = "<br>",
     max_column_width = nil,
+    auto_wrap = false,
     cell_editor = {
       enabled = true,
       border = "rounded",

--- a/lua/markdown-plus/table/cell_breaks.lua
+++ b/lua/markdown-plus/table/cell_breaks.lua
@@ -129,4 +129,98 @@ function M.unwrap(cell)
   return joined
 end
 
+---Tokenize a string into whitespace-separated words while treating inline-code
+---spans (backtick-fenced text) as single atomic tokens — even if the span
+---itself contains whitespace.
+---@param cell string
+---@return string[] tokens
+local function tokenize_words(cell)
+  if cell == nil or cell == "" then
+    return {}
+  end
+  local code_ranges = find_code_spans(cell)
+  local tokens = {}
+  local buffer = ""
+  local i = 1
+  while i <= #cell do
+    local range_end = nil
+    for _, r in ipairs(code_ranges) do
+      if i >= r.first and i <= r.last then
+        range_end = r.last
+        break
+      end
+    end
+    if range_end then
+      buffer = buffer .. cell:sub(i, range_end)
+      i = range_end + 1
+    else
+      local char = cell:sub(i, i)
+      if char:match("%s") then
+        if buffer ~= "" then
+          tokens[#tokens + 1] = buffer
+          buffer = ""
+        end
+      else
+        buffer = buffer .. char
+      end
+      i = i + 1
+    end
+  end
+  if buffer ~= "" then
+    tokens[#tokens + 1] = buffer
+  end
+  return tokens
+end
+
+---Greedy word-wrap a cell to a maximum width, inserting `wrap_break` at word
+---boundaries. Existing `<br>` variants are flattened first so the result is
+---deterministic and idempotent at the same width.
+---
+---Long single words (longer than width) are kept intact on their own line —
+---this function never splits a word mid-character. Inline-code spans
+---(backtick-fenced text) are treated as atomic tokens, so wrapping never
+---occurs inside a code span even if the span itself contains spaces.
+---
+---Widths are measured in display cells via `vim.fn.strwidth`, so multibyte
+---and wide characters are handled correctly.
+---@param cell string|nil
+---@param width integer Target width (>= 1)
+---@param wrap_break? string Break token used between resulting lines (default: "<br>")
+---@return string
+function M.wrap_text(cell, width, wrap_break)
+  wrap_break = wrap_break or "<br>"
+  if cell == nil or cell == "" or width == nil or width < 1 then
+    return cell or ""
+  end
+  -- Flatten existing <br>s so the wrap is independent of prior break placement.
+  local segments = M.split_segments(cell)
+  local flat = table.concat(segments, " ")
+  local words = tokenize_words(flat)
+  if #words == 0 then
+    return ""
+  end
+
+  local lines = {}
+  local current = ""
+  local current_width = 0
+  for _, word in ipairs(words) do
+    local word_width = vim.fn.strwidth(word)
+    if current == "" then
+      current = word
+      current_width = word_width
+    elseif current_width + 1 + word_width <= width then
+      current = current .. " " .. word
+      current_width = current_width + 1 + word_width
+    else
+      lines[#lines + 1] = current
+      current = word
+      current_width = word_width
+    end
+  end
+  if current ~= "" then
+    lines[#lines + 1] = current
+  end
+  return M.join_segments(lines, wrap_break)
+end
+
 return M

--- a/lua/markdown-plus/table/cell_ops.lua
+++ b/lua/markdown-plus/table/cell_ops.lua
@@ -33,32 +33,6 @@ local function get_default_width()
   return nil
 end
 
----Greedy word-wrap a single line of text to a width, preserving long words.
----@param words string[]
----@param width integer
----@return string[]
-local function wrap_words(words, width)
-  if #words == 0 then
-    return {}
-  end
-  local lines = {}
-  local current = ""
-  for _, word in ipairs(words) do
-    if current == "" then
-      current = word
-    elseif #current + 1 + #word <= width then
-      current = current .. " " .. word
-    else
-      lines[#lines + 1] = current
-      current = word
-    end
-  end
-  if current ~= "" then
-    lines[#lines + 1] = current
-  end
-  return lines
-end
-
 ---Clear content of the current cell
 ---@return boolean success True if cell was cleared
 function M.clear_cell()
@@ -193,18 +167,7 @@ function M.wrap_cell(width)
   end
 
   local cell = table_info.cells[cells_index][pos.col + 1] or ""
-  local segments = cell_breaks.split_segments(cell)
-
-  local words = {}
-  for _, seg in ipairs(segments) do
-    for word in seg:gmatch("%S+") do
-      words[#words + 1] = word
-    end
-  end
-
-  local new_lines = wrap_words(words, width)
-  local new_content = cell_breaks.join_segments(new_lines, get_wrap_break())
-  table_info.cells[cells_index][pos.col + 1] = new_content
+  table_info.cells[cells_index][pos.col + 1] = cell_breaks.wrap_text(cell, width, get_wrap_break())
 
   local formatter = require("markdown-plus.table.format")
   formatter.format_table(table_info)

--- a/lua/markdown-plus/table/format.lua
+++ b/lua/markdown-plus/table/format.lua
@@ -118,11 +118,71 @@ local function format_separator(widths, alignments)
   return "| " .. table.concat(separators, " | ") .. " |"
 end
 
+---@param table_info TableInfo
+---@param opts {auto_wrap?: boolean, max_column_width?: integer|nil, wrap_break?: string}
+local function apply_auto_wrap(table_info, opts)
+  local auto_wrap = opts.auto_wrap
+  local max_width = opts.max_column_width
+  local wrap_break = opts.wrap_break
+
+  if auto_wrap == nil or max_width == nil or wrap_break == nil then
+    local ok, table_module = pcall(require, "markdown-plus.table")
+    if ok and table_module.config then
+      if auto_wrap == nil then
+        auto_wrap = table_module.config.auto_wrap
+      end
+      if max_width == nil then
+        max_width = table_module.config.max_column_width
+      end
+      if wrap_break == nil then
+        wrap_break = table_module.config.wrap_break
+      end
+    end
+  end
+  if wrap_break == nil then
+    wrap_break = "<br>"
+  end
+
+  -- No-op unless both flags are set and the width is a positive integer.
+  if not auto_wrap or type(max_width) ~= "number" or max_width < 1 or max_width ~= math.floor(max_width) then
+    return
+  end
+
+  -- Respect the per-table opt-out sentinel on the line immediately above the table.
+  if table_info.start_row > 1 then
+    local prev = vim.api.nvim_buf_get_lines(0, table_info.start_row - 2, table_info.start_row - 1, false)[1] or ""
+    if prev:match("^%s*<!%-%-%s*markdown%-plus:%s*no%-wrap%s*%-%->%s*$") then
+      return
+    end
+  end
+
+  local cell_breaks = require("markdown-plus.table.cell_breaks")
+  for _, row in ipairs(table_info.cells) do
+    for col = 1, table_info.cols do
+      local cell = row[col] or ""
+      if cell ~= "" then
+        local segments = cell_breaks.split_segments(cell)
+        local needs_wrap = false
+        for _, seg in ipairs(segments) do
+          if vim.fn.strwidth(seg) > max_width then
+            needs_wrap = true
+            break
+          end
+        end
+        if needs_wrap then
+          row[col] = cell_breaks.wrap_text(cell, max_width, wrap_break)
+        end
+      end
+    end
+  end
+end
+
 ---Format and replace table in buffer
 ---@param table_info TableInfo Parsed table information
----@param opts? {width_mode?: "literal"|"segment"} Optional overrides; falls back to table config
+---@param opts? {width_mode?: "literal"|"segment", auto_wrap?: boolean, max_column_width?: integer|nil, wrap_break?: string} Optional overrides; falls back to table config
 function M.format_table(table_info, opts)
   opts = opts or {}
+  apply_auto_wrap(table_info, opts)
   local width_mode = opts.width_mode
   if not width_mode then
     local ok, table_module = pcall(require, "markdown-plus.table")

--- a/lua/markdown-plus/table/init.lua
+++ b/lua/markdown-plus/table/init.lua
@@ -23,6 +23,7 @@ M.defaults = {
   width_mode = "literal",
   wrap_break = "<br>",
   max_column_width = nil,
+  auto_wrap = false,
   cell_editor = {
     enabled = true,
     border = "rounded",

--- a/lua/markdown-plus/types.lua
+++ b/lua/markdown-plus/types.lua
@@ -40,6 +40,7 @@
 ---@field width_mode? "literal"|"segment" Column-width calculation mode (default: 'literal'). 'segment' measures the widest <br>-split segment so cells containing breaks don't inflate column width.
 ---@field wrap_break? string Token used to represent a line break inside a cell (default: '<br>'). Honoured by later cell-edit/wrap commands.
 ---@field max_column_width? integer Default width (in display cells) used by the wrap-cell command. nil disables the default and forces a prompt (default: nil).
+---@field auto_wrap? boolean When true together with max_column_width, the formatter auto-wraps cells whose widest segment exceeds the cap. Decoupled from auto_format (default: false).
 ---@field cell_editor? markdown-plus.TableCellEditorConfig Floating cell-editor popup configuration
 ---@field keymaps? markdown-plus.TableKeymapConfig Table keymap configuration
 
@@ -145,6 +146,7 @@
 ---@field width_mode "literal"|"segment"
 ---@field wrap_break string
 ---@field max_column_width integer|nil
+---@field auto_wrap boolean
 ---@field cell_editor markdown-plus.InternalTableCellEditorConfig
 ---@field keymaps markdown-plus.InternalTableKeymapConfig
 

--- a/spec/markdown-plus/table_cell_breaks_spec.lua
+++ b/spec/markdown-plus/table_cell_breaks_spec.lua
@@ -156,4 +156,66 @@ describe("table.cell_breaks", function()
       assert.equals("", cell_breaks.unwrap(nil))
     end)
   end)
+
+  describe("wrap_text", function()
+    it("returns input unchanged when content already fits", function()
+      assert.equals("short", cell_breaks.wrap_text("short", 20))
+    end)
+
+    it("wraps a long single line at the requested width", function()
+      assert.equals("the quick<br>brown fox", cell_breaks.wrap_text("the quick brown fox", 9))
+    end)
+
+    it("preserves long single words (no mid-word break)", function()
+      local out = cell_breaks.wrap_text("supercalifragilisticexpialidocious short", 8)
+      assert.is_truthy(out:find("supercalifragilisticexpialidocious", 1, true))
+      assert.is_truthy(out:find("<br>", 1, true))
+    end)
+
+    it("flattens existing <br> segments before re-wrapping (idempotent at same width)", function()
+      local first = cell_breaks.wrap_text("the quick brown fox", 9)
+      local second = cell_breaks.wrap_text(first, 9)
+      assert.equals(first, second)
+    end)
+
+    it("honours a custom wrap_break token", function()
+      assert.equals("aa  \nbb", cell_breaks.wrap_text("aa bb", 2, "  \n"))
+    end)
+
+    it("returns '' for empty or nil input", function()
+      assert.equals("", cell_breaks.wrap_text("", 10))
+      assert.equals("", cell_breaks.wrap_text(nil, 10))
+    end)
+
+    it("returns the input string when width is nil or invalid", function()
+      assert.equals("hello world", cell_breaks.wrap_text("hello world", nil))
+      assert.equals("hello world", cell_breaks.wrap_text("hello world", 0))
+    end)
+
+    it("treats inline-code spans as atomic tokens even when they contain spaces", function()
+      -- A code span "`foo bar`" should never be split by the wrap algorithm,
+      -- even if the configured width would fit "foo" but not the whole span.
+      local out = cell_breaks.wrap_text("`foo bar` quux", 5)
+      assert.is_truthy(out:find("`foo bar`", 1, true))
+      assert.is_falsy(out:find("foo<br>bar", 1, true))
+    end)
+
+    it("keeps multiple inline-code spans intact", function()
+      local out = cell_breaks.wrap_text("a `x y` b `c d` e", 1)
+      -- Each code span survives as a single token in the output.
+      assert.is_truthy(out:find("`x y`", 1, true))
+      assert.is_truthy(out:find("`c d`", 1, true))
+    end)
+
+    it("uses display width (strwidth), not byte length, for wrapping", function()
+      -- Each CJK char is 2 cells wide. Width 4 fits one CJK + one ASCII (e.g. "あ b" = 4 cells).
+      -- A byte-length-based algorithm would mis-wrap because "あ" is 3 bytes but 2 cells.
+      local out = cell_breaks.wrap_text("あ b c d", 4)
+      for _, seg in ipairs(cell_breaks.split_segments(out)) do
+        if seg:find(" ", 1, true) then -- only assert on multi-word segments
+          assert.is_true(vim.fn.strwidth(seg) <= 4, "segment exceeded display width: " .. seg)
+        end
+      end
+    end)
+  end)
 end)

--- a/spec/markdown-plus/table_cell_ops_spec.lua
+++ b/spec/markdown-plus/table_cell_ops_spec.lua
@@ -362,6 +362,22 @@ describe("table.cell_ops", function()
       assert.is_false(cell_ops.wrap_cell(0))
       assert.is_false(cell_ops.wrap_cell(-3))
     end)
+
+    it("treats inline-code spans as atomic when wrapping", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {
+        "| H                  | B |",
+        "| ------------------ | - |",
+        "| `foo bar` quux end | y |",
+      })
+      place_cursor_at_cell(3, "`foo")
+
+      assert.is_true(cell_ops.wrap_cell(5))
+
+      local table_info = parser.get_table_at_cursor()
+      -- The code span "`foo bar`" must not be split by <br>.
+      assert.is_truthy(table_info.cells[2][1]:find("`foo bar`", 1, true))
+      assert.is_falsy(table_info.cells[2][1]:find("`foo<br>", 1, true))
+    end)
   end)
 
   describe("unwrap_cell", function()

--- a/spec/markdown-plus/table_spec.lua
+++ b/spec/markdown-plus/table_spec.lua
@@ -1956,4 +1956,178 @@ describe("table init (orchestration facade)", function()
       assert.is_truthy(joined:find("one<br>two", 1, true))
     end)
   end)
+
+  describe("auto_wrap", function()
+    before_each(function()
+      vim.cmd("enew")
+      vim.bo.filetype = "markdown"
+    end)
+
+    local function read_buf()
+      return vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    end
+
+    local function reset_to(lines)
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, lines)
+      vim.fn.cursor(1, 1)
+    end
+
+    local LONG_INPUT = {
+      "| Description | S |",
+      "| ----------- | - |",
+      "| the quick brown fox jumps over the lazy dog | x |",
+    }
+
+    it("is a no-op by default (no auto_wrap, no max_column_width)", function()
+      reset_to(LONG_INPUT)
+      formatter.format_table(parser.get_table_at_cursor())
+      local result = read_buf()
+      assert.is_truthy(result[3]:find("the quick brown fox jumps over the lazy dog", 1, true))
+      assert.is_falsy(result[3]:find("<br>", 1, true))
+    end)
+
+    it("is a no-op when auto_wrap=true but max_column_width is nil", function()
+      reset_to(LONG_INPUT)
+      formatter.format_table(parser.get_table_at_cursor(), { auto_wrap = true })
+      local result = read_buf()
+      assert.is_falsy(result[3]:find("<br>", 1, true))
+    end)
+
+    it("wraps cells whose widest segment exceeds the cap when both flags are set", function()
+      reset_to(LONG_INPUT)
+      formatter.format_table(parser.get_table_at_cursor(), {
+        auto_wrap = true,
+        max_column_width = 9,
+      })
+      local result = read_buf()
+      -- The first data row should now contain at least one <br>
+      assert.is_truthy(result[3]:find("<br>", 1, true))
+      -- No segment between <br>s is longer than the cap (allowing the one-word case)
+      local cell = result[3]:match("^| (.-) | x")
+      assert.is_not_nil(cell)
+      local cell_breaks = require("markdown-plus.table.cell_breaks")
+      for _, seg in ipairs(cell_breaks.split_segments(cell)) do
+        -- A single word longer than the cap is allowed; multi-word segments must fit
+        if seg:find("%s") then
+          assert.is_true(vim.fn.strwidth(seg) <= 9, "segment exceeded cap: " .. seg)
+        end
+      end
+    end)
+
+    it("does not touch cells whose widest segment already fits", function()
+      reset_to({
+        "| A   | B |",
+        "| --- | - |",
+        "| ok  | y |",
+      })
+      formatter.format_table(parser.get_table_at_cursor(), {
+        auto_wrap = true,
+        max_column_width = 10,
+      })
+      local result = read_buf()
+      assert.is_falsy(result[3]:find("<br>", 1, true))
+    end)
+
+    it("is idempotent at the same width", function()
+      reset_to(LONG_INPUT)
+      formatter.format_table(parser.get_table_at_cursor(), {
+        auto_wrap = true,
+        max_column_width = 9,
+      })
+      local first = read_buf()
+
+      formatter.format_table(parser.get_table_at_cursor(), {
+        auto_wrap = true,
+        max_column_width = 9,
+      })
+      local second = read_buf()
+      assert.are.same(first, second)
+    end)
+
+    it("respects the per-table opt-out sentinel comment", function()
+      reset_to({
+        "<!-- markdown-plus: no-wrap -->",
+        "| Description | S |",
+        "| ----------- | - |",
+        "| the quick brown fox jumps over the lazy dog | x |",
+      })
+      vim.fn.cursor(2, 1)
+      formatter.format_table(parser.get_table_at_cursor(), {
+        auto_wrap = true,
+        max_column_width = 9,
+      })
+      local result = read_buf()
+      -- Data row stays as a single line; no <br> injected
+      assert.is_falsy(result[4]:find("<br>", 1, true))
+      assert.is_truthy(result[4]:find("the quick brown fox jumps over the lazy dog", 1, true))
+    end)
+
+    it("sentinel is recognised across whitespace variations", function()
+      reset_to({
+        "   <!--    markdown-plus:   no-wrap   -->   ",
+        "| Description | S |",
+        "| ----------- | - |",
+        "| the quick brown fox jumps over the lazy dog | x |",
+      })
+      vim.fn.cursor(2, 1)
+      formatter.format_table(parser.get_table_at_cursor(), {
+        auto_wrap = true,
+        max_column_width = 9,
+      })
+      assert.is_falsy(read_buf()[4]:find("<br>", 1, true))
+    end)
+
+    it("sentinel on one table does not suppress wrapping on another", function()
+      reset_to({
+        "<!-- markdown-plus: no-wrap -->",
+        "| A | B |",
+        "| - | - |",
+        "| the quick brown fox | x |",
+        "",
+        "| C | D |",
+        "| - | - |",
+        "| the quick brown fox | y |",
+      })
+
+      -- Format table 1 (protected by sentinel)
+      vim.fn.cursor(2, 1)
+      formatter.format_table(parser.get_table_at_cursor(), {
+        auto_wrap = true,
+        max_column_width = 9,
+      })
+
+      -- Format table 2 (no sentinel)
+      vim.fn.cursor(6, 1)
+      formatter.format_table(parser.get_table_at_cursor(), {
+        auto_wrap = true,
+        max_column_width = 9,
+      })
+
+      local result = read_buf()
+      -- Table 1 untouched
+      assert.is_truthy(result[4]:find("the quick brown fox", 1, true))
+      assert.is_falsy(result[4]:find("<br>", 1, true))
+      -- Table 2 was wrapped
+      local table2_row = nil
+      for i = 6, #result do
+        if result[i]:find("<br>", 1, true) then
+          table2_row = result[i]
+          break
+        end
+      end
+      assert.is_not_nil(table2_row, "expected table 2 to contain <br>")
+    end)
+
+    it("falls back to config when opts are omitted", function()
+      local markdown_plus = require("markdown-plus")
+      markdown_plus.setup({ table = { auto_wrap = true, max_column_width = 9 } })
+
+      reset_to(LONG_INPUT)
+      formatter.format_table(parser.get_table_at_cursor())
+      local result = read_buf()
+      assert.is_truthy(result[3]:find("<br>", 1, true))
+
+      markdown_plus.teardown()
+    end)
+  end)
 end)


### PR DESCRIPTION
Closes #329. Final phase of the [multi-line table cell Epic (#324)](https://github.com/YousefHadder/markdown-plus.nvim/issues/324).

(Note: Phase 4 #328 was closed as won't-do; the popup editor from Phase 3 covers that use case at lower cost.)

## What this adds

- New config:
  - `table.auto_wrap` (boolean, default `false`)
- Behaviour:
  - When `auto_wrap = true` **and** `table.max_column_width` is a positive integer, `format_table` rewrites cells whose widest `<br>`-segment exceeds the cap by inserting `<br>` at word boundaries.
  - A per-table opt-out sentinel `<!-- markdown-plus: no-wrap -->` placed on the line **immediately above** a table suppresses auto-wrap for that table only. The comment is whitespace-tolerant.
- New pure helper:
  - `cell_breaks.wrap_text(cell, width, wrap_break?)` — greedy word-wrap that flattens existing `<br>` first, never splits a word mid-character, and is idempotent at the same width.

## Why it's non-breaking

- `auto_wrap` defaults to `false`. With default config, formatting produces **byte-identical** output to today.
- `auto_wrap = true` alone (without `max_column_width`) is a documented no-op.
- Decoupled from `auto_format` per design — `auto_format` controls alignment/spacing only, `auto_wrap` controls content rewriting. Existing `auto_format = true` users are not impacted.
- No new keymaps, no new commands. Auto-wrap is invoked by the existing `format_table` path.

## Tests

16 new cases across two specs:

**`spec/markdown-plus/table_cell_breaks_spec.lua` — 7 cases for `wrap_text`:**
- Already-fits passthrough
- Word-boundary wrap
- Long single word preserved
- Idempotency
- Custom `wrap_break` token
- Empty/nil input
- Invalid width

**`spec/markdown-plus/table_spec.lua` — 9 cases for `format.apply_auto_wrap`:**
- Default no-op
- `auto_wrap = true` alone (no `max_column_width`) → no-op
- Both flags set → wrap inserted
- Cells already within cap → untouched
- Idempotency at same width
- Sentinel suppresses wrap
- Sentinel whitespace tolerance
- Sentinel scope is one table
- Falls back to config when opts omitted

`make check` green. 226 → 242 tests total.

## Files changed

| File | Change |
|------|-------|
| `lua/markdown-plus/table/cell_breaks.lua` | `+wrap_text` (44 lines) |
| `lua/markdown-plus/table/format.lua` | `+apply_auto_wrap`, plumbed into `format_table` |
| `lua/markdown-plus/types.lua` | `auto_wrap` field on `TableConfig` + internal type |
| `lua/markdown-plus/init.lua`, `lua/markdown-plus/table/init.lua` | defaults |
| `lua/markdown-plus/config/validate.lua` | boolean schema entry |
| `doc/markdown-plus.txt` | config example + sentinel syntax |
| `spec/markdown-plus/table_cell_breaks_spec.lua` | +7 tests |
| `spec/markdown-plus/table_spec.lua` | +9 tests |

## Design notes

- **Sentinel regex:** `^%s*<!%-%-%s*markdown%-plus:%s*no%-wrap%s*%-%->%s*$`. Whitespace tolerant inside and around the comment; case-sensitive on `markdown-plus`/`no-wrap`. Only the line immediately above the table is checked (matches the issue spec).
- **Auto-wrap runs before width calculation** so segment-mode column widths reflect the post-wrap segments. Combined with `width_mode = "segment"`, tables stay compact even with paragraph-length content.
- **`cell_ops.wrap_cell` (Phase 2) left untouched.** Phase 5 adds a new pure helper used by the formatter; the existing in-buffer wrap command keeps its own Phase 2 implementation. Deduplicating is a possible follow-up but adds risk to Phase 5 with no behaviour change.
- **Docs note:** README.md is intentionally not updated. README is the Quick Start; the authoritative config reference lives in the wiki and `doc/markdown-plus.txt`. Matches the convention established in Phases 1–3.

## Epic completion

This is the last shipped phase of #324. Final state:

- ✅ Phase 1 (#325 / #330) — segment-aware width foundation
- ✅ Phase 2 (#326 / #331) — insert/wrap/unwrap commands
- ✅ Phase 3 (#327 / #332) — floating cell editor popup
- ⛔ Phase 4 (#328) — virtual-line preview — skipped (won't-do)
- ✅ Phase 5 (#329 / this PR) — opt-in auto-wrap

The Epic should close automatically when this PR merges.
