### PR TITLE
docs(config): sync type annotations and doc comments (#362)

### DIFF
--- a/lua/markdown-plus/config/validate.lua
+++ b/lua/markdown-plus/config/validate.lua
@@ -60,7 +60,7 @@ local SCHEMA = {
       width_mode = { type = "string", enum = { literal = true, segment = true } },
       wrap_break = { type = "string" },
       max_column_width = {
-        type = "number",
+        type = "number", -- integer (Lua has no runtime integer type; validator enforces whole-number constraint)
         validator = function(value, path, _)
           if value < 1 then
             return false, path .. ": must be at least 1"

--- a/lua/markdown-plus/types.lua
+++ b/lua/markdown-plus/types.lua
@@ -35,7 +35,7 @@
 ---@class markdown-plus.TableConfig
 ---@field enabled? boolean Enable table features (default: true)
 ---@field auto_format? boolean Automatically format tables on edit (default: true)
----@field default_alignment? string Default column alignment: 'left', 'center', 'right' (default: 'left')
+---@field default_alignment? "left"|"center"|"right" Default column alignment (default: 'left')
 ---@field confirm_destructive? boolean Confirm before destructive operations like transpose/sort (default: true)
 ---@field width_mode? "literal"|"segment" Column-width calculation mode (default: 'literal'). 'segment' measures the widest <br>-split segment so cells containing breaks don't inflate column width.
 ---@field wrap_break? string Token used to represent a line break inside a cell (default: '<br>'). Honoured by later cell-edit/wrap commands.
@@ -97,7 +97,7 @@
 ---@class markdown-plus.CodeBlockConfig
 ---@field enabled? boolean Enable code block features (default: true)
 ---@field fence_style? "backtick"|"tilde" Preferred fence style for insertion (default: "backtick")
----@field languages? string[] Language options shown in picker
+---@field languages? string[] Language options shown in picker (default: {"lua","python","javascript","typescript","bash","json","yaml","markdown"})
 
 ---TOC window configuration
 ---@class markdown-plus.TocConfig


### PR DESCRIPTION
Syncs the config type annotations and doc comments flagged by the config-sync checker in #362. Annotation/comment-only — no runtime behavior change.

- `types.lua`: `table.default_alignment` now uses a `"left"|"center"|"right"` union annotation, matching the other enum-constrained fields
- `types.lua`: documented the default for `code_block.languages`
- `validate.lua`: noted that `max_column_width`'s `"number"` schema type is Lua's runtime form of `integer`

Tested with `make check` — lint, format-check, and all 44 specs pass.

Closes #362
