### PR TITLE
fix(list): defer normal-mode o/O to existing mappings with count support (#376)

### DIFF
--- a/lua/markdown-plus/keymap_fallback.lua
+++ b/lua/markdown-plus/keymap_fallback.lua
@@ -61,6 +61,12 @@ local normalized_cache = {}
 ---@field noremap boolean Whether fed keys must bypass further mapping resolution
 ---@field replace_keycodes boolean Whether expr results need `nvim_replace_termcodes`
 
+---Optional behavior overrides for `M.run`.
+---@class markdown-plus.FallbackOpts
+---@field count? integer Normal-mode count (`v:count1`) to re-apply to the keys the fallback
+---feeds — the resolved target's own keys, or the raw key when it degrades. Pass only from
+---normal-mode handlers that have not acted on the count themselves.
+
 ---Normalize a keymap left-hand side to its internal byte representation for comparison
 ---@param lhs string Left-hand side in any notation (e.g. "<BS>", "<F5>", "x")
 ---@return string Normalized key sequence
@@ -167,11 +173,18 @@ local function feed(keys, noremap)
   vim.api.nvim_feedkeys(keys, noremap and "ni" or "mi", false)
 end
 
----Feed the literal `lhs` as a last resort when no target could be run
+---Feed the literal `lhs` as a last resort when no target could be run.
+---
+---A normal-mode count is consumed by *our* mapping, so feeding the bare key would drop it and
+---turn `3o` into a single open-line. Re-prefixing the digits restores the native behavior.
+---Only callers that know the count is still unspent pass one: on the error path a foreign target
+---may already have acted on it, and re-applying would double it.
 ---@param lhs string Left-hand side to feed
+---@param count? integer Normal-mode count to re-apply; ignored when nil or 1
 ---@return nil
-local function feed_raw(lhs)
-  feed(normalize(lhs), true)
+local function feed_raw(lhs, count)
+  local prefix = (count and count > 1) and tostring(count) or ""
+  feed(prefix .. normalize(lhs), true)
 end
 
 ---Feed keys produced by a *remappable* target, applying Vim's own recursion rule.
@@ -201,18 +214,31 @@ local function feed_mapped(keys, lhs)
   feed(prefix, true)
 end
 
----Feed the keys a resolved target produced, honouring its `noremap` flag
+---Feed the keys a resolved target produced, honouring its `noremap` flag.
+---
+---A pending count survives an expr mapping in vanilla Neovim and applies to the keys the
+---mapping hands back (`3o` through a foreign expr `o` map opens three lines). Our own mapping
+---consumes the count, so it is re-prefixed onto the produced keys. Digits are never remappable,
+---so prefixing them cannot change how the rest of the sequence resolves.
+---
+---Known gap: the count is *not* applied on the remappable (`feed_mapped`) path. Digits break
+---the leading-lhs comparison that keeps a target reproducing its own lhs from looping, and a
+---remapped key after the digits could re-enter us. Remappable string-rhs `o`-style maps
+---therefore lose the multiplier; no real plugin uses that shape.
 ---@param keys string Key sequence with termcodes already expanded
 ---@param target markdown-plus.FallbackTarget Resolved target
 ---@param lhs string Left-hand side the target was resolved for
+---@param count? integer Normal-mode count to re-apply; ignored when nil or 1
 ---@return nil
-local function feed_target(keys, target, lhs)
+local function feed_target(keys, target, lhs, count)
   if routes_back_to_us(keys) then
-    feed_raw(lhs)
+    -- The bounce replaces the target's execution entirely, so the raw key carries the count.
+    feed_raw(lhs, count)
     return
   end
   if target.noremap then
-    feed(keys, true)
+    local prefix = (count and count > 1) and tostring(count) or ""
+    feed(prefix .. keys, true)
   else
     feed_mapped(keys, lhs)
   end
@@ -255,59 +281,76 @@ end
 ---@param result any Value returned by the expr callback or expression
 ---@param target markdown-plus.FallbackTarget Resolved target
 ---@param lhs string Left-hand side the target was resolved for
+---@param count? integer Normal-mode count to re-apply to the produced keys
 ---@return nil
-local function feed_expr_result(result, target, lhs)
+local function feed_expr_result(result, target, lhs, count)
   if type(result) ~= "string" or result == "" then
     return
   end
   local keys = target.replace_keycodes and vim.api.nvim_replace_termcodes(result, true, true, true) or result
-  feed_target(keys, target, lhs)
+  feed_target(keys, target, lhs, count)
 end
 
 ---Run a Lua callback target
 ---@param target markdown-plus.FallbackTarget Resolved target
 ---@param lhs string Left-hand side, used for error reporting and the raw-key fallback
+---@param count? integer Normal-mode count to re-apply to the produced keys
 ---@return nil
-local function run_callback(target, lhs)
+local function run_callback(target, lhs, count)
   local ok, result = pcall(target.callback)
   if not ok then
     notify_failure(lhs, result)
+    -- Deliberately countless: a target that threw partway may already have acted on the count,
+    -- so re-prefixing it here risks doubling. Unlike the `feed_mapped` punt, which drops the
+    -- count because prefixing is *unsafe*, this one drops it because it may be *already spent*.
     feed_raw(lhs)
     return
   end
   if target.expr then
-    feed_expr_result(result, target, lhs)
+    feed_expr_result(result, target, lhs, count)
   end
 end
 
 ---Run a string-rhs target
 ---@param target markdown-plus.FallbackTarget Resolved target
 ---@param lhs string Left-hand side, used for error reporting and the raw-key fallback
+---@param count? integer Normal-mode count to re-apply to the produced keys
 ---@return nil
-local function run_rhs(target, lhs)
+local function run_rhs(target, lhs, count)
   if target.expr then
     local ok, result = pcall(vim.api.nvim_eval, target.rhs)
     if not ok then
       notify_failure(lhs, result)
+      -- Countless for the same reason as the callback error path above: possibly already spent.
       feed_raw(lhs)
       return
     end
-    feed_expr_result(result, target, lhs)
+    feed_expr_result(result, target, lhs, count)
     return
   end
 
   -- `from_part = false` here: an rhs is a full key sequence, unlike an lhs, where
   -- `normalize()` passes `from_part = true` to keep partial-key semantics for comparison.
-  feed_target(vim.api.nvim_replace_termcodes(target.rhs, true, false, true), target, lhs)
+  feed_target(vim.api.nvim_replace_termcodes(target.rhs, true, false, true), target, lhs, count)
 end
 
 ---Execute the mapping markdown-plus is deferring to, or feed the raw key when there is none.
 ---The resolved target is executed directly — `lhs` is never re-fed through mapping
 ---resolution — so this can never recurse back into our own buffer-local default.
+---
+---Counts need help in two places. Targets are invoked synchronously from inside our own mapping,
+---where `v:count` is still the one the user typed, so a callback or expression *reads* it fine —
+---but the keys it produces are fed by us, outside that pending count, so the multiplier is lost
+---unless re-applied. Vim's own behavior is a plain prefix (`2` + rhs `jj` moves two lines, it
+---does not run `jj` twice), which is what `opts.count` reproduces on the noremap feed paths and
+---on the raw-key degradation.
+---
+---Remappable targets are the known gap: see `feed_target`.
 ---@param mode string Mapping mode ("i", "n", ...)
 ---@param lhs string Left-hand side (e.g. "<BS>")
+---@param opts? markdown-plus.FallbackOpts Optional behavior overrides
 ---@return nil
-function M.run(mode, lhs)
+function M.run(mode, lhs, opts)
   local guard_key = mode .. ":" .. vim.api.nvim_get_current_buf() .. ":" .. lhs
   if in_flight[guard_key] == buffer_tick() then
     -- Re-entered inside the same key-processing burst with nothing to show for the previous
@@ -319,20 +362,23 @@ function M.run(mode, lhs)
   end
 
   local target = M.resolve(mode, lhs)
+  local count = opts and opts.count
 
   if not target then
-    feed_raw(lhs)
+    feed_raw(lhs, count)
     return
   end
 
   arm_guard(guard_key)
   local ok, err = pcall(function()
     if target.callback then
-      run_callback(target, lhs)
+      run_callback(target, lhs, count)
     elseif type(target.rhs) == "string" and target.rhs ~= "" then
-      run_rhs(target, lhs)
+      run_rhs(target, lhs, count)
     else
-      feed_raw(lhs)
+      -- Target with an empty rhs: nothing to run, so this is the raw-key path and still owns
+      -- the count.
+      feed_raw(lhs, count)
     end
   end)
 

--- a/lua/markdown-plus/list/normal_handler.lua
+++ b/lua/markdown-plus/list/normal_handler.lua
@@ -89,6 +89,12 @@ local function is_last_item_at_indent(row, indent_level, lines, max_scan_row)
 end
 
 ---Handle normal mode 'o' key
+---
+---Outside of list context this yields to whatever `o` mapping would otherwise have run,
+---falling back to Neovim's own open-line when there is none. Reimplementing the open here
+---would clobber those mappings plus `'autoindent'` and `'formatoptions'` semantics.
+---The count is handed to the fallback so `3o` still opens three lines; a list item is always
+---created singly, matching the pre-existing behavior for the in-list case.
 ---@return nil
 function M.handle_normal_o()
   local current_line = utils.get_current_line()
@@ -99,10 +105,7 @@ function M.handle_normal_o()
   local list_info = parser.parse_list_line(current_line, row)
 
   if not list_info then
-    -- Not in a list, insert blank line below and enter insert mode
-    utils.insert_line(row + 1, "")
-    utils.set_cursor(row + 1, 0)
-    vim.cmd("startinsert")
+    keymap_fallback.run("n", "o", { count = vim.v.count1 })
     return
   end
 
@@ -139,6 +142,9 @@ function M.handle_normal_o()
 end
 
 ---Handle normal mode 'O' key
+---
+---Outside of list context this yields to whatever `O` mapping would otherwise have run
+---(see `handle_normal_o` for the rationale).
 ---@return nil
 function M.handle_normal_O()
   local current_line = utils.get_current_line()
@@ -149,10 +155,7 @@ function M.handle_normal_O()
   local list_info = parser.parse_list_line(current_line, row)
 
   if not list_info then
-    -- Not in a list, insert blank line above and enter insert mode
-    utils.insert_line(row, "")
-    utils.set_cursor(row, 0)
-    vim.cmd("startinsert")
+    keymap_fallback.run("n", "O", { count = vim.v.count1 })
     return
   end
 

--- a/spec/helpers/insert_mode.lua
+++ b/spec/helpers/insert_mode.lua
@@ -68,6 +68,49 @@ function M.press(keys, row, col)
     }
 end
 
+---Press `keys` in *normal* mode with the cursor at (row, col) and return the resulting state.
+---
+---Used for handlers that yield to `keymap_fallback` from normal mode (`o`, `O`): the fallback
+---queues keys instead of editing the buffer, so a real key-processing burst is required. The
+---trailing `<Esc>` closes the insert session that `o`/`O` open; state is captured before it.
+---
+---Shares the module-local `captured` slot with `press()`; both reset it before feeding, so the
+---two are safe to interleave across tests but must not be nested within one another. Note that
+---effects Vim applies only on leaving insert mode — a count, for instance — are by definition
+---absent from the returned mid-insert snapshot; read the buffer after this call for those.
+---@param keys string Keys to press (e.g. "o")
+---@param row integer 1-indexed row for the cursor
+---@param col integer 0-indexed byte column for the cursor
+---@return markdown-plus.spec.InsertResult
+function M.press_normal(keys, row, col)
+  -- Same rationale as `press()`: specs never reach the event-loop turn that expires the guard.
+  require("markdown-plus.keymap_fallback").reset()
+
+  vim.api.nvim_win_set_cursor(0, { row, col })
+
+  -- A spec that called a handler directly may have left a *pending* `startinsert` behind: it
+  -- takes effect on the next main-loop pass, i.e. in the middle of the burst below, where it
+  -- would swallow `keys` as literal text. `stopinsert` cancels the pending flag; a leading
+  -- `<Esc>` does not, because the typeahead is consumed before the flag is applied.
+  vim.cmd("stopinsert")
+
+  -- Specs that call a fallback handler directly leave the keys it queued sitting in the
+  -- typeahead (nothing drains them without a key-processing burst). Flush them first so they
+  -- cannot interleave with this press.
+  vim.api.nvim_feedkeys("", "x", false)
+  vim.cmd("stopinsert")
+
+  captured = nil
+  local sequence = keys .. '<Cmd>lua require("spec.helpers.insert_mode").__capture()<CR><Esc>'
+  vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(sequence, true, false, true), "x", false)
+
+  return captured
+    or {
+      lines = vim.api.nvim_buf_get_lines(0, 0, -1, false),
+      cursor = vim.api.nvim_win_get_cursor(0),
+    }
+end
+
 ---`maparg()` dicts for the global `<Plug>` mappings overwritten by `map_default`, keyed by
 ---"<mode>\0<plug>". The real ones are registered by `list/keymaps.lua` (which wraps the
 ---handler in `skip_in_codeblock`), so they are restored rather than deleted on teardown.

--- a/spec/markdown-plus/keymap_fallback_spec.lua
+++ b/spec/markdown-plus/keymap_fallback_spec.lua
@@ -233,6 +233,51 @@ describe("markdown-plus keymap_fallback", function()
       assert.are.equal(1, count)
       assert.are.equal("bc", vim.api.nvim_buf_get_lines(0, 0, 1, false)[1])
     end)
+
+    -- Vanilla Neovim keeps a pending count across an expr mapping and applies it to the keys
+    -- the mapping returns, so `3o` through a foreign `o` expr map opens three lines. Our
+    -- mapping consumes the count, so it has to be re-prefixed onto the produced keys.
+    it("applies opts.count to keys produced by a noremap expr target", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "plain text" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      local calls = 0
+      vim.keymap.set("n", "<F5>", function()
+        calls = calls + 1
+        return "ox<Esc>"
+      end, { expr = true, replace_keycodes = true })
+
+      fallback.run("n", "<F5>", { count = 3 })
+      flush()
+
+      assert.are.equal(1, calls)
+      assert.are.same({ "plain text", "x", "x", "x" }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+    end)
+
+    it("applies opts.count to a noremap string rhs target", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "plain text" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      vim.keymap.set("n", "<F5>", "ox<Esc>")
+
+      fallback.run("n", "<F5>", { count = 3 })
+      flush()
+
+      assert.are.same({ "plain text", "x", "x", "x" }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+    end)
+
+    it("keeps opts.count when the target routes back into markdown-plus", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "abcdef" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      vim.keymap.set("n", "x", function()
+        return "<Plug>(MarkdownPlusListBackspace)"
+      end, { expr = true, replace_keycodes = true })
+
+      fallback.run("n", "x", { count = 3 })
+      flush()
+
+      -- The bounce degrades to the raw key, which replaces the whole target execution:
+      -- `3x` must still delete three characters.
+      assert.are.equal("def", vim.api.nvim_buf_get_lines(0, 0, 1, false)[1])
+    end)
   end)
 
   -- Regression: a *remappable* foreign mapping whose keys start with its own lhs (the

--- a/spec/markdown-plus/list_normal_handler_spec.lua
+++ b/spec/markdown-plus/list_normal_handler_spec.lua
@@ -5,6 +5,10 @@ local normal_handler = require("markdown-plus.list.normal_handler")
 local list = require("markdown-plus.list")
 local insert_mode = require("spec.helpers.insert_mode")
 
+-- `<Plug>` names the production `o`/`O` defaults forward to (see `list/keymaps.lua`).
+local O_PLUG_BELOW = "<Plug>(MarkdownPlusNewListItemBelow)"
+local O_PLUG_ABOVE = "<Plug>(MarkdownPlusNewListItemAbove)"
+
 describe("markdown-plus list normal_handler", function()
   before_each(function()
     require("markdown-plus.keymap_fallback").reset()
@@ -135,11 +139,11 @@ describe("markdown-plus list normal_handler", function()
 
     it("on non-list inserts blank line", function()
       vim.api.nvim_buf_set_lines(0, 0, -1, false, { "plain text" })
-      vim.api.nvim_win_set_cursor(0, { 1, 0 })
-      normal_handler.handle_normal_o()
-      local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
-      assert.are.equal(2, #lines)
-      assert.are.equal("", lines[2])
+      insert_mode.map_default("n", "o", O_PLUG_BELOW, normal_handler.handle_normal_o)
+      local result = insert_mode.press_normal("o", 1, 0)
+      insert_mode.unmap_default("n", "o", O_PLUG_BELOW)
+      assert.are.equal(2, #result.lines)
+      assert.are.equal("", result.lines[2])
     end)
   end)
 
@@ -151,6 +155,188 @@ describe("markdown-plus list normal_handler", function()
       local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
       assert.are.equal(2, #lines)
       assert.are.equal("- ", lines[1])
+    end)
+  end)
+
+  -- Outside list context `o`/`O` defer to `keymap_fallback` instead of hand-rolling the open:
+  -- that preserves counts, 'autoindent', 'formatoptions' comment continuation, and any user
+  -- normal-mode `o`/`O` mapping. Inside a list, marker continuation still wins.
+  describe("normal-mode open-line fallback", function()
+    ---Install our buffer-local default and a *foreign* global mapping for the same key
+    ---@param key string "o" or "O"
+    ---@param plug string `<Plug>` name our default forwards to
+    ---@param handler fun() Our handler
+    ---@param state table Mutable state; `state.foreign` counts invocations, `state.count`
+    ---records the `v:count1` the foreign mapping observed
+    ---@return nil
+    local function install(key, plug, handler, state)
+      insert_mode.map_default("n", key, plug, handler)
+      vim.keymap.set("n", key, function()
+        state.foreign = state.foreign + 1
+        state.count = vim.v.count1
+      end, { silent = true })
+    end
+
+    -- Safety net: `press_normal` drives a real key burst, so an error mid-test would skip the
+    -- per-test `uninstall` and leak a global `o`/`O` mapping into every later spec in this
+    -- Neovim instance. Deleting unconditionally here is harmless when already removed.
+    after_each(function()
+      pcall(vim.keymap.del, "n", "o")
+      pcall(vim.keymap.del, "n", "O")
+    end)
+
+    ---Remove the mappings installed by `install`
+    ---@param key string "o" or "O"
+    ---@param plug string `<Plug>` name used with `install`
+    ---@return nil
+    local function uninstall(key, plug)
+      pcall(vim.keymap.del, "n", key)
+      insert_mode.unmap_default("n", key, plug)
+    end
+
+    it("runs a foreign global `o` mapping on a non-list line", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "plain text" })
+      local state = { foreign = 0 }
+      install("o", O_PLUG_BELOW, normal_handler.handle_normal_o, state)
+
+      insert_mode.press_normal("o", 1, 0)
+      uninstall("o", O_PLUG_BELOW)
+
+      assert.are.equal(1, state.foreign)
+    end)
+
+    it("does not run a foreign `o` mapping on a list line", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "- first" })
+      local state = { foreign = 0 }
+      install("o", O_PLUG_BELOW, normal_handler.handle_normal_o, state)
+
+      local result = insert_mode.press_normal("o", 1, 0)
+      uninstall("o", O_PLUG_BELOW)
+
+      assert.are.equal(0, state.foreign)
+      assert.are.equal("- ", result.lines[2])
+    end)
+
+    it("runs a foreign global `O` mapping on a non-list line", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "plain text" })
+      local state = { foreign = 0 }
+      install("O", O_PLUG_ABOVE, normal_handler.handle_normal_O, state)
+
+      insert_mode.press_normal("O", 1, 0)
+      uninstall("O", O_PLUG_ABOVE)
+
+      assert.are.equal(1, state.foreign)
+    end)
+
+    it("does not run a foreign `O` mapping on a list line", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "- first" })
+      local state = { foreign = 0 }
+      install("O", O_PLUG_ABOVE, normal_handler.handle_normal_O, state)
+
+      local result = insert_mode.press_normal("O", 1, 0)
+      uninstall("O", O_PLUG_ABOVE)
+
+      assert.are.equal(0, state.foreign)
+      assert.are.equal("- ", result.lines[1])
+    end)
+
+    it("falls back to native `o` when no foreign mapping exists", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "plain text" })
+      insert_mode.map_default("n", "o", O_PLUG_BELOW, normal_handler.handle_normal_o)
+
+      local result = insert_mode.press_normal("o", 1, 0)
+      insert_mode.unmap_default("n", "o", O_PLUG_BELOW)
+
+      assert.are.equal(2, #result.lines)
+      assert.are.equal("plain text", result.lines[1])
+      assert.are.equal("", result.lines[2])
+      assert.are.equal(2, result.cursor[1])
+    end)
+
+    it("falls back to native `O` when no foreign mapping exists", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "plain text" })
+      insert_mode.map_default("n", "O", O_PLUG_ABOVE, normal_handler.handle_normal_O)
+
+      local result = insert_mode.press_normal("O", 1, 0)
+      insert_mode.unmap_default("n", "O", O_PLUG_ABOVE)
+
+      assert.are.equal(2, #result.lines)
+      assert.are.equal("", result.lines[1])
+      assert.are.equal("plain text", result.lines[2])
+      assert.are.equal(1, result.cursor[1])
+    end)
+
+    -- The hand-rolled open this replaced inserted a literal empty line, which silently
+    -- dropped `'autoindent'`. Deferring to the real `o` restores it.
+    it("preserves 'autoindent' on the native `o` fallback", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "    plain text" })
+      local saved_autoindent = vim.bo.autoindent
+      vim.bo.autoindent = true
+      insert_mode.map_default("n", "o", O_PLUG_BELOW, normal_handler.handle_normal_o)
+
+      local result = insert_mode.press_normal("ox", 1, 4)
+      insert_mode.unmap_default("n", "o", O_PLUG_BELOW)
+      vim.bo.autoindent = saved_autoindent
+
+      assert.are.equal("    x", result.lines[2])
+    end)
+
+    -- A count is applied by `o`/`O` only when insert mode is left, so these assert on the
+    -- buffer *after* `press_normal`'s trailing `<Esc>` rather than on its mid-insert capture.
+
+    it("applies a count on the native `o` fallback", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "plain text" })
+      insert_mode.map_default("n", "o", O_PLUG_BELOW, normal_handler.handle_normal_o)
+
+      insert_mode.press_normal("3ox", 1, 0)
+      insert_mode.unmap_default("n", "o", O_PLUG_BELOW)
+
+      local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+      assert.are.same({ "plain text", "x", "x", "x" }, lines)
+    end)
+
+    it("applies a count on the native `O` fallback", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "plain text" })
+      insert_mode.map_default("n", "O", O_PLUG_ABOVE, normal_handler.handle_normal_O)
+
+      insert_mode.press_normal("3Ox", 1, 0)
+      insert_mode.unmap_default("n", "O", O_PLUG_ABOVE)
+
+      local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+      assert.are.same({ "x", "x", "x", "plain text" }, lines)
+    end)
+
+    -- Foreign targets are invoked synchronously from inside our own mapping, where `v:count`
+    -- is still the one the user typed, so they read it themselves and must NOT be prefixed.
+    it("leaves the count readable by a foreign `o` mapping", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "plain text" })
+      local state = { foreign = 0 }
+      install("o", O_PLUG_BELOW, normal_handler.handle_normal_o, state)
+
+      insert_mode.press_normal("3o", 1, 0)
+      uninstall("o", O_PLUG_BELOW)
+
+      assert.are.equal(1, state.foreign)
+      assert.are.equal(3, state.count)
+    end)
+
+    -- A foreign expr `o` map that returns `o` (the shape used by counter/notifier plugins) is
+    -- the vanilla case where the pending count survives the mapping and applies to the returned
+    -- key. Our mapping consumes the count, so the fallback has to re-prefix it.
+    it("applies the count to keys returned by a foreign expr `o` mapping", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "plain text" })
+      local state = { foreign = 0 }
+      insert_mode.map_default("n", "o", O_PLUG_BELOW, normal_handler.handle_normal_o)
+      vim.keymap.set("n", "o", function()
+        state.foreign = state.foreign + 1
+        return "o"
+      end, { expr = true, silent = true })
+
+      insert_mode.press_normal("3ox", 1, 0)
+      uninstall("o", O_PLUG_BELOW)
+
+      assert.are.equal(1, state.foreign)
+      assert.are.same({ "plain text", "x", "x", "x" }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
     end)
   end)
 end)


### PR DESCRIPTION
## Summary

Layer 3 of the #376 stack: normal-mode `o`/`O` on non-list lines defer to the user's own mapping or native Vim behavior, with count support.

## Changes

- **`list/normal_handler.lua`**: `handle_normal_o`/`handle_normal_O` non-list branches replace the hand-rolled `insert_line` + `startinsert` with `keymap_fallback.run("n", "o"/"O", { count = vim.v.count1 })`. List branches (marker continuation, smart outdent) untouched
- **`keymap_fallback.lua`**: new optional `FallbackOpts` (`{ count }`) on `M.run` — count digits are prefixed on the noremap feed paths (foreign-target result, raw-key degradation, bounce), matching measured vanilla semantics: a pending count survives an expr mapping and applies to the returned keys, and `:map <F5> jj` + `2<F5>` executes `2jj` (prefix, not rhs-repeat)
- **`spec/helpers/insert_mode.lua`**: new `press_normal()` for real normal-mode key bursts
- Foreign Lua callbacks still read `v:count` themselves (verified synchronously) — no double-apply

## Behavior notes

- `'autoindent'`, `'formatoptions'` comment continuation, and user `o`/`O` mappings now work on non-list lines
- `3o` opens three lines like vanilla (previously one)
- Known gaps (documented in-code): count is not re-applied on the erroring-target path (may already be spent), and remappable string-rhs targets don't get the multiplier (interacts with the recursion guard; no real plugin has this shape)

## Test plan

- [x] `make check` green
- [x] 1533 passing / 0 failed (net +14 over layer 2)
- [x] Manual testing: 9-case guide (list regression, native behavior, autoindent, counts, foreign mapping, code blocks)
