### PR TITLE
feat(list): add toggle-list type picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ That's it! The plugin will automatically activate with default keymaps when you 
 - New heading toggle: `<localleader>ms` switches ATX/setext heading style (H1/H2).
 - New thematic-break commands: `<localleader>mh` (insert) and `<localleader>mH` (cycle style).
 - Smart list outdent is enabled by default (`list.smart_outdent = true`) for parent-aware marker continuation.
+- New list type toggling: `<localleader>lt` starts a picker — press it, then a type key (`u` unordered, `t` task, `n` `1.`, `N` `1)`, `l` `a.`, `L` `A.`, `p` `a)`, `P` `A)`, `c` clear) to toggle the current line or selection. Works in normal and visual mode; each type also has a `<Plug>` mapping.
 - New formatting escape toggle: `<localleader>me` (visual mode) escapes/unescapes markdown punctuation.
 - Code block module is now first-class: `<localleader>mc` insert/wrap, `]b`/`[b` navigate, `<localleader>mC` change language.
 - Formatting defaults moved to avoid key collisions: strikethrough `<localleader>mS`, inline code `<localleader>m\``, highlight `<localleader>m=`, clear formatting `<localleader>mF`.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ That's it! The plugin will automatically activate with default keymaps when you 
 - New heading toggle: `<localleader>ms` switches ATX/setext heading style (H1/H2).
 - New thematic-break commands: `<localleader>mh` (insert) and `<localleader>mH` (cycle style).
 - Smart list outdent is enabled by default (`list.smart_outdent = true`) for parent-aware marker continuation.
-- New list type toggling: `<localleader>lt` starts a picker — press it, then a type key (`u` unordered, `t` task, `n` `1.`, `N` `1)`, `l` `a.`, `L` `A.`, `p` `a)`, `P` `A)`, `c` clear) to toggle the current line or selection. Works in normal and visual mode; each type also has a `<Plug>` mapping.
+- New list type toggling: the `<localleader>lt` prefix toggles list types — press it, then a type key (`u` unordered, `t` task, `n` `1.`, `N` `1)`, `l` `a.`, `L` `A.`, `p` `a)`, `P` `A)`, `c` clear) to toggle the current line or selection. These are real nested keymaps, so which-key shows the menu after the prefix. Works in normal and visual mode; each type also has a `<Plug>` mapping. Prefer an indefinitely-waiting picker? Bind `<Plug>(MarkdownPlusToggleListPick)` to `<localleader>lt` yourself.
 - New formatting escape toggle: `<localleader>me` (visual mode) escapes/unescapes markdown punctuation.
 - Code block module is now first-class: `<localleader>mc` insert/wrap, `]b`/`[b` navigate, `<localleader>mC` change language.
 - Formatting defaults moved to avoid key collisions: strikethrough `<localleader>mS`, inline code `<localleader>m\``, highlight `<localleader>m=`, clear formatting `<localleader>mF`.

--- a/doc/markdown-plus.txt
+++ b/doc/markdown-plus.txt
@@ -342,19 +342,29 @@ Toggle the current line (normal mode) or a selection (visual mode) to a list
 type. Plain text gains a marker; a line already of the target type is cleared
 back to plain text; a line of a different type is converted.
 
-The default mapping `<localleader>lt` (normal and visual mode) starts the toggle
-picker: press it, then a single key to choose the list type:
+The default mappings live under the `<localleader>lt` prefix (normal and visual
+mode). Press the prefix, then a single key to choose the list type:
 
 >markdown
-    u   unordered          -
-    t   task               - [ ]
-    n   numbered           1.
-    N   numbered paren     1)
-    l   lowercase letter   a.
-    L   uppercase letter   A.
-    p   lowercase paren    a)
-    P   uppercase paren    A)
-    c   clear              strip list markers (force plain text)
+    <localleader>ltu   unordered          -
+    <localleader>ltt   task               - [ ]
+    <localleader>ltn   numbered           1.
+    <localleader>ltN   numbered paren     1)
+    <localleader>ltl   lowercase letter   a.
+    <localleader>ltL   uppercase letter   A.
+    <localleader>ltp   lowercase paren    a)
+    <localleader>ltP   uppercase paren    A)
+    <localleader>ltc   clear              strip list markers (force plain text)
+<
+
+Because these are real buffer-local mappings, plugins such as which-key.nvim
+discover them automatically and show the menu after you press `<localleader>lt`.
+The second key must be pressed within 'timeoutlen'.
+
+If you prefer a picker that waits indefinitely for the type key (the original
+behavior), bind the picker `<Plug>` mapping yourself: >lua
+    vim.keymap.set({ "n", "x" }, "<localleader>lt",
+      "<Plug>(MarkdownPlusToggleListPick)", { buffer = true })
 <
 
 In visual mode the decision is range-level: if every non-blank selected line
@@ -366,13 +376,13 @@ Conversions preserve a checkbox when moving to an ordered or task type and drop
 it when moving to a plain unordered list:
 
 >markdown
-    write README          <localleader>lt t  →  - [ ] write README
-    1. [x] ship           <localleader>lt u  →  - ship
-    - [x] ship            <localleader>lt n  →  1. [x] ship
+    write README          <localleader>ltt  →  - [ ] write README
+    1. [x] ship           <localleader>ltu  →  - ship
+    - [x] ship            <localleader>ltn  →  1. [x] ship
 <
 
-Each type also has a direct `<Plug>` mapping if you prefer a dedicated key per
-type instead of the picker; see |markdown-plus-keymaps|.
+Each type also has a direct `<Plug>` mapping if you prefer your own dedicated
+key per type; see |markdown-plus-keymaps|.
 
 CHECKBOX TOGGLING ~
 
@@ -1782,14 +1792,15 @@ LIST MANAGEMENT ~
     <Plug>(MarkdownPlusNewListItemAbove)   - New item above (n)
     <Plug>(MarkdownPlusToggleCheckbox)     - Toggle checkbox (n, x, i)
     <Plug>(MarkdownPlusToggleListPick)     - Toggle list, pick type with next key (n, x)
-    <Plug>(MarkdownPlusToggleListUnordered) - Toggle unordered list (n, x)
-    <Plug>(MarkdownPlusToggleListOrdered)  - Toggle ordered list (n, x)
-    <Plug>(MarkdownPlusToggleListTask)     - Toggle task list (n, x)
-    <Plug>(MarkdownPlusToggleListOrderedParen) - Toggle parenthesized ordered list (n, x)
-    <Plug>(MarkdownPlusToggleListLetterLower) - Toggle lowercase letter list (n, x)
-    <Plug>(MarkdownPlusToggleListLetterUpper) - Toggle uppercase letter list (n, x)
-    <Plug>(MarkdownPlusToggleListLetterLowerParen) - Toggle parenthesized lowercase letter list (n, x)
-    <Plug>(MarkdownPlusToggleListLetterUpperParen) - Toggle parenthesized uppercase letter list (n, x)
+    <Plug>(MarkdownPlusToggleListUnordered) - Toggle unordered list (n, x) [<localleader>ltu]
+    <Plug>(MarkdownPlusToggleListOrdered)  - Toggle ordered list (n, x) [<localleader>ltn]
+    <Plug>(MarkdownPlusToggleListTask)     - Toggle task list (n, x) [<localleader>ltt]
+    <Plug>(MarkdownPlusToggleListOrderedParen) - Toggle parenthesized ordered list (n, x) [<localleader>ltN]
+    <Plug>(MarkdownPlusToggleListLetterLower) - Toggle lowercase letter list (n, x) [<localleader>ltl]
+    <Plug>(MarkdownPlusToggleListLetterUpper) - Toggle uppercase letter list (n, x) [<localleader>ltL]
+    <Plug>(MarkdownPlusToggleListLetterLowerParen) - Toggle parenthesized lowercase letter list (n, x) [<localleader>ltp]
+    <Plug>(MarkdownPlusToggleListLetterUpperParen) - Toggle parenthesized uppercase letter list (n, x) [<localleader>ltP]
+    <Plug>(MarkdownPlusToggleListClear)    - Clear list markers, leaving plain text (n, x) [<localleader>ltc]
 
 THEMATIC BREAKS ~
 

--- a/doc/markdown-plus.txt
+++ b/doc/markdown-plus.txt
@@ -335,6 +335,45 @@ behavior for multiple list types:
 
 All list types support checkboxes (e.g., `- [ ]`, `1. [x]`, `a. [ ]`).
 
+LIST TYPE TOGGLING ~
+                                                *markdown-plus-list-toggle*
+
+Toggle the current line (normal mode) or a selection (visual mode) to a list
+type. Plain text gains a marker; a line already of the target type is cleared
+back to plain text; a line of a different type is converted.
+
+The default mapping `<localleader>lt` (normal and visual mode) starts the toggle
+picker: press it, then a single key to choose the list type:
+
+>markdown
+    u   unordered          -
+    t   task               - [ ]
+    n   numbered           1.
+    N   numbered paren     1)
+    l   lowercase letter   a.
+    L   uppercase letter   A.
+    p   lowercase paren    a)
+    P   uppercase paren    A)
+    c   clear              strip list markers (force plain text)
+<
+
+In visual mode the decision is range-level: if every non-blank selected line
+already matches the target type the whole selection is cleared; otherwise every
+non-blank line is converted. Blank lines are left untouched, and ordered types
+are renumbered automatically per indentation group.
+
+Conversions preserve a checkbox when moving to an ordered or task type and drop
+it when moving to a plain unordered list:
+
+>markdown
+    write README          <localleader>lt t  →  - [ ] write README
+    1. [x] ship           <localleader>lt u  →  - ship
+    - [x] ship            <localleader>lt n  →  1. [x] ship
+<
+
+Each type also has a direct `<Plug>` mapping if you prefer a dedicated key per
+type instead of the picker; see |markdown-plus-keymaps|.
+
 CHECKBOX TOGGLING ~
 
 Toggle checkboxes with `<localleader>mx` in normal/visual mode or `<C-t>` in insert
@@ -1742,6 +1781,15 @@ LIST MANAGEMENT ~
     <Plug>(MarkdownPlusNewListItemBelow)   - New item below (n)
     <Plug>(MarkdownPlusNewListItemAbove)   - New item above (n)
     <Plug>(MarkdownPlusToggleCheckbox)     - Toggle checkbox (n, x, i)
+    <Plug>(MarkdownPlusToggleListPick)     - Toggle list, pick type with next key (n, x)
+    <Plug>(MarkdownPlusToggleListUnordered) - Toggle unordered list (n, x)
+    <Plug>(MarkdownPlusToggleListOrdered)  - Toggle ordered list (n, x)
+    <Plug>(MarkdownPlusToggleListTask)     - Toggle task list (n, x)
+    <Plug>(MarkdownPlusToggleListOrderedParen) - Toggle parenthesized ordered list (n, x)
+    <Plug>(MarkdownPlusToggleListLetterLower) - Toggle lowercase letter list (n, x)
+    <Plug>(MarkdownPlusToggleListLetterUpper) - Toggle uppercase letter list (n, x)
+    <Plug>(MarkdownPlusToggleListLetterLowerParen) - Toggle parenthesized lowercase letter list (n, x)
+    <Plug>(MarkdownPlusToggleListLetterUpperParen) - Toggle parenthesized uppercase letter list (n, x)
 
 THEMATIC BREAKS ~
 

--- a/lua/markdown-plus/list/init.lua
+++ b/lua/markdown-plus/list/init.lua
@@ -138,6 +138,7 @@ function M.setup_keymaps()
         end,
       },
       modes = { "n", "x" },
+      default_key = { "<localleader>ltu", "<localleader>ltu" },
       desc = "Toggle unordered list",
     },
     {
@@ -151,6 +152,7 @@ function M.setup_keymaps()
         end,
       },
       modes = { "n", "x" },
+      default_key = { "<localleader>ltn", "<localleader>ltn" },
       desc = "Toggle ordered list",
     },
     {
@@ -164,6 +166,7 @@ function M.setup_keymaps()
         end,
       },
       modes = { "n", "x" },
+      default_key = { "<localleader>ltt", "<localleader>ltt" },
       desc = "Toggle task list",
     },
     {
@@ -173,7 +176,6 @@ function M.setup_keymaps()
         toggle.toggle_list_pick_range,
       },
       modes = { "n", "x" },
-      default_key = { "<localleader>lt", "<localleader>lt" },
       desc = "Toggle list (pick type: u/t/n/N/l/L/p/P, c=clear)",
     },
     {
@@ -187,6 +189,7 @@ function M.setup_keymaps()
         end,
       },
       modes = { "n", "x" },
+      default_key = { "<localleader>ltN", "<localleader>ltN" },
       desc = "Toggle parenthesized ordered list",
     },
     {
@@ -200,6 +203,7 @@ function M.setup_keymaps()
         end,
       },
       modes = { "n", "x" },
+      default_key = { "<localleader>ltl", "<localleader>ltl" },
       desc = "Toggle lowercase letter list",
     },
     {
@@ -213,6 +217,7 @@ function M.setup_keymaps()
         end,
       },
       modes = { "n", "x" },
+      default_key = { "<localleader>ltL", "<localleader>ltL" },
       desc = "Toggle uppercase letter list",
     },
     {
@@ -226,6 +231,7 @@ function M.setup_keymaps()
         end,
       },
       modes = { "n", "x" },
+      default_key = { "<localleader>ltp", "<localleader>ltp" },
       desc = "Toggle parenthesized lowercase letter list",
     },
     {
@@ -239,7 +245,18 @@ function M.setup_keymaps()
         end,
       },
       modes = { "n", "x" },
+      default_key = { "<localleader>ltP", "<localleader>ltP" },
       desc = "Toggle parenthesized uppercase letter list",
+    },
+    {
+      plug = keymap_helper.plug_name("ToggleListClear"),
+      fn = {
+        toggle.clear_list_line,
+        toggle.clear_list_range,
+      },
+      modes = { "n", "x" },
+      default_key = { "<localleader>ltc", "<localleader>ltc" },
+      desc = "Clear list markers (plain text)",
     },
   })
 
@@ -406,6 +423,8 @@ M.toggle_list_line = toggle.toggle_list_line
 M.toggle_list_range = toggle.toggle_list_range
 M.toggle_list_in_range = toggle.toggle_list_in_range
 M.clear_list_in_range = toggle.clear_list_in_range
+M.clear_list_line = toggle.clear_list_line
+M.clear_list_range = toggle.clear_list_range
 M.toggle_list_pick_line = toggle.toggle_list_pick_line
 M.toggle_list_pick_range = toggle.toggle_list_pick_range
 

--- a/lua/markdown-plus/list/init.lua
+++ b/lua/markdown-plus/list/init.lua
@@ -7,6 +7,7 @@ local parser = require("markdown-plus.list.parser")
 local handlers = require("markdown-plus.list.handlers")
 local renumber = require("markdown-plus.list.renumber")
 local checkbox = require("markdown-plus.list.checkbox")
+local toggle = require("markdown-plus.list.toggle")
 
 local M = {}
 
@@ -125,6 +126,120 @@ function M.setup_keymaps()
       modes = { "n", "x", "i" },
       default_key = { "<localleader>mx", "<localleader>mx", "<C-t>" },
       desc = "Toggle checkbox",
+    },
+    {
+      plug = keymap_helper.plug_name("ToggleListUnordered"),
+      fn = {
+        function()
+          toggle.toggle_list_line("unordered")
+        end,
+        function()
+          toggle.toggle_list_range("unordered")
+        end,
+      },
+      modes = { "n", "x" },
+      desc = "Toggle unordered list",
+    },
+    {
+      plug = keymap_helper.plug_name("ToggleListOrdered"),
+      fn = {
+        function()
+          toggle.toggle_list_line("ordered")
+        end,
+        function()
+          toggle.toggle_list_range("ordered")
+        end,
+      },
+      modes = { "n", "x" },
+      desc = "Toggle ordered list",
+    },
+    {
+      plug = keymap_helper.plug_name("ToggleListTask"),
+      fn = {
+        function()
+          toggle.toggle_list_line("task")
+        end,
+        function()
+          toggle.toggle_list_range("task")
+        end,
+      },
+      modes = { "n", "x" },
+      desc = "Toggle task list",
+    },
+    {
+      plug = keymap_helper.plug_name("ToggleListPick"),
+      fn = {
+        toggle.toggle_list_pick_line,
+        toggle.toggle_list_pick_range,
+      },
+      modes = { "n", "x" },
+      default_key = { "<localleader>lt", "<localleader>lt" },
+      desc = "Toggle list (pick type: u/t/n/N/l/L/p/P, c=clear)",
+    },
+    {
+      plug = keymap_helper.plug_name("ToggleListOrderedParen"),
+      fn = {
+        function()
+          toggle.toggle_list_line("ordered_paren")
+        end,
+        function()
+          toggle.toggle_list_range("ordered_paren")
+        end,
+      },
+      modes = { "n", "x" },
+      desc = "Toggle parenthesized ordered list",
+    },
+    {
+      plug = keymap_helper.plug_name("ToggleListLetterLower"),
+      fn = {
+        function()
+          toggle.toggle_list_line("letter_lower")
+        end,
+        function()
+          toggle.toggle_list_range("letter_lower")
+        end,
+      },
+      modes = { "n", "x" },
+      desc = "Toggle lowercase letter list",
+    },
+    {
+      plug = keymap_helper.plug_name("ToggleListLetterUpper"),
+      fn = {
+        function()
+          toggle.toggle_list_line("letter_upper")
+        end,
+        function()
+          toggle.toggle_list_range("letter_upper")
+        end,
+      },
+      modes = { "n", "x" },
+      desc = "Toggle uppercase letter list",
+    },
+    {
+      plug = keymap_helper.plug_name("ToggleListLetterLowerParen"),
+      fn = {
+        function()
+          toggle.toggle_list_line("letter_lower_paren")
+        end,
+        function()
+          toggle.toggle_list_range("letter_lower_paren")
+        end,
+      },
+      modes = { "n", "x" },
+      desc = "Toggle parenthesized lowercase letter list",
+    },
+    {
+      plug = keymap_helper.plug_name("ToggleListLetterUpperParen"),
+      fn = {
+        function()
+          toggle.toggle_list_line("letter_upper_paren")
+        end,
+        function()
+          toggle.toggle_list_range("letter_upper_paren")
+        end,
+      },
+      modes = { "n", "x" },
+      desc = "Toggle parenthesized uppercase letter list",
     },
   })
 
@@ -287,5 +402,11 @@ M.toggle_checkbox_line = checkbox.toggle_checkbox_line
 M.toggle_checkbox_range = checkbox.toggle_checkbox_range
 M.toggle_checkbox_insert = checkbox.toggle_checkbox_insert
 M.get_completion_config = checkbox.get_completion_config
+M.toggle_list_line = toggle.toggle_list_line
+M.toggle_list_range = toggle.toggle_list_range
+M.toggle_list_in_range = toggle.toggle_list_in_range
+M.clear_list_in_range = toggle.clear_list_in_range
+M.toggle_list_pick_line = toggle.toggle_list_pick_line
+M.toggle_list_pick_range = toggle.toggle_list_pick_range
 
 return M

--- a/lua/markdown-plus/list/toggle.lua
+++ b/lua/markdown-plus/list/toggle.lua
@@ -60,7 +60,7 @@ local function line_matches_target(list_info, target_type)
 
   local def = TYPE_DEFS[target_type]
   if def.family == "unordered" then
-    return list_info.type == "unordered" and list_info.checkbox == nil and list_info.marker == "-"
+    return list_info.type == "unordered" and list_info.checkbox == nil
   elseif def.family == "task" then
     return list_info.type == "unordered" and list_info.checkbox ~= nil and list_info.marker == "-"
   end

--- a/lua/markdown-plus/list/toggle.lua
+++ b/lua/markdown-plus/list/toggle.lua
@@ -1,0 +1,304 @@
+-- List type toggling for markdown-plus.nvim
+-- Toggle the current line (normal mode) or a visual selection between list types.
+local parser = require("markdown-plus.list.parser")
+local shared = require("markdown-plus.list.shared")
+local renumber = require("markdown-plus.list.renumber")
+
+local M = {}
+
+---Supported toggle target types and their family/metadata.
+---@type table<string, {family: string, list_type?: string}>
+local TYPE_DEFS = {
+  unordered = { family = "unordered" },
+  task = { family = "task" },
+  ordered = { family = "orderable", list_type = "ordered" },
+  ordered_paren = { family = "orderable", list_type = "ordered_paren" },
+  letter_lower = { family = "orderable", list_type = "letter_lower" },
+  letter_upper = { family = "orderable", list_type = "letter_upper" },
+  letter_lower_paren = { family = "orderable", list_type = "letter_lower_paren" },
+  letter_upper_paren = { family = "orderable", list_type = "letter_upper_paren" },
+}
+
+---@class markdown-plus.list.ToggleParts
+---@field indent string Leading whitespace
+---@field content string Text after the marker (or after indent for plain lines)
+---@field checkbox string|nil Existing checkbox state, if any
+---@field list_info markdown-plus.ListInfo|nil Parsed list info, or nil for plain lines
+
+---Split a non-blank line into indent/content/checkbox parts.
+---@param line string Line text
+---@param row number 1-indexed row (for treesitter parsing)
+---@return markdown-plus.list.ToggleParts
+local function get_line_parts(line, row)
+  local list_info = parser.parse_list_line(line, row)
+  if list_info then
+    return {
+      indent = list_info.indent,
+      content = shared.extract_list_content(line, list_info),
+      checkbox = list_info.checkbox,
+      list_info = list_info,
+    }
+  end
+
+  local indent = line:match("^(%s*)") or ""
+  return {
+    indent = indent,
+    content = line:sub(#indent + 1),
+    checkbox = nil,
+    list_info = nil,
+  }
+end
+
+---Check whether a parsed line already matches the target type (for toggle-off).
+---@param list_info markdown-plus.ListInfo|nil Parsed list info
+---@param target_type string Target toggle type
+---@return boolean
+local function line_matches_target(list_info, target_type)
+  if not list_info then
+    return false
+  end
+
+  local def = TYPE_DEFS[target_type]
+  if def.family == "unordered" then
+    return list_info.type == "unordered" and list_info.checkbox == nil and list_info.marker == "-"
+  elseif def.family == "task" then
+    return list_info.type == "unordered" and list_info.checkbox ~= nil and list_info.marker == "-"
+  end
+
+  return list_info.type == def.list_type
+end
+
+---Normalize a checkbox capture into a single-character state.
+---@param checkbox string|nil Captured checkbox state
+---@return string
+local function checkbox_state(checkbox)
+  if checkbox and checkbox ~= "" then
+    return checkbox
+  end
+  return " "
+end
+
+---Build the converted line for a given target type.
+---For orderable types the marker is the type's first marker; sequential
+---numbering is fixed afterwards by renumber.renumber_ordered_lists.
+---@param parts markdown-plus.list.ToggleParts Parsed parts
+---@param target_type string Target toggle type
+---@return string
+local function build_converted_line(parts, target_type)
+  local def = TYPE_DEFS[target_type]
+  local indent = parts.indent
+  local content = parts.content
+
+  if def.family == "unordered" then
+    return indent .. "- " .. content
+  elseif def.family == "task" then
+    return indent .. "- [" .. checkbox_state(parts.checkbox) .. "] " .. content
+  end
+
+  -- Orderable: preserve an existing checkbox so e.g. "1. [x]" survives conversion.
+  local marker = shared.get_marker_for_index(def.list_type, 1)
+  if parts.checkbox then
+    return indent .. marker .. " [" .. checkbox_state(parts.checkbox) .. "] " .. content
+  end
+  return indent .. marker .. " " .. content
+end
+
+---Build the cleared (plain text) line, dropping any marker and checkbox.
+---@param parts markdown-plus.list.ToggleParts Parsed parts
+---@return string
+local function build_cleared_line(parts)
+  return parts.indent .. parts.content
+end
+
+---Toggle the list type across a row range.
+---@param start_row number 1-indexed start row
+---@param end_row number 1-indexed end row
+---@param target_type string Target toggle type
+---@return nil
+function M.toggle_list_in_range(start_row, end_row, target_type)
+  if not TYPE_DEFS[target_type] then
+    return
+  end
+  if not vim.bo.modifiable then
+    return
+  end
+
+  if start_row > end_row then
+    start_row, end_row = end_row, start_row
+  end
+
+  local lines = vim.api.nvim_buf_get_lines(0, start_row - 1, end_row, false)
+
+  -- Parse each line; remember blanks so they stay untouched.
+  local entries = {}
+  local nonblank = {}
+  for idx, line in ipairs(lines) do
+    local row = start_row + idx - 1
+    if line:match("^%s*$") then
+      entries[idx] = { blank = true }
+    else
+      local parts = get_line_parts(line, row)
+      entries[idx] = { parts = parts }
+      table.insert(nonblank, parts)
+    end
+  end
+
+  if #nonblank == 0 then
+    return
+  end
+
+  -- Range-level decision: clear only when every non-blank line already matches.
+  local all_match = true
+  for _, parts in ipairs(nonblank) do
+    if not line_matches_target(parts.list_info, target_type) then
+      all_match = false
+      break
+    end
+  end
+  local clearing = all_match
+
+  local new_lines = {}
+  for idx, line in ipairs(lines) do
+    local entry = entries[idx]
+    if entry.blank then
+      new_lines[idx] = line
+    elseif clearing then
+      new_lines[idx] = build_cleared_line(entry.parts)
+    else
+      new_lines[idx] = build_converted_line(entry.parts, target_type)
+    end
+  end
+
+  local cursor = vim.api.nvim_win_get_cursor(0)
+  vim.api.nvim_buf_set_lines(0, start_row - 1, end_row, false, new_lines)
+
+  -- Orderable conversions need sequential markers fixed per indent group.
+  if not clearing and TYPE_DEFS[target_type].family == "orderable" then
+    renumber.renumber_ordered_lists()
+  end
+
+  -- Toggle never changes the line count, so restore the cursor row directly.
+  local line_count = vim.api.nvim_buf_line_count(0)
+  local row = math.min(cursor[1], line_count)
+  local row_text = vim.api.nvim_buf_get_lines(0, row - 1, row, false)[1] or ""
+  local col = math.min(cursor[2], math.max(0, #row_text))
+  vim.api.nvim_win_set_cursor(0, { row, col })
+end
+
+---Toggle the list type on the current line (normal mode).
+---@param target_type string Target toggle type
+---@return nil
+function M.toggle_list_line(target_type)
+  local row = vim.api.nvim_win_get_cursor(0)[1]
+  M.toggle_list_in_range(row, row, target_type)
+end
+
+---Toggle the list type across the current visual selection.
+---@param target_type string Target toggle type
+---@return nil
+function M.toggle_list_range(target_type)
+  local start_row = vim.fn.line("v")
+  local end_row = vim.fn.line(".")
+  if start_row == 0 or end_row == 0 then
+    return
+  end
+  M.toggle_list_in_range(start_row, end_row, target_type)
+end
+
+---Clear list markers (and checkboxes) from a row range, leaving plain text.
+---Non-list lines and blank lines are left untouched.
+---@param start_row number 1-indexed start row
+---@param end_row number 1-indexed end row
+---@return nil
+function M.clear_list_in_range(start_row, end_row)
+  if not vim.bo.modifiable then
+    return
+  end
+  if start_row > end_row then
+    start_row, end_row = end_row, start_row
+  end
+
+  local lines = vim.api.nvim_buf_get_lines(0, start_row - 1, end_row, false)
+  local new_lines = {}
+  for idx, line in ipairs(lines) do
+    if line:match("^%s*$") then
+      new_lines[idx] = line
+    else
+      local parts = get_line_parts(line, start_row + idx - 1)
+      new_lines[idx] = parts.list_info and build_cleared_line(parts) or line
+    end
+  end
+
+  local cursor = vim.api.nvim_win_get_cursor(0)
+  vim.api.nvim_buf_set_lines(0, start_row - 1, end_row, false, new_lines)
+
+  local line_count = vim.api.nvim_buf_line_count(0)
+  local row = math.min(cursor[1], line_count)
+  local row_text = vim.api.nvim_buf_get_lines(0, row - 1, row, false)[1] or ""
+  vim.api.nvim_win_set_cursor(0, { row, math.min(cursor[2], math.max(0, #row_text)) })
+end
+
+---Maps a picker key to a target toggle type. `c` is handled separately as clear.
+---@type table<string, string>
+M.KEY_MAP = {
+  u = "unordered",
+  t = "task",
+  n = "ordered",
+  N = "ordered_paren",
+  l = "letter_lower",
+  L = "letter_upper",
+  p = "letter_lower_paren",
+  P = "letter_upper_paren",
+}
+
+---Read a single keypress for the picker. Exposed so tests can stub it.
+---@return string|nil key The pressed key, or nil on <Esc>/error
+function M.read_key()
+  local ok, ch = pcall(vim.fn.getcharstr)
+  if not ok or ch == nil or ch == "" or ch == "\27" then
+    return nil
+  end
+  return ch
+end
+
+---Dispatch a picker key to the matching operation over a row range.
+---@param start_row number 1-indexed start row
+---@param end_row number 1-indexed end row
+---@return nil
+local function dispatch_pick(start_row, end_row)
+  local key = M.read_key()
+  if not key then
+    return
+  end
+  if key == "c" then
+    M.clear_list_in_range(start_row, end_row)
+    return
+  end
+  local target_type = M.KEY_MAP[key]
+  if target_type then
+    M.toggle_list_in_range(start_row, end_row, target_type)
+  end
+end
+
+---Picker entry point for the current line (normal mode): prompts for a type key.
+---@return nil
+function M.toggle_list_pick_line()
+  local row = vim.api.nvim_win_get_cursor(0)[1]
+  dispatch_pick(row, row)
+end
+
+---Picker entry point for the current visual selection: prompts for a type key.
+---@return nil
+function M.toggle_list_pick_range()
+  local start_row = vim.fn.line("v")
+  local end_row = vim.fn.line(".")
+  if start_row == 0 or end_row == 0 then
+    return
+  end
+  dispatch_pick(start_row, end_row)
+end
+
+-- Expose supported target types for callers/tests.
+M.TYPE_DEFS = TYPE_DEFS
+
+return M

--- a/lua/markdown-plus/list/toggle.lua
+++ b/lua/markdown-plus/list/toggle.lua
@@ -238,6 +238,24 @@ function M.clear_list_in_range(start_row, end_row)
   vim.api.nvim_win_set_cursor(0, { row, math.min(cursor[2], math.max(0, #row_text)) })
 end
 
+---Clear list markers (and checkboxes) from the current line, leaving plain text.
+---@return nil
+function M.clear_list_line()
+  local row = vim.api.nvim_win_get_cursor(0)[1]
+  M.clear_list_in_range(row, row)
+end
+
+---Clear list markers (and checkboxes) across the current visual selection.
+---@return nil
+function M.clear_list_range()
+  local start_row = vim.fn.line("v")
+  local end_row = vim.fn.line(".")
+  if start_row == 0 or end_row == 0 then
+    return
+  end
+  M.clear_list_in_range(start_row, end_row)
+end
+
 ---Maps a picker key to a target toggle type. `c` is handled separately as clear.
 ---@type table<string, string>
 M.KEY_MAP = {

--- a/spec/markdown-plus/list_toggle_spec.lua
+++ b/spec/markdown-plus/list_toggle_spec.lua
@@ -67,6 +67,20 @@ describe("markdown-plus list toggle", function()
       assert.are.same({ "hello" }, get_lines())
     end)
 
+    it("toggles off a star bullet with the unordered target", function()
+      set_lines({ "* hello" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      toggle.toggle_list_line("unordered")
+      assert.are.same({ "hello" }, get_lines())
+    end)
+
+    it("toggles off a plus bullet with the unordered target", function()
+      set_lines({ "+ hello" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      toggle.toggle_list_line("unordered")
+      assert.are.same({ "hello" }, get_lines())
+    end)
+
     it("removes a task marker including checkbox", function()
       set_lines({ "- [x] done" })
       vim.api.nvim_win_set_cursor(0, { 1, 0 })
@@ -179,6 +193,12 @@ describe("markdown-plus list toggle", function()
       -- A non-continuation blank line breaks list groups, so each side
       -- forms its own list and restarts numbering (established renumber behavior).
       assert.are.same({ "1. one", "", "1. two" }, get_lines())
+    end)
+
+    it("clears a mixed-bullet selection with the unordered target", function()
+      set_lines({ "- one", "* two", "+ three" })
+      toggle.toggle_list_in_range(1, 3, "unordered")
+      assert.are.same({ "one", "two", "three" }, get_lines())
     end)
 
     it("handles a reversed range", function()

--- a/spec/markdown-plus/list_toggle_spec.lua
+++ b/spec/markdown-plus/list_toggle_spec.lua
@@ -230,6 +230,31 @@ describe("markdown-plus list toggle", function()
     end)
   end)
 
+  describe("clear_list_line", function()
+    it("clears the current line", function()
+      set_lines({ "1. [x] item" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      toggle.clear_list_line()
+      assert.are.same({ "item" }, get_lines())
+    end)
+
+    it("leaves a plain line untouched", function()
+      set_lines({ "plain" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      toggle.clear_list_line()
+      assert.are.same({ "plain" }, get_lines())
+    end)
+  end)
+
+  describe("clear_list_range", function()
+    it("clears the current visual selection", function()
+      set_lines({ "- one", "1. two", "a) three" })
+      vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("ggVG", true, false, true), "x", false)
+      toggle.clear_list_range()
+      assert.are.same({ "one", "two", "three" }, get_lines())
+    end)
+  end)
+
   describe("picker dispatcher", function()
     local orig_read_key
 

--- a/spec/markdown-plus/list_toggle_spec.lua
+++ b/spec/markdown-plus/list_toggle_spec.lua
@@ -1,0 +1,296 @@
+---Test suite for markdown-plus.nvim list type toggling
+---@diagnostic disable: undefined-field
+local toggle = require("markdown-plus.list.toggle")
+
+describe("markdown-plus list toggle", function()
+  local buf
+
+  ---Replace the buffer contents with the given lines.
+  ---@param lines string[]
+  local function set_lines(lines)
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+  end
+
+  ---Get all buffer lines.
+  ---@return string[]
+  local function get_lines()
+    return vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+  end
+
+  before_each(function()
+    buf = vim.api.nvim_create_buf(false, true)
+    vim.bo[buf].filetype = "markdown"
+    vim.api.nvim_set_current_buf(buf)
+  end)
+
+  after_each(function()
+    if vim.api.nvim_buf_is_valid(buf) then
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end
+  end)
+
+  describe("single line conversion", function()
+    it("adds an unordered marker to plain text", function()
+      set_lines({ "hello world" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      toggle.toggle_list_line("unordered")
+      assert.are.same({ "- hello world" }, get_lines())
+    end)
+
+    it("adds a task marker to plain text", function()
+      set_lines({ "buy milk" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      toggle.toggle_list_line("task")
+      assert.are.same({ "- [ ] buy milk" }, get_lines())
+    end)
+
+    it("adds an ordered marker to plain text", function()
+      set_lines({ "first" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      toggle.toggle_list_line("ordered")
+      assert.are.same({ "1. first" }, get_lines())
+    end)
+
+    it("preserves indentation", function()
+      set_lines({ "    nested" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      toggle.toggle_list_line("unordered")
+      assert.are.same({ "    - nested" }, get_lines())
+    end)
+  end)
+
+  describe("toggle off (same type)", function()
+    it("removes an unordered marker", function()
+      set_lines({ "- hello" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      toggle.toggle_list_line("unordered")
+      assert.are.same({ "hello" }, get_lines())
+    end)
+
+    it("removes a task marker including checkbox", function()
+      set_lines({ "- [x] done" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      toggle.toggle_list_line("task")
+      assert.are.same({ "done" }, get_lines())
+    end)
+
+    it("removes an ordered marker", function()
+      set_lines({ "1. first" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      toggle.toggle_list_line("ordered")
+      assert.are.same({ "first" }, get_lines())
+    end)
+  end)
+
+  describe("conversion between types", function()
+    it("converts unordered to ordered", function()
+      set_lines({ "- item" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      toggle.toggle_list_line("ordered")
+      assert.are.same({ "1. item" }, get_lines())
+    end)
+
+    it("converts ordered to unordered", function()
+      set_lines({ "1. item" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      toggle.toggle_list_line("unordered")
+      assert.are.same({ "- item" }, get_lines())
+    end)
+
+    it("converts unordered to task", function()
+      set_lines({ "- item" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      toggle.toggle_list_line("task")
+      assert.are.same({ "- [ ] item" }, get_lines())
+    end)
+
+    it("drops the checkbox when converting task to unordered", function()
+      set_lines({ "- [x] item" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      toggle.toggle_list_line("unordered")
+      assert.are.same({ "- item" }, get_lines())
+    end)
+
+    it("preserves the checkbox when converting task to ordered", function()
+      set_lines({ "- [x] item" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      toggle.toggle_list_line("ordered")
+      assert.are.same({ "1. [x] item" }, get_lines())
+    end)
+
+    it("normalizes a star bullet task to a dash task", function()
+      set_lines({ "* [ ] item" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      toggle.toggle_list_line("task")
+      assert.are.same({ "- [ ] item" }, get_lines())
+    end)
+  end)
+
+  describe("alpha and paren ordered types", function()
+    it("converts plain text to lowercase letter list", function()
+      set_lines({ "item" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      toggle.toggle_list_line("letter_lower")
+      assert.are.same({ "a. item" }, get_lines())
+    end)
+
+    it("converts plain text to parenthesized ordered list", function()
+      set_lines({ "item" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      toggle.toggle_list_line("ordered_paren")
+      assert.are.same({ "1) item" }, get_lines())
+    end)
+  end)
+
+  describe("visual range", function()
+    it("converts a block of plain text to a numbered list", function()
+      set_lines({ "one", "two", "three" })
+      toggle.toggle_list_in_range(1, 3, "ordered")
+      assert.are.same({ "1. one", "2. two", "3. three" }, get_lines())
+    end)
+
+    it("converts a block to a lowercase letter list with correct sequence", function()
+      set_lines({ "one", "two", "three" })
+      toggle.toggle_list_in_range(1, 3, "letter_lower")
+      assert.are.same({ "a. one", "b. two", "c. three" }, get_lines())
+    end)
+
+    it("converts a block to an unordered list", function()
+      set_lines({ "one", "two" })
+      toggle.toggle_list_in_range(1, 2, "unordered")
+      assert.are.same({ "- one", "- two" }, get_lines())
+    end)
+
+    it("clears a numbered list when all lines already match", function()
+      set_lines({ "1. one", "2. two", "3. three" })
+      toggle.toggle_list_in_range(1, 3, "ordered")
+      assert.are.same({ "one", "two", "three" }, get_lines())
+    end)
+
+    it("converts (not clears) a mixed selection", function()
+      set_lines({ "1. one", "plain", "3. three" })
+      toggle.toggle_list_in_range(1, 3, "ordered")
+      assert.are.same({ "1. one", "2. plain", "3. three" }, get_lines())
+    end)
+
+    it("skips blank lines and restarts numbering across a list break", function()
+      set_lines({ "one", "", "two" })
+      toggle.toggle_list_in_range(1, 3, "ordered")
+      -- A non-continuation blank line breaks list groups, so each side
+      -- forms its own list and restarts numbering (established renumber behavior).
+      assert.are.same({ "1. one", "", "1. two" }, get_lines())
+    end)
+
+    it("handles a reversed range", function()
+      set_lines({ "one", "two" })
+      toggle.toggle_list_in_range(2, 1, "unordered")
+      assert.are.same({ "- one", "- two" }, get_lines())
+    end)
+  end)
+
+  describe("surrounding context numbering", function()
+    it("continues an existing ordered list when converting prose in the middle", function()
+      set_lines({ "1. before", "middle", "after", "4. last" })
+      toggle.toggle_list_in_range(2, 3, "ordered")
+      assert.are.same({ "1. before", "2. middle", "3. after", "4. last" }, get_lines())
+    end)
+  end)
+
+  describe("edge cases", function()
+    it("does nothing for an all-blank selection", function()
+      set_lines({ "", "" })
+      toggle.toggle_list_in_range(1, 2, "ordered")
+      assert.are.same({ "", "" }, get_lines())
+    end)
+
+    it("ignores unknown target types", function()
+      set_lines({ "item" })
+      toggle.toggle_list_in_range(1, 1, "bogus")
+      assert.are.same({ "item" }, get_lines())
+    end)
+  end)
+
+  describe("clear_list_in_range", function()
+    it("strips markers from a mixed-type selection", function()
+      set_lines({ "- one", "1. two", "a) three" })
+      toggle.clear_list_in_range(1, 3)
+      assert.are.same({ "one", "two", "three" }, get_lines())
+    end)
+
+    it("strips checkboxes too", function()
+      set_lines({ "- [x] done", "1. [ ] todo" })
+      toggle.clear_list_in_range(1, 2)
+      assert.are.same({ "done", "todo" }, get_lines())
+    end)
+
+    it("leaves plain and blank lines untouched", function()
+      set_lines({ "- one", "", "plain" })
+      toggle.clear_list_in_range(1, 3)
+      assert.are.same({ "one", "", "plain" }, get_lines())
+    end)
+  end)
+
+  describe("picker dispatcher", function()
+    local orig_read_key
+
+    before_each(function()
+      orig_read_key = toggle.read_key
+    end)
+
+    after_each(function()
+      toggle.read_key = orig_read_key
+    end)
+
+    ---Stub the next picker keypress.
+    ---@param key string|nil
+    local function stub_key(key)
+      toggle.read_key = function()
+        return key
+      end
+    end
+
+    it("maps each key to the matching list type on the current line", function()
+      local cases = {
+        u = "- item",
+        t = "- [ ] item",
+        n = "1. item",
+        N = "1) item",
+        l = "a. item",
+        L = "A. item",
+        p = "a) item",
+        P = "A) item",
+      }
+      for key, expected in pairs(cases) do
+        set_lines({ "item" })
+        vim.api.nvim_win_set_cursor(0, { 1, 0 })
+        stub_key(key)
+        toggle.toggle_list_pick_line()
+        assert.are.same({ expected }, get_lines(), "key " .. key)
+      end
+    end)
+
+    it("clears the line on key 'c'", function()
+      set_lines({ "1. item" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      stub_key("c")
+      toggle.toggle_list_pick_line()
+      assert.are.same({ "item" }, get_lines())
+    end)
+
+    it("does nothing on an unmapped key", function()
+      set_lines({ "item" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      stub_key("z")
+      toggle.toggle_list_pick_line()
+      assert.are.same({ "item" }, get_lines())
+    end)
+
+    it("does nothing when the picker is cancelled (nil key)", function()
+      set_lines({ "item" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      stub_key(nil)
+      toggle.toggle_list_pick_line()
+      assert.are.same({ "item" }, get_lines())
+    end)
+  end)
+end)


### PR DESCRIPTION
Adds a list-type toggle under the `<localleader>lt` prefix. Press the prefix, then a single key to convert the current line or selection to a list type — or back to plain text.

Type keys: `u` unordered, `t` task, `n` `1.`, `N` `1)`, `l` `a.`, `L` `A.`, `p` `a)`, `P` `A)`, and `c` to clear.

These are real nested buffer-local keymaps (not a `getcharstr` picker), so which-key discovers them automatically and shows the menu after the prefix. Each type — including clear — also has its own `<Plug>` mapping if you want to bind one key per type. If you'd rather have a picker that waits indefinitely for the type key, bind `<Plug>(MarkdownPlusToggleListPick)` to `<localleader>lt` yourself.

- Implements issue #338's "toggle command followed by a type key" design
- Preserves checkboxes when converting to ordered/task; orderable conversions reuse the existing renumber logic so sequences stay correct across nesting, blank-line group splits, and surrounding context
- Range toggles clear only when every selected line already matches the target type
- Tradeoff: the second key must be pressed within `'timeoutlen'` (documented), with the picker `<Plug>` as an escape hatch

Tested by `make check` (lint + format + tests, including 35 in the toggle spec) plus headless checks confirming all nested mappings resolve to the right `<Plug>` targets in normal and visual mode.

Closes #338
