### PR TITLE
feat(list): add configurable marker-to-content whitespace (#365)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ That's it! The plugin will automatically activate with default keymaps when you 
 - New heading toggle: `<localleader>ms` switches ATX/setext heading style (H1/H2).
 - New thematic-break commands: `<localleader>mh` (insert) and `<localleader>mH` (cycle style).
 - Smart list outdent is enabled by default (`list.smart_outdent = true`) for parent-aware marker continuation.
+- New list marker spacing: set `list.whitespace = "shiftwidth"` (with `list.whitespace_width`, default 4) to align list content to a fixed-width block instead of collapsing to a single space, keeping continuation lines aligned. Defaults to `"single"` (unchanged). Note: Markdown formatters that enforce single-space list markers (e.g. Prettier) will override this on format/save.
 - New list type toggling: the `<localleader>lt` prefix toggles list types — press it, then a type key (`u` unordered, `t` task, `n` `1.`, `N` `1)`, `l` `a.`, `L` `A.`, `p` `a)`, `P` `A)`, `c` clear) to toggle the current line or selection. These are real nested keymaps, so which-key shows the menu after the prefix. Works in normal and visual mode; each type also has a `<Plug>` mapping. Prefer an indefinitely-waiting picker? Bind `<Plug>(MarkdownPlusToggleListPick)` to `<localleader>lt` yourself.
 - New formatting escape toggle: `<localleader>me` (visual mode) escapes/unescapes markdown punctuation.
 - Code block module is now first-class: `<localleader>mc` insert/wrap, `]b`/`[b` navigate, `<localleader>mC` change language.

--- a/doc/markdown-plus.txt
+++ b/doc/markdown-plus.txt
@@ -588,6 +588,44 @@ Example of fenced code block handling:
 <
 
 
+MARKER WHITESPACE ~
+
+By default markdown-plus keeps a single space between a list marker and its
+content. Set `list.whitespace = 'shiftwidth'` to pad that gap so content aligns
+to a fixed-width block (the width comes from `list.whitespace_width`, default
+4). This keeps wrapped/continuation lines aligned with the first line's
+content, as recommended by the CommonMark list-items spec.
+
+>lua
+    require('markdown-plus').setup({
+      list = {
+        whitespace = 'shiftwidth',   -- align content to a block
+        whitespace_width = 4,        -- block width (defaults to 4)
+      },
+    })
+<
+
+The marker length determines the pad, so content lands on the next multiple of
+the width (always with at least one space). With `whitespace_width = 4`,
+single-digit ordered markers get two spaces, `10.` gets one, and `100.` gets
+four:
+>markdown
+    1.  Item 1        <- '1.'   + 2 spaces -> content column 4
+    2.  Item 2
+    10. Item 10       <- '10.'  + 1 space  -> content column 4
+    100.    Item 100  <- '100.' + 4 spaces -> content column 8
+<
+Unordered markers follow the same rule (`-` becomes three spaces at width 4).
+The pad is relative to each item's indentation and is independent of the
+buffer's actual 'shiftwidth' option. The default `'single'` mode is unchanged.
+
+Note: external Markdown formatters that enforce single-space list markers (for
+example Prettier) will collapse this padding when they reformat the buffer, such
+as on format-on-save. markdown-plus applies the spacing as you edit, but a
+formatter runs at write time and wins. If you rely on `shiftwidth` spacing,
+exclude Markdown from that formatter (or disable it) so the two don't fight.
+
+
 SMART BACKSPACE ~
 
 The `<BS>` key in insert mode is context-aware:
@@ -1579,6 +1617,8 @@ The plugin can be configured through the setup function:
       },
       list = {                   -- List configuration
         smart_outdent = true,         -- Parent-aware outdent and parent continuation on `o`
+        whitespace = 'single',        -- 'single' (one space) | 'shiftwidth' (align to block)
+        whitespace_width = 4,         -- Block width used when whitespace = 'shiftwidth'
         checkbox_completion = {
           enabled = false,            -- Add timestamps when checking tasks
           format = 'emoji',           -- 'emoji', 'comment', 'dataview', 'parenthetical'

--- a/lua/markdown-plus/config/validate.lua
+++ b/lua/markdown-plus/config/validate.lua
@@ -181,6 +181,19 @@ local SCHEMA = {
     type = "table",
     fields = {
       smart_outdent = { type = "boolean" },
+      whitespace = { type = "string", enum = { single = true, shiftwidth = true } },
+      whitespace_width = {
+        type = "number", -- integer (validator enforces whole-number constraint)
+        validator = function(value, path, _)
+          if value < 1 then
+            return false, path .. ": must be at least 1"
+          end
+          if value ~= math.floor(value) then
+            return false, path .. ": must be an integer"
+          end
+          return true
+        end,
+      },
       checkbox_completion = {
         type = "table",
         fields = {

--- a/lua/markdown-plus/init.lua
+++ b/lua/markdown-plus/init.lua
@@ -64,6 +64,8 @@ local DEFAULT_CONFIG = {
   },
   list = {
     smart_outdent = true,
+    whitespace = "single",
+    whitespace_width = 4,
     checkbox_completion = {
       enabled = false,
       format = "emoji",

--- a/lua/markdown-plus/list/checkbox.lua
+++ b/lua/markdown-plus/list/checkbox.lua
@@ -1,6 +1,7 @@
 -- Checkbox management module for markdown-plus.nvim
 local utils = require("markdown-plus.utils")
 local parser = require("markdown-plus.list.parser")
+local shared = require("markdown-plus.list.shared")
 local M = {}
 
 ---@type markdown-plus.InternalListConfig|nil
@@ -197,7 +198,11 @@ function M.replace_checkbox_state(line, list_info)
       end
     end
 
-    return prefix .. "[" .. new_state .. "] " .. content
+    -- Honor the configured marker→content spacing. The full marker includes the
+    -- checkbox bracket; spaces_after_marker returns a single space in "single"
+    -- mode, so this is byte-identical to the historical layout by default.
+    local full_marker = prefix:sub(#indent + 1) .. "[" .. new_state .. "]"
+    return prefix .. "[" .. new_state .. "]" .. shared.spaces_after_marker(full_marker) .. content
   end
 
   return line
@@ -217,7 +222,9 @@ function M.add_checkbox_to_line(line, list_info)
   local prefix, content = line:match(list_pattern)
 
   if prefix and content ~= nil then
-    return prefix .. "[ ] " .. content
+    -- Pad to the configured block (single space in "single" mode → unchanged).
+    local full_marker = prefix:sub(#indent + 1) .. "[ ]"
+    return prefix .. "[ ]" .. shared.spaces_after_marker(full_marker) .. content
   end
 
   return line

--- a/lua/markdown-plus/list/enter_handler.lua
+++ b/lua/markdown-plus/list/enter_handler.lua
@@ -108,16 +108,12 @@ function M.handle_enter()
 
     -- Create next list item with content after cursor
     local next_marker = parser.get_next_marker(list_info)
-    local next_line = handler_utils.build_list_prefix(list_info.indent, next_marker, list_info.checkbox)
-      .. content_after:match("^%s*(.*)")
+    local next_prefix = handler_utils.build_list_prefix(list_info.indent, next_marker, list_info.checkbox)
+    local next_line = next_prefix .. content_after:match("^%s*(.*)")
 
     utils.insert_line(row + 1, next_line)
-    -- Calculate cursor position on new line (after marker and optional checkbox)
-    local new_cursor_col = #list_info.indent + #next_marker + 1
-    if list_info.checkbox then
-      new_cursor_col = new_cursor_col + 4 -- Add "[ ] " length
-    end
-    utils.set_cursor(row + 1, new_cursor_col)
+    -- Place cursor at the start of the new item's content (after marker, pad, and optional checkbox)
+    utils.set_cursor(row + 1, #next_prefix)
     return
   end
 

--- a/lua/markdown-plus/list/handler_utils.lua
+++ b/lua/markdown-plus/list/handler_utils.lua
@@ -29,11 +29,11 @@ end
 ---@param checkbox string|nil Non-nil if the list uses checkboxes (value ignored — new items always start unchecked)
 ---@return string prefix The constructed list item prefix
 function M.build_list_prefix(indent, marker, checkbox)
-  local prefix = indent .. marker .. " "
+  local full_marker = marker
   if checkbox then
-    prefix = prefix .. "[ ] "
+    full_marker = full_marker .. " [ ]"
   end
-  return prefix
+  return indent .. full_marker .. shared.spaces_after_marker(full_marker)
 end
 
 ---Find parent list item by looking upward from current line

--- a/lua/markdown-plus/list/indent_handler.lua
+++ b/lua/markdown-plus/list/indent_handler.lua
@@ -36,7 +36,7 @@ function M.handle_tab()
 
   local new_indent = list_info.indent .. string.rep(" ", indent_size)
   local content = shared.extract_list_content(current_line, list_info)
-  local new_line = new_indent .. list_info.full_marker .. " " .. content
+  local new_line = new_indent .. list_info.full_marker .. shared.spaces_after_marker(list_info.full_marker) .. content
 
   utils.set_line(row, new_line)
   utils.set_cursor(row, col + indent_size)
@@ -84,13 +84,15 @@ function M.handle_shift_tab()
     end
   end
 
-  local new_line = new_indent .. new_marker .. " " .. content
+  local new_line = new_indent .. new_marker .. shared.spaces_after_marker(new_marker) .. content
 
   utils.set_line(row, new_line)
 
-  -- Adjust cursor position
+  -- Adjust cursor position. Account for marker-length and pad-length changes so the
+  -- cursor tracks the content column under any whitespace mode.
   local marker_delta = #new_marker - #list_info.full_marker
-  local new_col = math.max(0, col - remove + marker_delta)
+  local pad_delta = #shared.spaces_after_marker(new_marker) - #shared.spaces_after_marker(list_info.full_marker)
+  local new_col = math.max(0, col - remove + marker_delta + pad_delta)
   utils.set_cursor(row, new_col)
 end
 

--- a/lua/markdown-plus/list/init.lua
+++ b/lua/markdown-plus/list/init.lua
@@ -3,6 +3,7 @@ local utils = require("markdown-plus.utils")
 
 -- Load sub-modules
 local parser = require("markdown-plus.list.parser")
+local shared = require("markdown-plus.list.shared")
 local handlers = require("markdown-plus.list.handlers")
 local renumber = require("markdown-plus.list.renumber")
 local checkbox = require("markdown-plus.list.checkbox")
@@ -25,6 +26,7 @@ function M.setup(config)
   M.config = config or {}
   -- Pass list-specific config to checkbox module
   checkbox.setup(M.config.list)
+  shared.set_whitespace_config(M.config.list)
   handlers.set_config(M.config)
   renumber.set_html_awareness(utils.is_html_awareness_enabled(M.config))
 end

--- a/lua/markdown-plus/list/normal_handler.lua
+++ b/lua/markdown-plus/list/normal_handler.lua
@@ -55,7 +55,7 @@ function M.handle_backspace()
   end
 
   -- If at the start of list content, remove the list marker
-  local marker_end_col = #list_info.indent + #list_info.full_marker + 1
+  local marker_end_col = shared.get_content_start_col(list_info)
   if col <= marker_end_col and col > #list_info.indent then
     -- Remove list marker, keep content
     local content = shared.extract_list_content(current_line, list_info)

--- a/lua/markdown-plus/list/renumber.lua
+++ b/lua/markdown-plus/list/renumber.lua
@@ -31,14 +31,19 @@ function M.renumber_list_group(group)
 
     -- Determine expected marker based on list type
     local expected_marker = shared.get_marker_for_index(group.list_type, idx)
+    local full_marker = expected_marker .. checkbox_part
 
-    local expected_line = item.indent .. expected_marker .. checkbox_part .. " " .. item.content
+    local expected_line = item.indent .. full_marker .. shared.spaces_after_marker(full_marker) .. item.content
 
     -- Only create change if line is different
     if expected_line ~= item.original_line then
       table.insert(changes, {
         line_num = item.line_num,
         new_line = expected_line,
+        -- Column where content starts, before and after the rewrite. Used to keep
+        -- the cursor on its content character when the marker/spacing length changes.
+        old_content_start = #item.original_line - #item.content,
+        new_content_start = #item.indent + #full_marker + #shared.spaces_after_marker(full_marker),
       })
     end
   end
@@ -126,7 +131,36 @@ function M.renumber_ordered_lists()
 
   -- Apply changes if any were made
   if modified then
+    -- Capture the cursor first so we can keep it on the same content character
+    -- when the rewrite changes the marker/spacing length on the cursor's line.
+    -- Without this the cursor keeps its absolute column and drifts as text shifts.
+    local cursor_ok, cursor = pcall(vim.api.nvim_win_get_cursor, 0)
+    local cursor_change
+    if cursor_ok then
+      for _, change in ipairs(changes) do
+        if change.line_num == cursor[1] then
+          cursor_change = change
+          break
+        end
+      end
+    end
+
     apply_changes(changes)
+
+    if cursor_change then
+      local col = cursor[2]
+      local new_col
+      if col >= cursor_change.old_content_start then
+        -- Cursor is within the content: shift it by the prefix-length delta.
+        new_col = col + (cursor_change.new_content_start - cursor_change.old_content_start)
+      else
+        -- Cursor is within the marker/indent prefix: leave it, but never let it
+        -- spill past where the content now starts.
+        new_col = math.min(col, cursor_change.new_content_start)
+      end
+      new_col = math.max(0, math.min(new_col, #cursor_change.new_line))
+      pcall(vim.api.nvim_win_set_cursor, 0, { cursor[1], new_col })
+    end
   end
 end
 

--- a/lua/markdown-plus/list/shared.lua
+++ b/lua/markdown-plus/list/shared.lua
@@ -19,6 +19,45 @@ M.DELIMITER_PAREN = ")"
 -- Maximum number of lines to look back when searching for parent list item
 M.MAX_PARENT_LOOKBACK = 20
 
+-- Whitespace behavior between a list marker and its content.
+-- "single" reproduces the historical single-space layout; "shiftwidth" pads so
+-- content aligns to a `whitespace_width` block (relative to the item's indent).
+local whitespace_mode = "single"
+local whitespace_width = 4
+
+---Configure marker-to-content whitespace behavior from list config
+---@param list_config markdown-plus.InternalListConfig|nil
+---@return nil
+function M.set_whitespace_config(list_config)
+  if list_config and list_config.whitespace == "shiftwidth" then
+    whitespace_mode = "shiftwidth"
+  else
+    whitespace_mode = "single"
+  end
+
+  local width = list_config and list_config.whitespace_width
+  if type(width) == "number" and width >= 1 then
+    whitespace_width = math.floor(width)
+  else
+    whitespace_width = 4
+  end
+end
+
+---Compute the whitespace that should follow a list marker before its content.
+---In "single" mode this is always one space (byte-identical to the historical
+---behavior). In "shiftwidth" mode the pad aligns content to a `whitespace_width`
+---block relative to the item's indentation, always returning at least one space.
+---@param marker string The full marker (e.g. "1.", "- [x]") whose trailing pad is needed
+---@return string spaces The whitespace string to place after the marker
+function M.spaces_after_marker(marker)
+  if whitespace_mode ~= "shiftwidth" then
+    return " "
+  end
+  local width = whitespace_width
+  local pad = width - (#marker % width)
+  return string.rep(" ", pad)
+end
+
 ---Check if a list type is orderable (supports renumbering)
 ---@param list_type string List type to check
 ---@return boolean True if the list type is orderable
@@ -42,10 +81,12 @@ end
 
 ---Calculate the column position where list content starts (after marker and checkbox)
 ---Note: full_marker already includes checkbox if present (e.g., "- [x]", "1. [ ]")
+---Honors the configured marker-to-content whitespace (see set_whitespace_config).
 ---@param list_info table List information
 ---@return number The column position where content starts
 function M.get_content_start_col(list_info)
-  return #list_info.indent + #list_info.full_marker + 1
+  local spaces = M.spaces_after_marker(list_info.full_marker)
+  return #list_info.indent + #list_info.full_marker + #spaces
 end
 
 ---Get the expected marker for a given index and list type

--- a/lua/markdown-plus/list/toggle.lua
+++ b/lua/markdown-plus/list/toggle.lua
@@ -90,17 +90,19 @@ local function build_converted_line(parts, target_type)
   local content = parts.content
 
   if def.family == "unordered" then
-    return indent .. "- " .. content
+    return indent .. "-" .. shared.spaces_after_marker("-") .. content
   elseif def.family == "task" then
-    return indent .. "- [" .. checkbox_state(parts.checkbox) .. "] " .. content
+    local full_marker = "- [" .. checkbox_state(parts.checkbox) .. "]"
+    return indent .. full_marker .. shared.spaces_after_marker(full_marker) .. content
   end
 
   -- Orderable: preserve an existing checkbox so e.g. "1. [x]" survives conversion.
   local marker = shared.get_marker_for_index(def.list_type, 1)
   if parts.checkbox then
-    return indent .. marker .. " [" .. checkbox_state(parts.checkbox) .. "] " .. content
+    local full_marker = marker .. " [" .. checkbox_state(parts.checkbox) .. "]"
+    return indent .. full_marker .. shared.spaces_after_marker(full_marker) .. content
   end
-  return indent .. marker .. " " .. content
+  return indent .. marker .. shared.spaces_after_marker(marker) .. content
 end
 
 ---Build the cleared (plain text) line, dropping any marker and checkbox.

--- a/lua/markdown-plus/types.lua
+++ b/lua/markdown-plus/types.lua
@@ -71,6 +71,8 @@
 ---@class markdown-plus.ListConfig
 ---@field checkbox_completion? markdown-plus.CheckboxCompletionConfig Checkbox completion timestamp configuration
 ---@field smart_outdent? boolean Enable parent-aware smart outdent/continuation (default: true)
+---@field whitespace? "single"|"shiftwidth" Spacing between a list marker and its content (default: "single")
+---@field whitespace_width? number Alignment block width used when whitespace = "shiftwidth" (default: 4)
 
 ---Thematic break configuration
 ---@class markdown-plus.ThematicBreakConfig
@@ -195,6 +197,8 @@
 ---@class markdown-plus.InternalListConfig
 ---@field checkbox_completion markdown-plus.InternalCheckboxCompletionConfig
 ---@field smart_outdent boolean
+---@field whitespace string
+---@field whitespace_width number
 
 ---Internal links configuration
 ---@class markdown-plus.InternalLinksConfig

--- a/spec/markdown-plus/config_spec.lua
+++ b/spec/markdown-plus/config_spec.lua
@@ -194,6 +194,42 @@ describe("markdown-plus configuration", function()
     end)
   end)
 
+  describe("list whitespace config", function()
+    it("defaults whitespace to 'single' and whitespace_width to 4", function()
+      markdown_plus.setup({})
+      assert.equals("single", markdown_plus.config.list.whitespace)
+      assert.equals(4, markdown_plus.config.list.whitespace_width)
+    end)
+
+    it("accepts whitespace = 'shiftwidth'", function()
+      markdown_plus.setup({ list = { whitespace = "shiftwidth" } })
+      assert.equals("shiftwidth", markdown_plus.config.list.whitespace)
+    end)
+
+    it("rejects unknown whitespace values", function()
+      local before = vim.deepcopy(markdown_plus.config.list)
+      markdown_plus.setup({ list = { whitespace = "bogus" } })
+      assert.equals(before.whitespace, markdown_plus.config.list.whitespace)
+    end)
+
+    it("accepts a custom positive-integer whitespace_width", function()
+      markdown_plus.setup({ list = { whitespace_width = 2 } })
+      assert.equals(2, markdown_plus.config.list.whitespace_width)
+    end)
+
+    it("rejects a non-integer whitespace_width", function()
+      local before = vim.deepcopy(markdown_plus.config.list)
+      markdown_plus.setup({ list = { whitespace_width = 2.5 } })
+      assert.equals(before.whitespace_width, markdown_plus.config.list.whitespace_width)
+    end)
+
+    it("rejects a whitespace_width below 1", function()
+      local before = vim.deepcopy(markdown_plus.config.list)
+      markdown_plus.setup({ list = { whitespace_width = 0 } })
+      assert.equals(before.whitespace_width, markdown_plus.config.list.whitespace_width)
+    end)
+  end)
+
   describe("feature toggles", function()
     it("can disable all features", function()
       markdown_plus.setup({

--- a/spec/markdown-plus/list_whitespace_spec.lua
+++ b/spec/markdown-plus/list_whitespace_spec.lua
@@ -199,6 +199,39 @@ describe("markdown-plus list whitespace", function()
     end)
   end)
 
+  describe("checkbox spacing honors whitespace mode", function()
+    local function parse(line)
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { line })
+      return list.parse_list_line(line, 1)
+    end
+
+    it("single mode: adding a checkbox keeps one space (unchanged)", function()
+      require("markdown-plus").setup({ list = { whitespace = "single" } })
+      assert.are.equal("- [ ] thing", list.add_checkbox_to_line("- thing", parse("- thing")))
+    end)
+
+    it("single mode: toggling checkbox state keeps one space (unchanged)", function()
+      require("markdown-plus").setup({ list = { whitespace = "single" } })
+      assert.are.equal("- [x] Hello", list.replace_checkbox_state("- [ ] Hello", parse("- [ ] Hello")))
+    end)
+
+    it("shiftwidth mode: adding a checkbox aligns content to the block", function()
+      require("markdown-plus").setup({ list = { whitespace = "shiftwidth", whitespace_width = 4 } })
+      -- Full marker "- [ ]" (5 chars) -> 3 pad spaces -> content column 8.
+      assert.are.equal("- [ ]   thing", list.add_checkbox_to_line("- thing", parse("- thing")))
+    end)
+
+    it("shiftwidth mode: checking a box preserves block alignment", function()
+      require("markdown-plus").setup({ list = { whitespace = "shiftwidth", whitespace_width = 4 } })
+      assert.are.equal("- [x]   Hello", list.replace_checkbox_state("- [ ]   Hello", parse("- [ ]   Hello")))
+    end)
+
+    it("shiftwidth mode: unchecking a box preserves block alignment", function()
+      require("markdown-plus").setup({ list = { whitespace = "shiftwidth", whitespace_width = 4 } })
+      assert.are.equal("- [ ]   Hello", list.replace_checkbox_state("- [x]   Hello", parse("- [x]   Hello")))
+    end)
+  end)
+
   describe("setup propagation", function()
     it("wires whitespace config through the public setup() path", function()
       require("markdown-plus").setup({ list = { whitespace = "shiftwidth", whitespace_width = 4 } })

--- a/spec/markdown-plus/list_whitespace_spec.lua
+++ b/spec/markdown-plus/list_whitespace_spec.lua
@@ -1,0 +1,211 @@
+---Test suite for configurable list marker-to-content whitespace (issue #365)
+---Covers the shared.spaces_after_marker helper, get_content_start_col, and the
+---generation sites (renumber + build_list_prefix) under "single" and "shiftwidth"
+---modes. "single" mode must stay byte-identical to the historical behavior.
+---@diagnostic disable: undefined-field
+local shared = require("markdown-plus.list.shared")
+local handler_utils = require("markdown-plus.list.handler_utils")
+local list = require("markdown-plus.list")
+
+describe("markdown-plus list whitespace", function()
+  local buf
+
+  before_each(function()
+    buf = vim.api.nvim_create_buf(false, true)
+    vim.bo[buf].filetype = "markdown"
+    vim.api.nvim_set_current_buf(buf)
+  end)
+
+  after_each(function()
+    -- Reset to the default so other describe blocks / files are never affected.
+    shared.set_whitespace_config({ whitespace = "single", whitespace_width = 4 })
+    if vim.api.nvim_buf_is_valid(buf) then
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end
+  end)
+
+  describe("spaces_after_marker", function()
+    it("always returns a single space in single mode", function()
+      shared.set_whitespace_config({ whitespace = "single", whitespace_width = 4 })
+      assert.are.equal(" ", shared.spaces_after_marker("1."))
+      assert.are.equal(" ", shared.spaces_after_marker("100."))
+      assert.are.equal(" ", shared.spaces_after_marker("-"))
+      assert.are.equal(" ", shared.spaces_after_marker("1. [x]"))
+    end)
+
+    it("defaults to single mode when no list config is given", function()
+      shared.set_whitespace_config(nil)
+      assert.are.equal(" ", shared.spaces_after_marker("1."))
+    end)
+
+    it("pads ordered markers to the width-4 block in shiftwidth mode", function()
+      shared.set_whitespace_config({ whitespace = "shiftwidth", whitespace_width = 4 })
+      assert.are.equal("  ", shared.spaces_after_marker("1.")) -- len 2 -> content col 4
+      assert.are.equal(" ", shared.spaces_after_marker("10.")) -- len 3 -> content col 4
+      assert.are.equal("    ", shared.spaces_after_marker("100.")) -- len 4 -> content col 8
+    end)
+
+    it("pads unordered markers to three spaces at width 4 (reporter's case)", function()
+      shared.set_whitespace_config({ whitespace = "shiftwidth", whitespace_width = 4 })
+      assert.are.equal("   ", shared.spaces_after_marker("-")) -- len 1 -> content col 4
+    end)
+
+    it("treats the checkbox bracket as part of the marker", function()
+      shared.set_whitespace_config({ whitespace = "shiftwidth", whitespace_width = 4 })
+      assert.are.equal("  ", shared.spaces_after_marker("1. [x]")) -- len 6 -> content col 8
+    end)
+
+    it("honors a custom whitespace_width", function()
+      shared.set_whitespace_config({ whitespace = "shiftwidth", whitespace_width = 2 })
+      assert.are.equal(" ", shared.spaces_after_marker("-")) -- len 1 -> col 2
+      assert.are.equal("  ", shared.spaces_after_marker("1.")) -- len 2 -> col 4
+    end)
+
+    it("never returns fewer than one space", function()
+      shared.set_whitespace_config({ whitespace = "shiftwidth", whitespace_width = 4 })
+      for _, marker in ipairs({ "1.", "10.", "100.", "-", "+", "a)", "1. [ ]" }) do
+        assert.is_true(#shared.spaces_after_marker(marker) >= 1)
+      end
+    end)
+  end)
+
+  describe("get_content_start_col", function()
+    it("matches the single-space layout in single mode", function()
+      shared.set_whitespace_config({ whitespace = "single", whitespace_width = 4 })
+      assert.are.equal(3, shared.get_content_start_col({ indent = "", full_marker = "1." }))
+    end)
+
+    it("reflects the padded content column in shiftwidth mode", function()
+      shared.set_whitespace_config({ whitespace = "shiftwidth", whitespace_width = 4 })
+      -- Continuation lines align here, fixing the reporter's misalignment.
+      assert.are.equal(4, shared.get_content_start_col({ indent = "", full_marker = "1." }))
+      assert.are.equal(4, shared.get_content_start_col({ indent = "", full_marker = "10." }))
+      assert.are.equal(8, shared.get_content_start_col({ indent = "", full_marker = "100." }))
+    end)
+  end)
+
+  describe("build_list_prefix", function()
+    it("produces the historical layout in single mode", function()
+      shared.set_whitespace_config({ whitespace = "single", whitespace_width = 4 })
+      assert.are.equal("1. ", handler_utils.build_list_prefix("", "1.", nil))
+      assert.are.equal("- ", handler_utils.build_list_prefix("", "-", nil))
+      assert.are.equal("1. [ ] ", handler_utils.build_list_prefix("", "1.", " "))
+    end)
+
+    it("pads to the alignment block in shiftwidth mode", function()
+      shared.set_whitespace_config({ whitespace = "shiftwidth", whitespace_width = 4 })
+      assert.are.equal("1.  ", handler_utils.build_list_prefix("", "1.", nil))
+      assert.are.equal("-   ", handler_utils.build_list_prefix("", "-", nil))
+      -- Checkbox is part of the marker: "1. [ ]" (len 6) -> 2 pad spaces.
+      assert.are.equal("1. [ ]  ", handler_utils.build_list_prefix("", "1.", " "))
+    end)
+  end)
+
+  describe("renumber_ordered_lists", function()
+    it("keeps a single space after the marker in single mode", function()
+      shared.set_whitespace_config({ whitespace = "single", whitespace_width = 4 })
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "1. Alpha", "2. Beta" })
+      list.renumber_ordered_lists()
+      local result = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+      assert.are.equal("1. Alpha", result[1])
+      assert.are.equal("2. Beta", result[2])
+    end)
+
+    it("aligns content to the width block in shiftwidth mode", function()
+      shared.set_whitespace_config({ whitespace = "shiftwidth", whitespace_width = 4 })
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "1. Alpha", "2. Beta" })
+      list.renumber_ordered_lists()
+      local result = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+      assert.are.equal("1.  Alpha", result[1])
+      assert.are.equal("2.  Beta", result[2])
+    end)
+
+    it("does not collapse the user's aligned spacing on edit (issue #365)", function()
+      shared.set_whitespace_config({ whitespace = "shiftwidth", whitespace_width = 4 })
+      -- User typed content already aligned to a 4-space block.
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "1.  Item 1", "2.  Item 2" })
+      list.renumber_ordered_lists()
+      local result = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+      assert.are.equal("1.  Item 1", result[1])
+      assert.are.equal("2.  Item 2", result[2])
+    end)
+
+    it("collapses extra spacing back to single space in single mode", function()
+      shared.set_whitespace_config({ whitespace = "single", whitespace_width = 4 })
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "1.  Item 1", "2.  Item 2" })
+      list.renumber_ordered_lists()
+      local result = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+      assert.are.equal("1. Item 1", result[1])
+      assert.are.equal("2. Item 2", result[2])
+    end)
+  end)
+
+  -- Regression: renumber rewrites the cursor's line via nvim_buf_set_lines, which
+  -- keeps the cursor's absolute column. When the marker→content prefix grows or
+  -- shrinks, the cursor must follow its content character instead of drifting.
+  describe("cursor preservation on renumber", function()
+    it("keeps the cursor on the same content char when padding grows (shiftwidth)", function()
+      shared.set_whitespace_config({ whitespace = "shiftwidth", whitespace_width = 4 })
+      -- "1. Alpha" typed with one space; cursor on the final 'a' (col 7, 0-based).
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "1. Alpha" })
+      vim.api.nvim_win_set_cursor(0, { 1, 7 })
+
+      list.renumber_ordered_lists()
+
+      assert.are.equal("1.  Alpha", vim.api.nvim_get_current_line())
+      local cursor = vim.api.nvim_win_get_cursor(0)
+      assert.are.equal(8, cursor[2]) -- shifted right by the +1 pad
+      local line = vim.api.nvim_get_current_line()
+      assert.are.equal("a", line:sub(cursor[2] + 1, cursor[2] + 1))
+    end)
+
+    it("keeps the cursor on the same content char when spacing collapses (single)", function()
+      shared.set_whitespace_config({ whitespace = "single", whitespace_width = 4 })
+      -- "1.  First" typed with two spaces; cursor on 'F' (col 4, 0-based).
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "1.  First" })
+      vim.api.nvim_win_set_cursor(0, { 1, 4 })
+
+      list.renumber_ordered_lists()
+
+      assert.are.equal("1. First", vim.api.nvim_get_current_line())
+      local cursor = vim.api.nvim_win_get_cursor(0)
+      assert.are.equal(3, cursor[2]) -- shifted left by the -1 collapse
+      local line = vim.api.nvim_get_current_line()
+      assert.are.equal("F", line:sub(cursor[2] + 1, cursor[2] + 1))
+    end)
+
+    it("does not move the cursor when its line is unchanged", function()
+      shared.set_whitespace_config({ whitespace = "single", whitespace_width = 4 })
+      -- Line 1 is already correct; only line 2 needs renumbering.
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "1. Alpha", "5. Beta" })
+      vim.api.nvim_win_set_cursor(0, { 1, 6 }) -- on line 1 (unchanged)
+
+      list.renumber_ordered_lists()
+
+      assert.are.equal("2. Beta", vim.api.nvim_buf_get_lines(buf, 1, 2, false)[1])
+      assert.are.same({ 1, 6 }, vim.api.nvim_win_get_cursor(0))
+    end)
+
+    it("leaves the cursor in the prefix region without pushing it into content", function()
+      shared.set_whitespace_config({ whitespace = "shiftwidth", whitespace_width = 4 })
+      -- Cursor on the marker digit (col 0); padding grows after the marker.
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "1. Alpha" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+      list.renumber_ordered_lists()
+
+      assert.are.equal("1.  Alpha", vim.api.nvim_get_current_line())
+      assert.are.equal(0, vim.api.nvim_win_get_cursor(0)[2]) -- stays on the marker
+    end)
+  end)
+
+  describe("setup propagation", function()
+    it("wires whitespace config through the public setup() path", function()
+      require("markdown-plus").setup({ list = { whitespace = "shiftwidth", whitespace_width = 4 } })
+      assert.are.equal("  ", shared.spaces_after_marker("1."))
+      -- Restore defaults via the same public path.
+      require("markdown-plus").setup({})
+      assert.are.equal(" ", shared.spaces_after_marker("1."))
+    end)
+  end)
+end)


### PR DESCRIPTION
Adds a `list.whitespace` option so list marker→content spacing can align to a fixed-width block instead of always collapsing to one space (#365).

- `list.whitespace = "single"` (default, unchanged) or `"shiftwidth"`
- `list.whitespace_width` (default 4) sets the alignment block in shiftwidth mode
- Applied across renumber, auto-continue, indent/outdent, and toggle so spacing stays consistent
- Fixes cursor drift where the debounced renumber rewrote the current line and left the cursor a character behind
- Docs note that single-space-enforcing formatters (e.g. Prettier) override this on save

Tested by adding 26 specs and running `make check` — lint, format-check, and all 45 spec files pass. Also verified the cursor fix end-to-end through the live debounced autocmd.
