### PR TITLE
refactor(list): split init.lua into keymaps and autocmds sub-modules

### DIFF
--- a/lua/markdown-plus/list/autocmds.lua
+++ b/lua/markdown-plus/list/autocmds.lua
@@ -1,0 +1,153 @@
+-- List auto-renumber autocommands for markdown-plus.nvim
+-- Debounced renumbering of ordered lists plus per-buffer timer/augroup cleanup.
+local parser = require("markdown-plus.list.parser")
+local renumber = require("markdown-plus.list.renumber")
+local shared = require("markdown-plus.list.shared")
+
+local M = {}
+
+local RENUMBER_DEBOUNCE_MS = 150
+local ORDERED_LOOKAROUND = 20
+local RENUMBER_AUGROUP_PREFIX = "MarkdownPlusListRenumber_"
+
+---Per-buffer debounce timer handles, keyed by buffer number.
+---@type table<integer, integer>
+M.renumber_timers = {}
+
+---Get the cursor row for a buffer, even when it is not the current buffer.
+---@param bufnr integer Buffer number
+---@return integer row 1-indexed cursor row
+function M.get_cursor_row_for_buffer(bufnr)
+  if vim.api.nvim_get_current_buf() == bufnr then
+    return vim.api.nvim_win_get_cursor(0)[1]
+  end
+
+  local row = 1
+  vim.api.nvim_buf_call(bufnr, function()
+    row = vim.api.nvim_win_get_cursor(0)[1]
+  end)
+  return row
+end
+
+---Check whether an orderable list exists within the lookaround window of a row.
+---@param bufnr integer Buffer number
+---@param row integer 1-indexed row to search around
+---@return boolean
+function M.has_ordered_list_near_row(bufnr, row)
+  local line_count = vim.api.nvim_buf_line_count(bufnr)
+  local start_row = math.max(1, row - ORDERED_LOOKAROUND)
+  local end_row = math.min(line_count, row + ORDERED_LOOKAROUND)
+  local lines = vim.api.nvim_buf_get_lines(bufnr, start_row - 1, end_row, false)
+
+  for idx, line in ipairs(lines) do
+    local line_row = start_row + idx - 1
+    local list_info = parser.parse_list_line(line, line_row)
+    if list_info and shared.is_orderable_type(list_info.type) then
+      return true
+    end
+  end
+
+  return false
+end
+
+---Stop and clear the debounce timer for a buffer, if one is pending.
+---@param bufnr integer Buffer number
+---@return nil
+function M.stop_debounce_timer(bufnr)
+  local timer_id = M.renumber_timers[bufnr]
+  if timer_id then
+    pcall(vim.fn.timer_stop, timer_id)
+    M.renumber_timers[bufnr] = nil
+  end
+end
+
+---Set up auto-renumber autocommands for the current buffer.
+---@return nil
+function M.setup_renumber_autocmds()
+  local current_bufnr = vim.api.nvim_get_current_buf()
+  local group = vim.api.nvim_create_augroup(RENUMBER_AUGROUP_PREFIX .. current_bufnr, { clear = true })
+
+  -- Normal-mode edits: renumber immediately.
+  vim.api.nvim_create_autocmd("TextChanged", {
+    group = group,
+    buffer = current_bufnr,
+    callback = function(args)
+      local changed_bufnr = args.buf
+      if not vim.api.nvim_buf_is_valid(changed_bufnr) or not vim.bo[changed_bufnr].modifiable then
+        return
+      end
+      local cursor_row = M.get_cursor_row_for_buffer(changed_bufnr)
+      if not M.has_ordered_list_near_row(changed_bufnr, cursor_row) then
+        return
+      end
+
+      vim.api.nvim_buf_call(changed_bufnr, function()
+        renumber.renumber_ordered_lists()
+      end)
+    end,
+  })
+
+  -- Insert-mode edits: debounce to avoid renumbering on every keystroke.
+  vim.api.nvim_create_autocmd("TextChangedI", {
+    group = group,
+    buffer = current_bufnr,
+    callback = function(args)
+      local changed_bufnr = args.buf
+      local cursor_row = M.get_cursor_row_for_buffer(changed_bufnr)
+      if not M.has_ordered_list_near_row(changed_bufnr, cursor_row) then
+        return
+      end
+
+      M.stop_debounce_timer(changed_bufnr)
+
+      M.renumber_timers[changed_bufnr] = vim.fn.timer_start(RENUMBER_DEBOUNCE_MS, function()
+        M.renumber_timers[changed_bufnr] = nil
+        vim.schedule(function()
+          if not vim.api.nvim_buf_is_valid(changed_bufnr) or not vim.bo[changed_bufnr].modifiable then
+            return
+          end
+          vim.api.nvim_buf_call(changed_bufnr, function()
+            renumber.renumber_ordered_lists()
+          end)
+        end)
+      end)
+    end,
+  })
+
+  -- Ensure timers are cleaned up for deleted buffers.
+  vim.api.nvim_create_autocmd({ "BufDelete", "BufWipeout" }, {
+    group = group,
+    buffer = current_bufnr,
+    callback = function(args)
+      M.stop_debounce_timer(args.buf)
+    end,
+  })
+end
+
+---Tear down list autocommand runtime state: stop all timers and remove the
+---per-buffer renumber augroups.
+---@return nil
+function M.teardown()
+  local bufnrs = {}
+  for bufnr in pairs(M.renumber_timers) do
+    table.insert(bufnrs, bufnr)
+  end
+  for _, bufnr in ipairs(bufnrs) do
+    M.stop_debounce_timer(bufnr)
+  end
+
+  local autocmds = vim.api.nvim_get_autocmds({})
+  local groups = {}
+  for _, autocmd in ipairs(autocmds) do
+    local group_name = autocmd.group_name
+    if group_name and group_name:sub(1, #RENUMBER_AUGROUP_PREFIX) == RENUMBER_AUGROUP_PREFIX then
+      groups[group_name] = true
+    end
+  end
+
+  for group_name in pairs(groups) do
+    vim.api.nvim_del_augroup_by_name(group_name)
+  end
+end
+
+return M

--- a/lua/markdown-plus/list/init.lua
+++ b/lua/markdown-plus/list/init.lua
@@ -1,6 +1,5 @@
 -- List management module for markdown-plus.nvim
 local utils = require("markdown-plus.utils")
-local keymap_helper = require("markdown-plus.keymap_helper")
 
 -- Load sub-modules
 local parser = require("markdown-plus.list.parser")
@@ -8,21 +7,10 @@ local handlers = require("markdown-plus.list.handlers")
 local renumber = require("markdown-plus.list.renumber")
 local checkbox = require("markdown-plus.list.checkbox")
 local toggle = require("markdown-plus.list.toggle")
+local keymaps = require("markdown-plus.list.keymaps")
+local autocmds = require("markdown-plus.list.autocmds")
 
 local M = {}
-
-local RENUMBER_DEBOUNCE_MS = 150
-local renumber_timers = {}
-local ORDERED_LOOKAROUND = 20
-local ORDERABLE_LIST_TYPES = {
-  ordered = true,
-  ordered_paren = true,
-  letter_lower = true,
-  letter_upper = true,
-  letter_lower_paren = true,
-  letter_upper_paren = true,
-}
-local RENUMBER_AUGROUP_PREFIX = "MarkdownPlusListRenumber_"
 
 ---@type markdown-plus.InternalConfig
 M.config = {}
@@ -32,6 +20,7 @@ M.patterns = parser.patterns
 
 ---Setup list management module
 ---@param config markdown-plus.InternalConfig Plugin configuration
+---@return nil
 function M.setup(config)
   M.config = config or {}
   -- Pass list-specific config to checkbox module
@@ -41,356 +30,25 @@ function M.setup(config)
 end
 
 ---Enable list features for current buffer
+---@return nil
 function M.enable()
   if not utils.is_markdown_buffer() then
     return
   end
 
-  -- Set up keymaps
   M.setup_keymaps()
 end
 
----Set up keymaps for list management
-function M.setup_keymaps()
-  keymap_helper.setup_keymaps(M.config, {
-    {
-      plug = keymap_helper.plug_name("ListEnter"),
-      fn = handlers.skip_in_codeblock(handlers.handle_enter, "<CR>"),
-      modes = "i",
-      default_key = "<CR>",
-      desc = "Auto-continue list or split content",
-    },
-    {
-      plug = keymap_helper.plug_name("ListShiftEnter"),
-      fn = handlers.skip_in_codeblock(handlers.continue_list_content, "<A-CR>"),
-      modes = "i",
-      default_key = "<A-CR>",
-      desc = "Continue list content on next line",
-    },
-    {
-      plug = keymap_helper.plug_name("ListIndent"),
-      fn = handlers.skip_in_codeblock(handlers.handle_tab, "<Tab>"),
-      modes = "i",
-      default_key = "<Tab>",
-      desc = "Indent list item",
-    },
-    {
-      plug = keymap_helper.plug_name("ListOutdent"),
-      fn = handlers.skip_in_codeblock(handlers.handle_shift_tab, "<S-Tab>"),
-      modes = "i",
-      default_key = "<S-Tab>",
-      desc = "Outdent list item",
-    },
-    {
-      plug = keymap_helper.plug_name("ListBackspace"),
-      fn = handlers.skip_in_codeblock(handlers.handle_backspace, "<BS>"),
-      modes = "i",
-      default_key = "<BS>",
-      desc = "Smart backspace (remove empty list)",
-    },
-    {
-      plug = keymap_helper.plug_name("RenumberLists"),
-      fn = renumber.renumber_ordered_lists,
-      modes = "n",
-      default_key = "<localleader>mr",
-      desc = "Renumber ordered lists",
-    },
-    {
-      plug = keymap_helper.plug_name("DebugLists"),
-      fn = renumber.debug_list_groups,
-      modes = "n",
-      default_key = "<localleader>md",
-      desc = "Debug list groups",
-    },
-    {
-      plug = keymap_helper.plug_name("NewListItemBelow"),
-      fn = handlers.skip_in_codeblock(handlers.handle_normal_o, "o"),
-      modes = "n",
-      default_key = "o",
-      desc = "New list item below",
-    },
-    {
-      plug = keymap_helper.plug_name("NewListItemAbove"),
-      fn = handlers.skip_in_codeblock(handlers.handle_normal_O, "O"),
-      modes = "n",
-      default_key = "O",
-      desc = "New list item above",
-    },
-    {
-      plug = keymap_helper.plug_name("ToggleCheckbox"),
-      fn = {
-        checkbox.toggle_checkbox_line,
-        checkbox.toggle_checkbox_range,
-        checkbox.toggle_checkbox_insert,
-      },
-      modes = { "n", "x", "i" },
-      default_key = { "<localleader>mx", "<localleader>mx", "<C-t>" },
-      desc = "Toggle checkbox",
-    },
-    {
-      plug = keymap_helper.plug_name("ToggleListUnordered"),
-      fn = {
-        function()
-          toggle.toggle_list_line("unordered")
-        end,
-        function()
-          toggle.toggle_list_range("unordered")
-        end,
-      },
-      modes = { "n", "x" },
-      default_key = { "<localleader>ltu", "<localleader>ltu" },
-      desc = "Toggle unordered list",
-    },
-    {
-      plug = keymap_helper.plug_name("ToggleListOrdered"),
-      fn = {
-        function()
-          toggle.toggle_list_line("ordered")
-        end,
-        function()
-          toggle.toggle_list_range("ordered")
-        end,
-      },
-      modes = { "n", "x" },
-      default_key = { "<localleader>ltn", "<localleader>ltn" },
-      desc = "Toggle ordered list",
-    },
-    {
-      plug = keymap_helper.plug_name("ToggleListTask"),
-      fn = {
-        function()
-          toggle.toggle_list_line("task")
-        end,
-        function()
-          toggle.toggle_list_range("task")
-        end,
-      },
-      modes = { "n", "x" },
-      default_key = { "<localleader>ltt", "<localleader>ltt" },
-      desc = "Toggle task list",
-    },
-    {
-      plug = keymap_helper.plug_name("ToggleListPick"),
-      fn = {
-        toggle.toggle_list_pick_line,
-        toggle.toggle_list_pick_range,
-      },
-      modes = { "n", "x" },
-      desc = "Toggle list (pick type: u/t/n/N/l/L/p/P, c=clear)",
-    },
-    {
-      plug = keymap_helper.plug_name("ToggleListOrderedParen"),
-      fn = {
-        function()
-          toggle.toggle_list_line("ordered_paren")
-        end,
-        function()
-          toggle.toggle_list_range("ordered_paren")
-        end,
-      },
-      modes = { "n", "x" },
-      default_key = { "<localleader>ltN", "<localleader>ltN" },
-      desc = "Toggle parenthesized ordered list",
-    },
-    {
-      plug = keymap_helper.plug_name("ToggleListLetterLower"),
-      fn = {
-        function()
-          toggle.toggle_list_line("letter_lower")
-        end,
-        function()
-          toggle.toggle_list_range("letter_lower")
-        end,
-      },
-      modes = { "n", "x" },
-      default_key = { "<localleader>ltl", "<localleader>ltl" },
-      desc = "Toggle lowercase letter list",
-    },
-    {
-      plug = keymap_helper.plug_name("ToggleListLetterUpper"),
-      fn = {
-        function()
-          toggle.toggle_list_line("letter_upper")
-        end,
-        function()
-          toggle.toggle_list_range("letter_upper")
-        end,
-      },
-      modes = { "n", "x" },
-      default_key = { "<localleader>ltL", "<localleader>ltL" },
-      desc = "Toggle uppercase letter list",
-    },
-    {
-      plug = keymap_helper.plug_name("ToggleListLetterLowerParen"),
-      fn = {
-        function()
-          toggle.toggle_list_line("letter_lower_paren")
-        end,
-        function()
-          toggle.toggle_list_range("letter_lower_paren")
-        end,
-      },
-      modes = { "n", "x" },
-      default_key = { "<localleader>ltp", "<localleader>ltp" },
-      desc = "Toggle parenthesized lowercase letter list",
-    },
-    {
-      plug = keymap_helper.plug_name("ToggleListLetterUpperParen"),
-      fn = {
-        function()
-          toggle.toggle_list_line("letter_upper_paren")
-        end,
-        function()
-          toggle.toggle_list_range("letter_upper_paren")
-        end,
-      },
-      modes = { "n", "x" },
-      default_key = { "<localleader>ltP", "<localleader>ltP" },
-      desc = "Toggle parenthesized uppercase letter list",
-    },
-    {
-      plug = keymap_helper.plug_name("ToggleListClear"),
-      fn = {
-        toggle.clear_list_line,
-        toggle.clear_list_range,
-      },
-      modes = { "n", "x" },
-      default_key = { "<localleader>ltc", "<localleader>ltc" },
-      desc = "Clear list markers (plain text)",
-    },
-  })
-
-  -- Set up autocommands for auto-renumbering
-  M.setup_renumber_autocmds()
-end
-
----Set up autocommands for auto-renumbering
-function M.setup_renumber_autocmds()
-  local current_bufnr = vim.api.nvim_get_current_buf()
-  local group = vim.api.nvim_create_augroup(RENUMBER_AUGROUP_PREFIX .. current_bufnr, { clear = true })
-
-  local function get_cursor_row_for_buffer(bufnr)
-    if vim.api.nvim_get_current_buf() == bufnr then
-      return vim.api.nvim_win_get_cursor(0)[1]
-    end
-
-    local row = 1
-    vim.api.nvim_buf_call(bufnr, function()
-      row = vim.api.nvim_win_get_cursor(0)[1]
-    end)
-    return row
-  end
-
-  local function has_ordered_list_near_row(bufnr, row)
-    local line_count = vim.api.nvim_buf_line_count(bufnr)
-    local start_row = math.max(1, row - ORDERED_LOOKAROUND)
-    local end_row = math.min(line_count, row + ORDERED_LOOKAROUND)
-    local lines = vim.api.nvim_buf_get_lines(bufnr, start_row - 1, end_row, false)
-
-    for idx, line in ipairs(lines) do
-      local line_row = start_row + idx - 1
-      local list_info = parser.parse_list_line(line, line_row)
-      if list_info and ORDERABLE_LIST_TYPES[list_info.type] then
-        return true
-      end
-    end
-
-    return false
-  end
-
-  local function stop_debounce_timer(bufnr)
-    local timer_id = renumber_timers[bufnr]
-    if timer_id then
-      pcall(vim.fn.timer_stop, timer_id)
-      renumber_timers[bufnr] = nil
-    end
-  end
-
-  -- Normal-mode edits: renumber immediately.
-  vim.api.nvim_create_autocmd("TextChanged", {
-    group = group,
-    buffer = current_bufnr,
-    callback = function(args)
-      local changed_bufnr = args.buf
-      if not vim.api.nvim_buf_is_valid(changed_bufnr) or not vim.bo[changed_bufnr].modifiable then
-        return
-      end
-      local cursor_row = get_cursor_row_for_buffer(changed_bufnr)
-      if not has_ordered_list_near_row(changed_bufnr, cursor_row) then
-        return
-      end
-
-      vim.api.nvim_buf_call(changed_bufnr, function()
-        renumber.renumber_ordered_lists()
-      end)
-    end,
-  })
-
-  -- Insert-mode edits: debounce to avoid renumbering on every keystroke.
-  vim.api.nvim_create_autocmd("TextChangedI", {
-    group = group,
-    buffer = current_bufnr,
-    callback = function(args)
-      local changed_bufnr = args.buf
-      local cursor_row = get_cursor_row_for_buffer(changed_bufnr)
-      if not has_ordered_list_near_row(changed_bufnr, cursor_row) then
-        return
-      end
-
-      stop_debounce_timer(changed_bufnr)
-
-      renumber_timers[changed_bufnr] = vim.fn.timer_start(RENUMBER_DEBOUNCE_MS, function()
-        renumber_timers[changed_bufnr] = nil
-        vim.schedule(function()
-          if not vim.api.nvim_buf_is_valid(changed_bufnr) or not vim.bo[changed_bufnr].modifiable then
-            return
-          end
-          vim.api.nvim_buf_call(changed_bufnr, function()
-            renumber.renumber_ordered_lists()
-          end)
-        end)
-      end)
-    end,
-  })
-
-  -- Ensure timers are cleaned up for deleted buffers.
-  vim.api.nvim_create_autocmd({ "BufDelete", "BufWipeout" }, {
-    group = group,
-    buffer = current_bufnr,
-    callback = function(args)
-      stop_debounce_timer(args.buf)
-    end,
-  })
-end
-
----Teardown list-specific runtime state
+---Set up list keymaps and auto-renumber autocommands for the current buffer
 ---@return nil
-function M.teardown()
-  local bufnrs = {}
-  for bufnr in pairs(renumber_timers) do
-    table.insert(bufnrs, bufnr)
-  end
-  for _, bufnr in ipairs(bufnrs) do
-    local timer_id = renumber_timers[bufnr]
-    if timer_id then
-      pcall(vim.fn.timer_stop, timer_id)
-    end
-    renumber_timers[bufnr] = nil
-  end
-
-  local autocmds = vim.api.nvim_get_autocmds({})
-  local groups = {}
-  for _, autocmd in ipairs(autocmds) do
-    local group_name = autocmd.group_name
-    if group_name and group_name:sub(1, #RENUMBER_AUGROUP_PREFIX) == RENUMBER_AUGROUP_PREFIX then
-      groups[group_name] = true
-    end
-  end
-
-  for group_name in pairs(groups) do
-    vim.api.nvim_del_augroup_by_name(group_name)
-  end
+function M.setup_keymaps()
+  keymaps.setup_keymaps(M.config)
+  autocmds.setup_renumber_autocmds()
 end
+
+-- Re-export autocommand lifecycle for backwards compatibility
+M.setup_renumber_autocmds = autocmds.setup_renumber_autocmds
+M.teardown = autocmds.teardown
 
 -- Re-export functions from sub-modules for backwards compatibility
 M.parse_list_line = parser.parse_list_line

--- a/lua/markdown-plus/list/keymaps.lua
+++ b/lua/markdown-plus/list/keymaps.lua
@@ -1,0 +1,225 @@
+-- List management keymaps for markdown-plus.nvim
+-- Registers <Plug> mappings and buffer-local defaults for list editing, renumber,
+-- new-item creation, checkbox toggling, and list-type toggling.
+local keymap_helper = require("markdown-plus.keymap_helper")
+local handlers = require("markdown-plus.list.handlers")
+local renumber = require("markdown-plus.list.renumber")
+local checkbox = require("markdown-plus.list.checkbox")
+local toggle = require("markdown-plus.list.toggle")
+
+local M = {}
+
+---Register list-management keymaps for the current buffer.
+---@param config markdown-plus.InternalConfig Plugin configuration
+---@return nil
+function M.setup_keymaps(config)
+  keymap_helper.setup_keymaps(config, {
+    {
+      plug = keymap_helper.plug_name("ListEnter"),
+      fn = handlers.skip_in_codeblock(handlers.handle_enter, "<CR>"),
+      modes = "i",
+      default_key = "<CR>",
+      desc = "Auto-continue list or split content",
+    },
+    {
+      plug = keymap_helper.plug_name("ListShiftEnter"),
+      fn = handlers.skip_in_codeblock(handlers.continue_list_content, "<A-CR>"),
+      modes = "i",
+      default_key = "<A-CR>",
+      desc = "Continue list content on next line",
+    },
+    {
+      plug = keymap_helper.plug_name("ListIndent"),
+      fn = handlers.skip_in_codeblock(handlers.handle_tab, "<Tab>"),
+      modes = "i",
+      default_key = "<Tab>",
+      desc = "Indent list item",
+    },
+    {
+      plug = keymap_helper.plug_name("ListOutdent"),
+      fn = handlers.skip_in_codeblock(handlers.handle_shift_tab, "<S-Tab>"),
+      modes = "i",
+      default_key = "<S-Tab>",
+      desc = "Outdent list item",
+    },
+    {
+      plug = keymap_helper.plug_name("ListBackspace"),
+      fn = handlers.skip_in_codeblock(handlers.handle_backspace, "<BS>"),
+      modes = "i",
+      default_key = "<BS>",
+      desc = "Smart backspace (remove empty list)",
+    },
+    {
+      plug = keymap_helper.plug_name("RenumberLists"),
+      fn = renumber.renumber_ordered_lists,
+      modes = "n",
+      default_key = "<localleader>mr",
+      desc = "Renumber ordered lists",
+    },
+    {
+      plug = keymap_helper.plug_name("DebugLists"),
+      fn = renumber.debug_list_groups,
+      modes = "n",
+      default_key = "<localleader>md",
+      desc = "Debug list groups",
+    },
+    {
+      plug = keymap_helper.plug_name("NewListItemBelow"),
+      fn = handlers.skip_in_codeblock(handlers.handle_normal_o, "o"),
+      modes = "n",
+      default_key = "o",
+      desc = "New list item below",
+    },
+    {
+      plug = keymap_helper.plug_name("NewListItemAbove"),
+      fn = handlers.skip_in_codeblock(handlers.handle_normal_O, "O"),
+      modes = "n",
+      default_key = "O",
+      desc = "New list item above",
+    },
+    {
+      plug = keymap_helper.plug_name("ToggleCheckbox"),
+      fn = {
+        checkbox.toggle_checkbox_line,
+        checkbox.toggle_checkbox_range,
+        checkbox.toggle_checkbox_insert,
+      },
+      modes = { "n", "x", "i" },
+      default_key = { "<localleader>mx", "<localleader>mx", "<C-t>" },
+      desc = "Toggle checkbox",
+    },
+    {
+      plug = keymap_helper.plug_name("ToggleListUnordered"),
+      fn = {
+        function()
+          toggle.toggle_list_line("unordered")
+        end,
+        function()
+          toggle.toggle_list_range("unordered")
+        end,
+      },
+      modes = { "n", "x" },
+      default_key = { "<localleader>ltu", "<localleader>ltu" },
+      desc = "Toggle unordered list",
+    },
+    {
+      plug = keymap_helper.plug_name("ToggleListOrdered"),
+      fn = {
+        function()
+          toggle.toggle_list_line("ordered")
+        end,
+        function()
+          toggle.toggle_list_range("ordered")
+        end,
+      },
+      modes = { "n", "x" },
+      default_key = { "<localleader>ltn", "<localleader>ltn" },
+      desc = "Toggle ordered list",
+    },
+    {
+      plug = keymap_helper.plug_name("ToggleListTask"),
+      fn = {
+        function()
+          toggle.toggle_list_line("task")
+        end,
+        function()
+          toggle.toggle_list_range("task")
+        end,
+      },
+      modes = { "n", "x" },
+      default_key = { "<localleader>ltt", "<localleader>ltt" },
+      desc = "Toggle task list",
+    },
+    {
+      plug = keymap_helper.plug_name("ToggleListPick"),
+      fn = {
+        toggle.toggle_list_pick_line,
+        toggle.toggle_list_pick_range,
+      },
+      modes = { "n", "x" },
+      desc = "Toggle list (pick type: u/t/n/N/l/L/p/P, c=clear)",
+    },
+    {
+      plug = keymap_helper.plug_name("ToggleListOrderedParen"),
+      fn = {
+        function()
+          toggle.toggle_list_line("ordered_paren")
+        end,
+        function()
+          toggle.toggle_list_range("ordered_paren")
+        end,
+      },
+      modes = { "n", "x" },
+      default_key = { "<localleader>ltN", "<localleader>ltN" },
+      desc = "Toggle parenthesized ordered list",
+    },
+    {
+      plug = keymap_helper.plug_name("ToggleListLetterLower"),
+      fn = {
+        function()
+          toggle.toggle_list_line("letter_lower")
+        end,
+        function()
+          toggle.toggle_list_range("letter_lower")
+        end,
+      },
+      modes = { "n", "x" },
+      default_key = { "<localleader>ltl", "<localleader>ltl" },
+      desc = "Toggle lowercase letter list",
+    },
+    {
+      plug = keymap_helper.plug_name("ToggleListLetterUpper"),
+      fn = {
+        function()
+          toggle.toggle_list_line("letter_upper")
+        end,
+        function()
+          toggle.toggle_list_range("letter_upper")
+        end,
+      },
+      modes = { "n", "x" },
+      default_key = { "<localleader>ltL", "<localleader>ltL" },
+      desc = "Toggle uppercase letter list",
+    },
+    {
+      plug = keymap_helper.plug_name("ToggleListLetterLowerParen"),
+      fn = {
+        function()
+          toggle.toggle_list_line("letter_lower_paren")
+        end,
+        function()
+          toggle.toggle_list_range("letter_lower_paren")
+        end,
+      },
+      modes = { "n", "x" },
+      default_key = { "<localleader>ltp", "<localleader>ltp" },
+      desc = "Toggle parenthesized lowercase letter list",
+    },
+    {
+      plug = keymap_helper.plug_name("ToggleListLetterUpperParen"),
+      fn = {
+        function()
+          toggle.toggle_list_line("letter_upper_paren")
+        end,
+        function()
+          toggle.toggle_list_range("letter_upper_paren")
+        end,
+      },
+      modes = { "n", "x" },
+      default_key = { "<localleader>ltP", "<localleader>ltP" },
+      desc = "Toggle parenthesized uppercase letter list",
+    },
+    {
+      plug = keymap_helper.plug_name("ToggleListClear"),
+      fn = {
+        toggle.clear_list_line,
+        toggle.clear_list_range,
+      },
+      modes = { "n", "x" },
+      default_key = { "<localleader>ltc", "<localleader>ltc" },
+      desc = "Clear list markers (plain text)",
+    },
+  })
+end
+
+return M

--- a/spec/markdown-plus/list_autocmds_spec.lua
+++ b/spec/markdown-plus/list_autocmds_spec.lua
@@ -1,0 +1,237 @@
+---Test suite for markdown-plus.nvim list auto-renumber autocommands
+---Tests the extracted autocmds sub-module: helpers, autocommand registration,
+---callback behavior, and teardown of timers and augroups.
+---@diagnostic disable: undefined-field
+local autocmds = require("markdown-plus.list.autocmds")
+
+local AUGROUP_PREFIX = "MarkdownPlusListRenumber_"
+
+describe("markdown-plus list autocmds", function()
+  local buf
+
+  ---Fetch the registered callback for a given event in the buffer's augroup.
+  ---@param target_buf integer
+  ---@param event string
+  ---@return function|nil
+  local function callback_for(target_buf, event)
+    local group = AUGROUP_PREFIX .. target_buf
+    for _, cmd in ipairs(vim.api.nvim_get_autocmds({ group = group, event = event })) do
+      if cmd.callback then
+        return cmd.callback
+      end
+    end
+    return nil
+  end
+
+  before_each(function()
+    buf = vim.api.nvim_create_buf(false, true)
+    vim.bo[buf].filetype = "markdown"
+    vim.api.nvim_set_current_buf(buf)
+  end)
+
+  after_each(function()
+    -- Stops any pending timers and removes all renumber augroups.
+    autocmds.teardown()
+    if vim.api.nvim_buf_is_valid(buf) then
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end
+  end)
+
+  describe("has_ordered_list_near_row", function()
+    it("returns true when an ordered list is near the row", function()
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "1. First", "2. Second" })
+      assert.is_true(autocmds.has_ordered_list_near_row(buf, 1))
+    end)
+
+    it("detects all orderable list types", function()
+      local cases = { "1. a", "1) a", "a. x", "A. x", "a) x", "A) x" }
+      for _, line in ipairs(cases) do
+        vim.api.nvim_buf_set_lines(buf, 0, -1, false, { line })
+        assert.is_true(autocmds.has_ordered_list_near_row(buf, 1), "expected orderable: " .. line)
+      end
+    end)
+
+    it("returns false for unordered lists", function()
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "- item", "* item", "+ item" })
+      assert.is_false(autocmds.has_ordered_list_near_row(buf, 1))
+    end)
+
+    it("returns false for plain text", function()
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "just text", "more text" })
+      assert.is_false(autocmds.has_ordered_list_near_row(buf, 1))
+    end)
+
+    it("respects the lookaround window", function()
+      local lines = {}
+      for i = 1, 60 do
+        lines[i] = "plain text"
+      end
+      lines[1] = "1. ordered far away"
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+
+      -- Ordered list at row 1 is >20 lines from row 50 -> not detected.
+      assert.is_false(autocmds.has_ordered_list_near_row(buf, 50))
+      -- Row 10 is within the lookaround window of row 1 -> detected.
+      assert.is_true(autocmds.has_ordered_list_near_row(buf, 10))
+    end)
+  end)
+
+  describe("get_cursor_row_for_buffer", function()
+    it("returns the cursor row for the current buffer", function()
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "a", "b", "c" })
+      vim.api.nvim_win_set_cursor(0, { 2, 0 })
+      assert.equals(2, autocmds.get_cursor_row_for_buffer(buf))
+    end)
+
+    it("returns a valid row for a non-current buffer", function()
+      local other = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_buf_set_lines(other, 0, -1, false, { "x", "y" })
+
+      local row = autocmds.get_cursor_row_for_buffer(other)
+      assert.is_number(row)
+      assert.is_true(row >= 1)
+
+      vim.api.nvim_buf_delete(other, { force = true })
+    end)
+  end)
+
+  describe("stop_debounce_timer", function()
+    it("is a no-op when no timer is registered", function()
+      assert.is_nil(autocmds.renumber_timers[buf])
+      assert.has_no.errors(function()
+        autocmds.stop_debounce_timer(buf)
+      end)
+      assert.is_nil(autocmds.renumber_timers[buf])
+    end)
+
+    it("stops and clears an existing timer", function()
+      local timer = vim.fn.timer_start(100000, function() end)
+      autocmds.renumber_timers[buf] = timer
+
+      autocmds.stop_debounce_timer(buf)
+
+      assert.is_nil(autocmds.renumber_timers[buf])
+    end)
+  end)
+
+  describe("setup_renumber_autocmds", function()
+    it("registers TextChanged, TextChangedI, and buffer-delete autocmds", function()
+      autocmds.setup_renumber_autocmds()
+
+      local registered = vim.api.nvim_get_autocmds({ group = AUGROUP_PREFIX .. buf })
+      local events = {}
+      for _, cmd in ipairs(registered) do
+        events[cmd.event] = true
+      end
+
+      assert.is_true(events.TextChanged)
+      assert.is_true(events.TextChangedI)
+      assert.is_true(events.BufDelete or events.BufWipeout)
+    end)
+
+    it("renumbers immediately on normal-mode TextChanged near an ordered list", function()
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "1. a", "1. b", "1. c" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      autocmds.setup_renumber_autocmds()
+
+      local cb = callback_for(buf, "TextChanged")
+      assert.is_function(cb)
+      cb({ buf = buf })
+
+      assert.same({ "1. a", "2. b", "3. c" }, vim.api.nvim_buf_get_lines(buf, 0, -1, false))
+    end)
+
+    it("skips renumber on TextChanged when no ordered list is near", function()
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "- a", "- b" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      autocmds.setup_renumber_autocmds()
+
+      local cb = callback_for(buf, "TextChanged")
+      cb({ buf = buf })
+
+      assert.same({ "- a", "- b" }, vim.api.nvim_buf_get_lines(buf, 0, -1, false))
+    end)
+
+    it("does not renumber a non-modifiable buffer on TextChanged", function()
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "1. a", "1. b" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      autocmds.setup_renumber_autocmds()
+
+      local cb = callback_for(buf, "TextChanged")
+      vim.bo[buf].modifiable = false
+      cb({ buf = buf })
+
+      vim.bo[buf].modifiable = true
+      assert.same({ "1. a", "1. b" }, vim.api.nvim_buf_get_lines(buf, 0, -1, false))
+    end)
+
+    it("registers a debounce timer on insert-mode TextChangedI near an ordered list", function()
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "1. a", "1. b" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      autocmds.setup_renumber_autocmds()
+
+      local cb = callback_for(buf, "TextChangedI")
+      assert.is_function(cb)
+
+      cb({ buf = buf })
+      assert.is_not_nil(autocmds.renumber_timers[buf])
+
+      -- A second edit restarts the debounce timer without erroring.
+      cb({ buf = buf })
+      assert.is_not_nil(autocmds.renumber_timers[buf])
+
+      autocmds.stop_debounce_timer(buf)
+    end)
+
+    it("does not register a debounce timer when no ordered list is near", function()
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "- a", "- b" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      autocmds.setup_renumber_autocmds()
+
+      local cb = callback_for(buf, "TextChangedI")
+      cb({ buf = buf })
+
+      assert.is_nil(autocmds.renumber_timers[buf])
+    end)
+
+    it("clears the debounce timer when the buffer is deleted", function()
+      autocmds.setup_renumber_autocmds()
+      autocmds.renumber_timers[buf] = vim.fn.timer_start(100000, function() end)
+
+      local cb = callback_for(buf, "BufDelete") or callback_for(buf, "BufWipeout")
+      assert.is_function(cb)
+      cb({ buf = buf })
+
+      assert.is_nil(autocmds.renumber_timers[buf])
+    end)
+  end)
+
+  describe("teardown", function()
+    it("stops and clears all debounce timers", function()
+      autocmds.renumber_timers[101] = vim.fn.timer_start(100000, function() end)
+      autocmds.renumber_timers[102] = vim.fn.timer_start(100000, function() end)
+
+      autocmds.teardown()
+
+      assert.is_nil(autocmds.renumber_timers[101])
+      assert.is_nil(autocmds.renumber_timers[102])
+    end)
+
+    it("removes renumber augroups for multiple buffers", function()
+      autocmds.setup_renumber_autocmds()
+
+      local buf2 = vim.api.nvim_create_buf(false, true)
+      vim.bo[buf2].filetype = "markdown"
+      vim.api.nvim_set_current_buf(buf2)
+      autocmds.setup_renumber_autocmds()
+
+      autocmds.teardown()
+
+      -- Querying a removed augroup raises, so pcall should fail for both.
+      assert.is_false(pcall(vim.api.nvim_get_autocmds, { group = AUGROUP_PREFIX .. buf }))
+      assert.is_false(pcall(vim.api.nvim_get_autocmds, { group = AUGROUP_PREFIX .. buf2 }))
+
+      vim.api.nvim_buf_delete(buf2, { force = true })
+    end)
+  end)
+end)


### PR DESCRIPTION
Splits the oversized list module into focused keymap and autocmd lifecycle modules, keeping list/init.lua as a thin orchestrator with the existing public API preserved.

- Move list keymap registration into lua/markdown-plus/list/keymaps.lua
- Move auto-renumber autocmds, debounce timers, and teardown into lua/markdown-plus/list/autocmds.lua
- Add direct coverage for the extracted autocmd helpers and lifecycle behavior

Fixes #357

Tested by: make lint, make format-check, targeted list/config specs, and full make test output showing 44 spec files with 0 failures / 0 errors.