### PR TITLE
fix(list): defer <BS> to existing mappings via keymap fallback (#376)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,12 +12,12 @@
 - **Link management:** Insert, edit, convert inline/reference, auto-link URLs
 
 ### Architecture
-- `lua/markdown-plus/` - Core modules (74 Lua files across 14 directories):
+- `lua/markdown-plus/` - Core modules (81 Lua files across 14 directories):
   - Feature modules: list/, format/, headers/, links/, table/, footnotes/, callouts/, quote/, images/, code_block/, thematic_break/
   - Shared: utils/ (buffer, text, selection, element, html), treesitter/, config/
   - Root: init.lua, types.lua, utils.lua, keymap_helper.lua, health.lua
 - `plugin/markdown-plus.lua` - Entry point with lazy initialization guard
-- `spec/` - 38 Busted test suites
+- `spec/` - 45 Busted test suites
 - `doc/` - Vimdoc help files
 - `rockspecs/` - LuaRocks package specifications
 
@@ -26,7 +26,7 @@
 - **Linting:** .luacheckrc
 - **Formatting:** .stylua.toml
 - **Type checking:** .luarc.json (Lua 5.1 runtime)
-- **Testing:** Busted + Plenary (38 spec files, ~85% coverage)
+- **Testing:** Busted + Plenary (45 spec files, ~85% coverage)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 **Stack**: Lua 5.1 / Neovim 0.11+ / Zero dependencies
 **Architecture**: Feature-based modular plugin — 11 user-facing feature modules plus shared config/utils/treesitter infrastructure under `lua/markdown-plus/`
 **Entry points**: `plugin/markdown-plus.lua` (load guard) → `lua/markdown-plus/init.lua` (setup + orchestration)
-**Test command**: `make test` (Busted + plenary.nvim, 38 spec files)
+**Test command**: `make test` (Busted + plenary.nvim, 45 spec files)
 **Build command**: `make check` (lint + format-check + test)
 
 ## Commands
@@ -13,6 +13,7 @@
 ```bash
 make test              # Run all tests (plenary.nvim harness)
 make test-file FILE=spec/markdown-plus/list_spec.lua
+make test-coverage     # Coverage thresholds: 85% overall, 80% critical files
 make lint              # luacheck
 make format            # stylua (120 col, 2-space indent, double quotes)
 make format-check      # Check only
@@ -21,12 +22,12 @@ make check             # Full CI: lint + format-check + test
 
 ## Key Directories
 
-- `lua/markdown-plus/` — Core plugin code (74 Lua files across 14 module directories)
+- `lua/markdown-plus/` — Core plugin code (81 Lua files across 14 module directories)
 - `lua/markdown-plus/types.lua` — LuaCATS type definitions (update FIRST for new types)
 - `lua/markdown-plus/config/validate.lua` — Schema-based config validation
 - `lua/markdown-plus/utils.lua` — Shared utilities (cursor, line, buffer ops)
 - `lua/markdown-plus/keymap_helper.lua` — Centralized `<Plug>` + default keymap registration
-- `spec/markdown-plus/` — 38 Busted test suites
+- `spec/markdown-plus/` — 45 Busted test suites
 - `doc/markdown-plus.txt` — Vimdoc help file
 - `plugin/markdown-plus.lua` — Load guard (no logic here)
 
@@ -65,7 +66,7 @@ require("markdown-plus").setup(opts)
 
 - Framework: Busted via plenary.nvim (`spec/minimal_init.lua` bootstraps)
 - Pattern: `describe()`/`it()` blocks, buffer fixtures in `before_each`
-- 39 test files covering: config, utils, list (4 files: main + group_scanner/normal_handler/parser), format (3 files: main + escape/repeat), headers (6 files: main + manipulation/navigation + toc actions/render/state), links, smart_paste, table (7 files: main + cell_breaks/creator/cell_ops/column_ops/row_ops/row_mapper), footnotes (7 files: main + insertion/navigation/window/line_parser/query/scanner), callouts, health, treesitter, images (2 files: main + insertion), code_block, thematic_break, quote
+- 45 test files covering: config, utils, list (4 files: main + group_scanner/normal_handler/parser), format (3 files: main + escape/repeat), headers (6 files: main + manipulation/navigation + toc actions/render/state), links, smart_paste, table (7 files: main + cell_breaks/creator/cell_ops/column_ops/row_ops/row_mapper), footnotes (7 files: main + insertion/navigation/window/line_parser/query/scanner), callouts, health, treesitter, images (2 files: main + insertion), code_block, thematic_break, quote
 
 ## Don't
 

--- a/lua/markdown-plus/keymap_fallback.lua
+++ b/lua/markdown-plus/keymap_fallback.lua
@@ -1,0 +1,236 @@
+-- Keymap fallback for markdown-plus.nvim
+--
+-- markdown-plus installs buffer-local default keymaps for keys other plugins commonly
+-- own (`<BS>`, `<CR>`, `<Tab>`, ...). When a contextual handler decides "this is not my
+-- context", it must yield back to whatever mapping would have run otherwise instead of
+-- reimplementing the default behavior.
+--
+-- Resolution is lazy (performed on every keypress) so that plugins which map late —
+-- lazy-loaded on `InsertEnter`, for example — are still found after our FileType
+-- `enable()` has already run.
+
+local M = {}
+
+-- rhs of a mapping installed by this plugin; excluded from fallback resolution.
+-- Kept in sync with the teardown predicate in init.lua's clear_plugin_default_keymaps().
+local OUR_RHS_PATTERN = "^<Plug>%(MarkdownPlus[^)]+%)$"
+
+-- Keys whose fallback is currently executing, keyed by "<mode>:<lhs>".
+-- Excluding our `<Plug>` rhs is not sufficient on its own: a user (or a spec) may map a key
+-- straight to a markdown-plus handler function, in which case the resolved target is our own
+-- handler and invoking it would recurse. Re-entry therefore degrades to the raw key.
+--
+-- Scope: the guard covers the *synchronous* execution of a target only — it is released as
+-- soon as run() returns. It does not protect against a foreign remappable (`noremap == 0`)
+-- string rhs that expands to contain the same lhs, since those keys are consumed from the
+-- typeahead after the guard is gone. That is not reachable with the plugins this exists for
+-- (mini.pairs, nvim-cmp, blink.cmp all use expr or noremap mappings), and a depth counter
+-- would not help either: the re-entry happens in a later event-loop turn, not on our stack.
+local in_flight = {}
+
+-- Memoized `normalize()` results. Keyed by the raw lhs string; the set of distinct keys in
+-- play is tiny (our own defaults plus whatever the user has mapped), so this stays bounded.
+local normalized_cache = {}
+
+---A mapping that markdown-plus should defer to.
+---@class markdown-plus.FallbackTarget
+---@field callback? fun():any Lua mapping callback (preferred over `rhs` when present)
+---@field rhs? string String right-hand side, termcodes unexpanded
+---@field expr boolean Whether the mapping is an expression mapping
+---@field noremap boolean Whether fed keys must bypass further mapping resolution
+---@field replace_keycodes boolean Whether expr results need `nvim_replace_termcodes`
+
+---Normalize a keymap left-hand side to its internal byte representation for comparison
+---@param lhs string Left-hand side in any notation (e.g. "<BS>", "<F5>", "x")
+---@return string Normalized key sequence
+local function normalize(lhs)
+  local cached = normalized_cache[lhs]
+  if cached == nil then
+    cached = vim.api.nvim_replace_termcodes(lhs, true, true, true)
+    normalized_cache[lhs] = cached
+  end
+  return cached
+end
+
+---Check whether a mapping was installed by markdown-plus
+---@param mapping table Keymap entry from `nvim_get_keymap`/`nvim_buf_get_keymap`
+---@return boolean
+local function is_ours(mapping)
+  return type(mapping.rhs) == "string" and mapping.rhs:match(OUR_RHS_PATTERN) ~= nil
+end
+
+---Convert a raw keymap entry into a fallback target
+---@param mapping table Keymap entry from `nvim_get_keymap`/`nvim_buf_get_keymap`
+---@return markdown-plus.FallbackTarget
+local function to_target(mapping)
+  return {
+    callback = mapping.callback,
+    rhs = mapping.rhs,
+    expr = mapping.expr == 1,
+    noremap = mapping.noremap == 1,
+    replace_keycodes = mapping.replace_keycodes == 1,
+  }
+end
+
+---Find the first foreign mapping for `lhs` in a list of keymap entries
+---@param mappings table[] Keymap entries
+---@param lhs string Left-hand side to match
+---@return markdown-plus.FallbackTarget|nil
+local function find_foreign(mappings, lhs)
+  local wanted = normalize(lhs)
+  for _, mapping in ipairs(mappings) do
+    -- Exact compare first: keymap entries usually report the lhs in the same notation we
+    -- were called with, so most iterations avoid normalizing at all.
+    local candidate = mapping.lhs
+    if type(candidate) == "string" and (candidate == lhs or normalize(candidate) == wanted) then
+      if not is_ours(mapping) then
+        return to_target(mapping)
+      end
+    end
+  end
+  return nil
+end
+
+---Feed keys to Neovim without re-entering markdown-plus mappings unexpectedly.
+---Keys are inserted at the *front* of the typeahead ("i"), so the fallback completes before
+---any keys the user has already typed behind the one being handled.
+---
+---Trade-off: front-insertion splices our keys ahead of anything the target itself queued —
+---an expr callback that both returns keys *and* calls `nvim_feedkeys` would see the two
+---interleaved in the wrong order. Accepted: a well-behaved expr mapping returns its keys
+---rather than feeding them, and appending instead would reorder against real user input,
+---which is the more common and more visible failure.
+---@param keys string Key sequence with termcodes already expanded
+---@param noremap boolean Whether to bypass mapping resolution for the fed keys
+---@return nil
+local function feed(keys, noremap)
+  vim.api.nvim_feedkeys(keys, noremap and "ni" or "mi", false)
+end
+
+---Feed the literal `lhs` as a last resort when no target could be run
+---@param lhs string Left-hand side to feed
+---@return nil
+local function feed_raw(lhs)
+  feed(normalize(lhs), true)
+end
+
+---Report a fallback failure to the user
+---@param lhs string Left-hand side whose fallback failed
+---@param err any Error value from `pcall`
+---@return nil
+local function notify_failure(lhs, err)
+  vim.notify(
+    string.format("markdown-plus: fallback mapping for %s failed: %s", lhs, tostring(err)),
+    vim.log.levels.ERROR
+  )
+end
+
+---Resolve the current non-markdown-plus mapping for `(mode, lhs)` in the current buffer.
+---Resolution order: buffer-local mapping that is not ours → global mapping → nil.
+---@param mode string Mapping mode ("i", "n", ...)
+---@param lhs string Left-hand side (e.g. "<BS>")
+---@return markdown-plus.FallbackTarget|nil target Resolved target, or nil when none exists
+function M.resolve(mode, lhs)
+  local ok, buf_maps = pcall(vim.api.nvim_buf_get_keymap, 0, mode)
+  if ok then
+    local target = find_foreign(buf_maps, lhs)
+    if target then
+      return target
+    end
+  end
+
+  local global_ok, global_maps = pcall(vim.api.nvim_get_keymap, mode)
+  if global_ok then
+    return find_foreign(global_maps, lhs)
+  end
+
+  return nil
+end
+
+---Execute the keys produced by an expr mapping
+---@param result any Value returned by the expr callback or expression
+---@param target markdown-plus.FallbackTarget Resolved target
+---@return nil
+local function feed_expr_result(result, target)
+  if type(result) ~= "string" or result == "" then
+    return
+  end
+  local keys = target.replace_keycodes and vim.api.nvim_replace_termcodes(result, true, true, true) or result
+  feed(keys, target.noremap)
+end
+
+---Run a Lua callback target
+---@param target markdown-plus.FallbackTarget Resolved target
+---@param lhs string Left-hand side, used for error reporting and the raw-key fallback
+---@return nil
+local function run_callback(target, lhs)
+  local ok, result = pcall(target.callback)
+  if not ok then
+    notify_failure(lhs, result)
+    feed_raw(lhs)
+    return
+  end
+  if target.expr then
+    feed_expr_result(result, target)
+  end
+end
+
+---Run a string-rhs target
+---@param target markdown-plus.FallbackTarget Resolved target
+---@param lhs string Left-hand side, used for error reporting and the raw-key fallback
+---@return nil
+local function run_rhs(target, lhs)
+  if target.expr then
+    local ok, result = pcall(vim.api.nvim_eval, target.rhs)
+    if not ok then
+      notify_failure(lhs, result)
+      feed_raw(lhs)
+      return
+    end
+    feed_expr_result(result, target)
+    return
+  end
+
+  -- `from_part = false` here: an rhs is a full key sequence, unlike an lhs, where
+  -- `normalize()` passes `from_part = true` to keep partial-key semantics for comparison.
+  feed(vim.api.nvim_replace_termcodes(target.rhs, true, false, true), target.noremap)
+end
+
+---Execute the mapping markdown-plus is deferring to, or feed the raw key when there is none.
+---The resolved target is executed directly — `lhs` is never re-fed through mapping
+---resolution — so this can never recurse back into our own buffer-local default.
+---@param mode string Mapping mode ("i", "n", ...)
+---@param lhs string Left-hand side (e.g. "<BS>")
+---@return nil
+function M.run(mode, lhs)
+  local guard_key = mode .. ":" .. lhs
+  if in_flight[guard_key] then
+    feed_raw(lhs)
+    return
+  end
+
+  local target = M.resolve(mode, lhs)
+
+  if not target then
+    feed_raw(lhs)
+    return
+  end
+
+  in_flight[guard_key] = true
+  local ok, err = pcall(function()
+    if target.callback then
+      run_callback(target, lhs)
+    elseif type(target.rhs) == "string" and target.rhs ~= "" then
+      run_rhs(target, lhs)
+    else
+      feed_raw(lhs)
+    end
+  end)
+  in_flight[guard_key] = nil
+
+  if not ok then
+    notify_failure(lhs, err)
+  end
+end
+
+return M

--- a/lua/markdown-plus/list/normal_handler.lua
+++ b/lua/markdown-plus/list/normal_handler.lua
@@ -3,6 +3,7 @@ local utils = require("markdown-plus.utils")
 local parser = require("markdown-plus.list.parser")
 local shared = require("markdown-plus.list.shared")
 local handler_utils = require("markdown-plus.list.handler_utils")
+local keymap_fallback = require("markdown-plus.keymap_fallback")
 
 local M = {}
 
@@ -14,23 +15,12 @@ function M.set_config(cfg) -- luacheck: no unused args
   -- This stub keeps the set_config interface uniform across all handler sub-modules.
 end
 
----Delete the character before the cursor (UTF-8 safe)
----@param line string Current line content
----@param row number Current row (1-indexed)
----@param col number Current column (0-indexed byte offset)
----@return nil
-local function delete_prev_char(line, row, col)
-  local char_idx = vim.fn.charidx(line, col)
-  local prev_char_idx = char_idx - 1
-  if prev_char_idx < 0 then
-    return
-  end
-  local new_col = vim.fn.byteidx(line, prev_char_idx)
-  vim.api.nvim_buf_set_text(0, row - 1, new_col, row - 1, col, { "" })
-  utils.set_cursor(row, new_col)
-end
-
 ---Handle Backspace key
+---
+---Outside of list-marker context this yields to whatever `<BS>` mapping would otherwise
+---have run (mini.pairs and friends), falling back to Neovim's own backspace when there is
+---none. Reimplementing deletion here would clobber those mappings and `'backspace'`
+---semantics.
 ---@return nil
 function M.handle_backspace()
   local current_line = utils.get_current_line()
@@ -41,16 +31,7 @@ function M.handle_backspace()
   local list_info = parser.parse_list_line(current_line, row)
 
   if not list_info then
-    -- Not in a list, default backspace behavior
-    if col > 0 then
-      delete_prev_char(current_line, row, col)
-    elseif row > 1 then
-      -- At start of line, join with previous line
-      local prev_line = utils.get_line(row - 1)
-      local joined_line = prev_line .. current_line
-      vim.api.nvim_buf_set_lines(0, row - 2, row, false, { joined_line })
-      utils.set_cursor(row - 1, #prev_line)
-    end
+    keymap_fallback.run("i", "<BS>")
     return
   end
 
@@ -64,10 +45,8 @@ function M.handle_backspace()
     return
   end
 
-  -- Default backspace in list content
-  if col > 0 then
-    delete_prev_char(current_line, row, col)
-  end
+  -- Inside list content: defer so pairs/completion plugins keep working there too
+  keymap_fallback.run("i", "<BS>")
 end
 
 ---Check whether the given row is the last list item at its indentation level

--- a/spec/helpers/insert_mode.lua
+++ b/spec/helpers/insert_mode.lua
@@ -1,0 +1,96 @@
+---Insert-mode simulation helpers for specs.
+---
+---Handlers that yield to `keymap_fallback` queue keys via `nvim_feedkeys` instead of
+---editing the buffer directly, so their effect is only observable once the typeahead is
+---flushed from a real insert-mode session. These helpers drive that session and capture
+---buffer state *before* insert mode exits, so cursor assertions stay meaningful (leaving
+---insert mode shifts the cursor one column left).
+local M = {}
+
+---@class markdown-plus.spec.InsertResult
+---@field lines string[] Buffer lines captured while still in insert mode
+---@field cursor integer[] `{ row, col }` captured while still in insert mode
+
+---@type markdown-plus.spec.InsertResult|nil
+local captured
+
+---Capture the current buffer state; invoked from a `<Cmd>` mapping mid-insert.
+---@return nil
+function M.__capture()
+  captured = {
+    lines = vim.api.nvim_buf_get_lines(0, 0, -1, false),
+    cursor = vim.api.nvim_win_get_cursor(0),
+  }
+end
+
+---Compute the keys needed to enter insert mode with the cursor at `col`.
+---@param line string Line contents
+---@param col integer 0-indexed byte column for the insert cursor
+---@return string enter_key Key that enters insert mode ("i" or "a")
+---@return integer normal_col 0-indexed byte column to place the normal-mode cursor on
+local function insert_entry(line, col)
+  if #line > 0 and col >= #line then
+    -- Past the last byte: sit on the final character and append after it
+    local last_char_idx = vim.fn.charidx(line, #line - 1)
+    return "a", vim.fn.byteidx(line, last_char_idx)
+  end
+  return "i", col
+end
+
+---Press `keys` in insert mode with the cursor at (row, col) and return the resulting state.
+---@param keys string Keys to press once insert mode is entered (e.g. "<BS>")
+---@param row integer 1-indexed row for the insert cursor
+---@param col integer 0-indexed byte column for the insert cursor
+---@return markdown-plus.spec.InsertResult
+function M.press(keys, row, col)
+  -- Backspace behavior across line starts and the insert-start boundary depends on
+  -- 'backspace'. Pin it so specs do not inherit whatever the ambient config happens to set.
+  vim.o.backspace = "indent,eol,start"
+
+  local line = vim.api.nvim_buf_get_lines(0, row - 1, row, false)[1] or ""
+  local enter_key, normal_col = insert_entry(line, col)
+
+  vim.api.nvim_win_set_cursor(0, { row, normal_col })
+
+  captured = nil
+  local sequence = enter_key .. keys .. '<Cmd>lua require("spec.helpers.insert_mode").__capture()<CR><Esc>'
+  vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(sequence, true, false, true), "x", false)
+
+  return captured
+    or {
+      lines = vim.api.nvim_buf_get_lines(0, 0, -1, false),
+      cursor = vim.api.nvim_win_get_cursor(0),
+    }
+end
+
+---Install a buffer-local `<BS>` default the way `keymap_helper` does in production:
+---the buffer-local mapping targets a `<Plug>` rhs, which `keymap_fallback` recognizes as
+---ours and skips when resolving a fallback.
+---@param handler fun() Handler invoked by the `<Plug>` mapping
+---@param bufnr? integer Buffer to map in (defaults to the current buffer)
+---@return nil
+function M.map_backspace_default(handler, bufnr)
+  vim.keymap.set("i", "<Plug>(MarkdownPlusListBackspace)", handler, { silent = true })
+  vim.keymap.set("i", "<BS>", "<Plug>(MarkdownPlusListBackspace)", { buffer = bufnr or 0 })
+end
+
+---Remove the mappings installed by `map_backspace_default`.
+---The `<Plug>` mapping is global and overwrites the real one registered by
+---`list/keymaps.lua` (which wraps the handler in `skip_in_codeblock`), so leaving it behind
+---would leak into every later spec in the same Neovim instance.
+---@param bufnr? integer Buffer the default was mapped in (defaults to the current buffer)
+---@return nil
+function M.unmap_backspace_default(bufnr)
+  pcall(vim.keymap.del, "i", "<BS>", { buffer = bufnr or 0 })
+  pcall(vim.keymap.del, "i", "<Plug>(MarkdownPlusListBackspace)")
+end
+
+---Press `<BS>` in insert mode with the cursor at (row, col).
+---@param row integer 1-indexed row for the insert cursor
+---@param col integer 0-indexed byte column for the insert cursor
+---@return markdown-plus.spec.InsertResult
+function M.backspace(row, col)
+  return M.press("<BS>", row, col)
+end
+
+return M

--- a/spec/markdown-plus/keymap_fallback_spec.lua
+++ b/spec/markdown-plus/keymap_fallback_spec.lua
@@ -1,0 +1,233 @@
+---Test suite for markdown-plus.nvim keymap_fallback
+---Tests lazy resolution of foreign (non-markdown-plus) mappings and their execution.
+---@diagnostic disable: undefined-field
+local fallback = require("markdown-plus.keymap_fallback")
+
+---Feed pending typeahead so queued nvim_feedkeys calls are actually executed
+---@return nil
+local function flush()
+  vim.api.nvim_feedkeys("", "x", false)
+end
+
+---Delete a mapping if it exists, ignoring "no such mapping" errors
+---@param mode string
+---@param lhs string
+---@param opts? table
+---@return nil
+local function unmap(mode, lhs, opts)
+  pcall(vim.keymap.del, mode, lhs, opts)
+end
+
+describe("markdown-plus keymap_fallback", function()
+  before_each(function()
+    vim.cmd("enew")
+    vim.bo.filetype = "markdown"
+  end)
+
+  after_each(function()
+    unmap("n", "<F5>")
+    unmap("n", "<F6>")
+    unmap("i", "<F5>")
+    unmap("n", "x")
+    unmap("n", "<F5>", { buffer = true })
+    unmap("i", "<BS>", { buffer = true })
+    unmap("i", "<BS>")
+    vim.cmd("bdelete!")
+  end)
+
+  describe("resolve", function()
+    it("returns nil when no mapping exists", function()
+      assert.is_nil(fallback.resolve("n", "<F5>"))
+    end)
+
+    it("resolves a global string rhs mapping", function()
+      vim.keymap.set("n", "<F5>", "ix<Esc>")
+      local target = fallback.resolve("n", "<F5>")
+      assert.is_not_nil(target)
+      assert.are.equal("ix<Esc>", target.rhs)
+      assert.is_nil(target.callback)
+      assert.is_false(target.expr)
+      assert.is_true(target.noremap)
+    end)
+
+    it("resolves a global Lua callback mapping", function()
+      vim.keymap.set("n", "<F5>", function() end)
+      local target = fallback.resolve("n", "<F5>")
+      assert.is_not_nil(target)
+      assert.are.equal("function", type(target.callback))
+      assert.is_false(target.expr)
+    end)
+
+    it("resolves a global expr callback with replace_keycodes enabled", function()
+      vim.keymap.set("i", "<F5>", function()
+        return "<BS>"
+      end, { expr = true, replace_keycodes = true })
+      local target = fallback.resolve("i", "<F5>")
+      assert.is_not_nil(target)
+      assert.is_true(target.expr)
+      assert.is_true(target.replace_keycodes)
+    end)
+
+    it("resolves a global expr callback with replace_keycodes disabled", function()
+      vim.keymap.set("i", "<F5>", function()
+        return "x"
+      end, { expr = true, replace_keycodes = false })
+      local target = fallback.resolve("i", "<F5>")
+      assert.is_not_nil(target)
+      assert.is_true(target.expr)
+      assert.is_false(target.replace_keycodes)
+    end)
+
+    it("prefers a buffer-local foreign mapping over a global one", function()
+      vim.keymap.set("n", "<F5>", "iglobal<Esc>")
+      vim.keymap.set("n", "<F5>", "ibuffer<Esc>", { buffer = true })
+      local target = fallback.resolve("n", "<F5>")
+      assert.is_not_nil(target)
+      assert.are.equal("ibuffer<Esc>", target.rhs)
+    end)
+
+    it("excludes our own buffer-local <Plug>(MarkdownPlus...) default", function()
+      vim.keymap.set("n", "<F5>", "iglobal<Esc>")
+      vim.keymap.set("n", "<F5>", "<Plug>(MarkdownPlusListBackspace)", { buffer = true })
+      local target = fallback.resolve("n", "<F5>")
+      assert.is_not_nil(target)
+      assert.are.equal("iglobal<Esc>", target.rhs)
+    end)
+
+    it("returns nil when the only mapping is our own default", function()
+      vim.keymap.set("n", "<F5>", "<Plug>(MarkdownPlusListBackspace)", { buffer = true })
+      assert.is_nil(fallback.resolve("n", "<F5>"))
+    end)
+
+    it("resolves lazily so mappings created after the first lookup are found", function()
+      assert.is_nil(fallback.resolve("n", "<F5>"))
+      vim.keymap.set("n", "<F5>", "ilate<Esc>")
+      local target = fallback.resolve("n", "<F5>")
+      assert.is_not_nil(target)
+      assert.are.equal("ilate<Esc>", target.rhs)
+    end)
+  end)
+
+  describe("run", function()
+    it("invokes a resolved Lua callback", function()
+      local called = false
+      vim.keymap.set("n", "<F5>", function()
+        called = true
+      end)
+      fallback.run("n", "<F5>")
+      assert.is_true(called)
+    end)
+
+    it("feeds keys returned by an expr callback", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "" })
+      vim.keymap.set("n", "<F5>", function()
+        return "ihi<Esc>"
+      end, { expr = true })
+      fallback.run("n", "<F5>")
+      flush()
+      assert.are.equal("hi", vim.api.nvim_buf_get_lines(0, 0, 1, false)[1])
+    end)
+
+    it("replaces keycodes in expr results when replace_keycodes is set", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "" })
+      vim.keymap.set("n", "<F5>", function()
+        return "ihi<Esc>"
+      end, { expr = true, replace_keycodes = true })
+      fallback.run("n", "<F5>")
+      flush()
+      assert.are.equal("hi", vim.api.nvim_buf_get_lines(0, 0, 1, false)[1])
+    end)
+
+    it("feeds a string rhs", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "" })
+      vim.keymap.set("n", "<F5>", "ix<Esc>")
+      fallback.run("n", "<F5>")
+      flush()
+      assert.are.equal("x", vim.api.nvim_buf_get_lines(0, 0, 1, false)[1])
+    end)
+
+    it("feeds a remappable rhs so nested mappings still fire", function()
+      local nested = false
+      vim.keymap.set("n", "<F6>", function()
+        nested = true
+      end)
+      vim.keymap.set("n", "<F5>", "<F6>", { remap = true })
+      fallback.run("n", "<F5>")
+      flush()
+      assert.is_true(nested)
+    end)
+
+    it("feeds a noremap rhs without resolving nested mappings", function()
+      local nested = false
+      vim.keymap.set("n", "<F6>", function()
+        nested = true
+      end)
+      vim.keymap.set("n", "<F5>", "<F6>")
+      fallback.run("n", "<F5>")
+      flush()
+      assert.is_false(nested)
+    end)
+
+    it("feeds the raw key when no mapping is resolved", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "abc" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      fallback.run("n", "x")
+      flush()
+      assert.are.equal("bc", vim.api.nvim_buf_get_lines(0, 0, 1, false)[1])
+    end)
+
+    it("notifies and does not throw when a callback errors", function()
+      local original_notify = vim.notify
+      local messages = {}
+      vim.notify = function(msg, level)
+        table.insert(messages, { msg = msg, level = level })
+      end
+
+      vim.keymap.set("n", "<F5>", function()
+        error("boom")
+      end)
+
+      local ok = pcall(fallback.run, "n", "<F5>")
+      vim.notify = original_notify
+
+      assert.is_true(ok)
+      assert.are.equal(1, #messages)
+      assert.is_truthy(messages[1].msg:match("^markdown%-plus:"))
+      assert.are.equal(vim.log.levels.ERROR, messages[1].level)
+    end)
+
+    it("does not recurse when the resolved target feeds the same key back", function()
+      local count = 0
+      vim.keymap.set("n", "<F5>", function()
+        count = count + 1
+        return "<F5>"
+      end, { expr = true, replace_keycodes = true })
+
+      fallback.run("n", "<F5>")
+      flush()
+
+      -- The expr target is noremap, so the fed <F5> is not resolved through
+      -- mappings again — the callback must run exactly once.
+      assert.are.equal(1, count)
+    end)
+
+    it("degrades to the raw key when the resolved target calls run for the same key", function()
+      -- A user may map a key straight to a markdown-plus handler, making the resolved
+      -- target our own handler. Re-entry must feed the raw key instead of recursing.
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "abc" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+      local count = 0
+      vim.keymap.set("n", "x", function()
+        count = count + 1
+        fallback.run("n", "x")
+      end)
+
+      fallback.run("n", "x")
+      flush()
+
+      assert.are.equal(1, count)
+      assert.are.equal("bc", vim.api.nvim_buf_get_lines(0, 0, 1, false)[1])
+    end)
+  end)
+end)

--- a/spec/markdown-plus/list_normal_handler_spec.lua
+++ b/spec/markdown-plus/list_normal_handler_spec.lua
@@ -3,6 +3,7 @@
 ---@diagnostic disable: undefined-field
 local normal_handler = require("markdown-plus.list.normal_handler")
 local list = require("markdown-plus.list")
+local insert_mode = require("spec.helpers.insert_mode")
 
 describe("markdown-plus list normal_handler", function()
   before_each(function()
@@ -25,24 +26,26 @@ describe("markdown-plus list normal_handler", function()
   end)
 
   describe("handle_backspace", function()
+    -- Outside list context the handler no longer reimplements deletion; it defers to
+    -- `keymap_fallback`, which queues keys. These cases therefore drive a real insert-mode
+    -- session so the queued keys are flushed and their effect is observable.
+    after_each(function()
+      insert_mode.unmap_backspace_default()
+    end)
+
     it("on non-list line deletes char", function()
       vim.api.nvim_buf_set_lines(0, 0, -1, false, { "hello" })
-      -- Enter insert mode so cursor can sit past the last char (col 5)
-      vim.cmd("startinsert!")
-      vim.api.nvim_win_set_cursor(0, { 1, 5 })
-      normal_handler.handle_backspace()
-      vim.cmd("stopinsert")
-      local line = vim.api.nvim_buf_get_lines(0, 0, 1, false)[1]
-      assert.are.equal("hell", line)
+      insert_mode.map_backspace_default(normal_handler.handle_backspace)
+      local result = insert_mode.backspace(1, 5)
+      assert.are.equal("hell", result.lines[1])
     end)
 
     it("at start of non-list line joins with previous", function()
       vim.api.nvim_buf_set_lines(0, 0, -1, false, { "first", "second" })
-      vim.api.nvim_win_set_cursor(0, { 2, 0 })
-      normal_handler.handle_backspace()
-      local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
-      assert.are.equal(1, #lines)
-      assert.are.equal("firstsecond", lines[1])
+      insert_mode.map_backspace_default(normal_handler.handle_backspace)
+      local result = insert_mode.backspace(2, 0)
+      assert.are.equal(1, #result.lines)
+      assert.are.equal("firstsecond", result.lines[1])
     end)
 
     it("removes list marker", function()
@@ -51,6 +54,62 @@ describe("markdown-plus list normal_handler", function()
       normal_handler.handle_backspace()
       local line = vim.api.nvim_buf_get_lines(0, 0, 1, false)[1]
       assert.are.equal("item", line)
+    end)
+  end)
+
+  describe("handle_backspace fallback to foreign mappings", function()
+    -- Simulates a mini.pairs-style global insert-mode `<BS>` mapping installed before
+    -- markdown-plus shadows `<BS>` with its buffer-local default.
+    local fired
+
+    before_each(function()
+      fired = false
+      vim.keymap.set("i", "<BS>", function()
+        fired = true
+        return "<BS>"
+      end, { expr = true, replace_keycodes = true })
+    end)
+
+    after_each(function()
+      pcall(vim.keymap.del, "i", "<BS>")
+    end)
+
+    it("invokes the foreign mapping when the cursor is not in a list", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "plain text" })
+      vim.api.nvim_win_set_cursor(0, { 1, 5 })
+      normal_handler.handle_backspace()
+      assert.is_true(fired)
+    end)
+
+    it("invokes the foreign mapping inside list item content", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "- item text" })
+      vim.api.nvim_win_set_cursor(0, { 1, 8 })
+      normal_handler.handle_backspace()
+      assert.is_true(fired)
+    end)
+
+    it("removes the list marker without invoking the foreign mapping", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "- item" })
+      vim.api.nvim_win_set_cursor(0, { 1, 2 })
+      normal_handler.handle_backspace()
+      assert.are.equal("item", vim.api.nvim_buf_get_lines(0, 0, 1, false)[1])
+      assert.is_false(fired)
+    end)
+
+    it("empties an empty list item marker without invoking the foreign mapping", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "- " })
+      vim.api.nvim_win_set_cursor(0, { 1, 2 })
+      normal_handler.handle_backspace()
+      assert.are.equal("", vim.api.nvim_buf_get_lines(0, 0, 1, false)[1])
+      assert.is_false(fired)
+    end)
+
+    it("ignores our own buffer-local default when resolving the fallback", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "plain text" })
+      vim.keymap.set("i", "<BS>", "<Plug>(MarkdownPlusListBackspace)", { buffer = true })
+      vim.api.nvim_win_set_cursor(0, { 1, 5 })
+      normal_handler.handle_backspace()
+      assert.is_true(fired)
     end)
   end)
 

--- a/spec/markdown-plus/list_spec.lua
+++ b/spec/markdown-plus/list_spec.lua
@@ -2,6 +2,7 @@
 ---Tests list parsing, empty list detection, and list continuation
 ---@diagnostic disable: undefined-field
 local list = require("markdown-plus.list")
+local insert_mode = require("spec.helpers.insert_mode")
 
 describe("markdown-plus list management", function()
   local buf
@@ -1832,117 +1833,95 @@ describe("markdown-plus list management", function()
 
   describe("unicode character handling", function()
     describe("handle_backspace with multi-byte characters", function()
+      -- Outside list-marker context `handle_backspace` now defers to `keymap_fallback`,
+      -- which queues keys rather than editing the buffer directly. These cases therefore
+      -- drive a real insert-mode session through the buffer-local `<BS>` mapping so the
+      -- queued keys are flushed; UTF-8 correctness is now Neovim's own backspace behavior.
+      before_each(function()
+        insert_mode.map_backspace_default(list.handle_backspace, buf)
+      end)
+
+      after_each(function()
+        insert_mode.unmap_backspace_default(buf)
+      end)
+
       it("deletes multi-byte CJK character (Chinese period) in non-list line", function()
         vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "Test。item" })
         -- Position cursor after the Chinese period character (3 bytes: E3 80 82)
-        vim.api.nvim_win_set_cursor(0, { 1, 7 }) -- After "Test。"
-        list.handle_backspace()
-        local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-        assert.are.equal("Testitem", lines[1])
+        local result = insert_mode.backspace(1, 7) -- After "Test。"
+        assert.are.equal("Testitem", result.lines[1])
       end)
 
       it("deletes multi-byte CJK character in list content", function()
         vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "- Test。item" })
-        -- Position cursor after the Chinese period character
-        vim.api.nvim_win_set_cursor(0, { 1, 9 }) -- After "- Test。"
-        list.handle_backspace()
-        local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-        assert.are.equal("- Testitem", lines[1])
+        local result = insert_mode.backspace(1, 9) -- After "- Test。"
+        assert.are.equal("- Testitem", result.lines[1])
       end)
 
       it("deletes emoji (4-byte UTF-8) in non-list line", function()
         vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "Test🎉item" })
         -- Position cursor after the emoji (4 bytes: F0 9F 8E 89)
-        vim.api.nvim_win_set_cursor(0, { 1, 8 }) -- After "Test🎉"
-        list.handle_backspace()
-        local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-        assert.are.equal("Testitem", lines[1])
+        local result = insert_mode.backspace(1, 8) -- After "Test🎉"
+        assert.are.equal("Testitem", result.lines[1])
       end)
 
       it("deletes emoji in list content", function()
         vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "- Test🎉item" })
-        -- Position cursor after the emoji
-        vim.api.nvim_win_set_cursor(0, { 1, 10 }) -- After "- Test🎉"
-        list.handle_backspace()
-        local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-        assert.are.equal("- Testitem", lines[1])
+        local result = insert_mode.backspace(1, 10) -- After "- Test🎉"
+        assert.are.equal("- Testitem", result.lines[1])
       end)
 
       it("deletes multi-byte character in ordered list", function()
         vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "1. Test。item" })
-        -- Position cursor after the Chinese period
-        vim.api.nvim_win_set_cursor(0, { 1, 10 }) -- After "1. Test。"
-        list.handle_backspace()
-        local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-        assert.are.equal("1. Testitem", lines[1])
+        local result = insert_mode.backspace(1, 10) -- After "1. Test。"
+        assert.are.equal("1. Testitem", result.lines[1])
       end)
 
       it("deletes multi-byte character in checkbox list", function()
         vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "- [ ] Test。item" })
-        -- Position cursor after the Chinese period
-        vim.api.nvim_win_set_cursor(0, { 1, 13 }) -- After "- [ ] Test。"
-        list.handle_backspace()
-        local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-        assert.are.equal("- [ ] Testitem", lines[1])
+        local result = insert_mode.backspace(1, 13) -- After "- [ ] Test。"
+        assert.are.equal("- [ ] Testitem", result.lines[1])
       end)
 
       it("deletes accented character (2-byte UTF-8) in list", function()
         vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "- Caféx" })
-        -- Position cursor after é, before x (2 bytes: C3 A9)
         -- "- Caféx" = "- " (2) + "Caf" (3) + "é" (2) + "x" (1) = 8 bytes total
-        vim.api.nvim_win_set_cursor(0, { 1, 7 }) -- After "- Café", before "x"
-        list.handle_backspace()
-        local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-        assert.are.equal("- Cafx", lines[1])
-        local cursor = vim.api.nvim_win_get_cursor(0)
-        assert.are.equal(5, cursor[2]) -- After "- Caf"
+        local result = insert_mode.backspace(1, 7) -- After "- Café", before "x"
+        assert.are.equal("- Cafx", result.lines[1])
+        assert.are.equal(5, result.cursor[2]) -- After "- Caf"
       end)
 
       it("deletes multiple multi-byte characters sequentially", function()
         vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "- 你好世界x" })
         -- Each Chinese character is 3 bytes: "- " (2) + 4 chars * 3 bytes + "x" = 15 bytes
-        vim.api.nvim_win_set_cursor(0, { 1, 14 }) -- After "- 你好世界", before "x"
-        list.handle_backspace() -- Delete 界
-        local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-        assert.are.equal("- 你好世x", lines[1])
-        local cursor = vim.api.nvim_win_get_cursor(0)
-        assert.are.equal(11, cursor[2]) -- After "- 你好世" (2 + 9)
+        local result = insert_mode.backspace(1, 14) -- Delete 界
+        assert.are.equal("- 你好世x", result.lines[1])
+        assert.are.equal(11, result.cursor[2]) -- After "- 你好世" (2 + 9)
 
-        list.handle_backspace() -- Delete 世 (cursor already positioned)
-        lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-        assert.are.equal("- 你好x", lines[1])
-        cursor = vim.api.nvim_win_get_cursor(0)
-        assert.are.equal(8, cursor[2]) -- After "- 你好" (2 + 6)
+        result = insert_mode.backspace(1, result.cursor[2]) -- Delete 世
+        assert.are.equal("- 你好x", result.lines[1])
+        assert.are.equal(8, result.cursor[2]) -- After "- 你好" (2 + 6)
       end)
 
       it("handles backspace at start of line with multi-byte characters", function()
         vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "First", "Second" })
-        -- Position cursor at start of second line
-        vim.api.nvim_win_set_cursor(0, { 2, 0 })
-        list.handle_backspace()
-        local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-        assert.are.equal("FirstSecond", lines[1])
-        assert.are.equal(1, #lines) -- Lines should be joined
-        local cursor = vim.api.nvim_win_get_cursor(0)
-        assert.are.equal(5, cursor[2]) -- After "First"
+        local result = insert_mode.backspace(2, 0)
+        assert.are.equal("FirstSecond", result.lines[1])
+        assert.are.equal(1, #result.lines) -- Lines should be joined
+        assert.are.equal(5, result.cursor[2]) -- After "First"
       end)
 
       it("does not delete before start of line", function()
         vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "Test。" })
-        -- Position cursor at start
-        vim.api.nvim_win_set_cursor(0, { 1, 0 })
-        list.handle_backspace()
-        local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-        assert.are.equal("Test。", lines[1]) -- Should remain unchanged
+        local result = insert_mode.backspace(1, 0)
+        assert.are.equal("Test。", result.lines[1]) -- Should remain unchanged
       end)
 
       it("positions cursor correctly after deleting multi-byte character", function()
         vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "- Test。item" })
-        vim.api.nvim_win_set_cursor(0, { 1, 9 }) -- After "- Test。"
-        list.handle_backspace()
-        local cursor = vim.api.nvim_win_get_cursor(0)
-        assert.are.equal(1, cursor[1]) -- Same line
-        assert.are.equal(6, cursor[2]) -- After "- Test" (before where 。 was)
+        local result = insert_mode.backspace(1, 9) -- After "- Test。"
+        assert.are.equal(1, result.cursor[1]) -- Same line
+        assert.are.equal(6, result.cursor[2]) -- After "- Test" (before where 。 was)
       end)
     end)
   end)


### PR DESCRIPTION
## Summary

Fixes #376 as reported: the plugin's insert-mode `<BS>` keymap clobbered mini.pairs (and any other plugin/user `<BS>` mapping). This PR introduces a `keymap_fallback` module and wires `<BS>` through it — the first layer of a 4-PR stack that fixes the whole shared-key surface.

## Changes

- **New `lua/markdown-plus/keymap_fallback.lua`**: when a contextual handler decides "not my context", it defers to whatever mapping would otherwise have run:
  - `resolve(mode, lhs)` — lazy, per-keypress resolution (buffer-local non-ours → global → nil), so lazy-loaded plugins (`InsertEnter`) are still found
  - `run(mode, lhs)` — executes the resolved target directly: Lua callbacks are `pcall`'d, `expr` results fed with `replace_keycodes` honored, string rhs fed respecting `noremap`; errors notify with a `markdown-plus:` prefix and degrade to the raw key
  - re-entrancy guard so a key mapped straight at our own handler cannot recurse
- **`list/normal_handler.lua`**: `handle_backspace()` non-list and in-list-content branches now defer via the fallback instead of hand-rolling deletion; list-marker removal is unchanged
- **New `spec/helpers/insert_mode.lua`**: drives real insert-mode key bursts (synchronous `feedkeys` `"x"` flag) so specs exercise the actual mapping chain
- 24 new specs (fallback unit + `<BS>` interop)

## Behavior notes

- mini.pairs-style paired deletion works again outside lists **and inside list content**
- `'backspace'` option is now honored; `<BS>` at column 0 of a list line joins lines (native behavior — was a silent no-op)
- Docs-count corrections to the project instruction files ride along in a separate commit

## Test plan

- [x] `make check` green (lint + format-check + full suite)
- [x] 1499 passing / 0 failed (baseline 1475, +24)
- [x] Manual testing: 18-case guide covering marker removal, pairs interop, unicode, nested lists, lazy-loaded mappings, erroring foreign mappings
