### PR TITLE
feat(list): add in_list_context API and defer <A-CR>; document keymap interop (#376)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,71 @@ opts = {
 
 Use `<Plug>(MarkdownPlus...)` mappings for custom remaps instead of undocumented top-level `keymaps.*` action keys.
 
+## Interop with completion/pairs plugins
+
+markdown-plus maps keys other plugins commonly own: `<BS>`, `<CR>`, `<Tab>`, `<S-Tab>`, `<A-CR>` (insert) and `o` / `O` (normal). In list context markdown-plus acts. **Everywhere else it hands the key back** instead of reimplementing the default behavior. No configuration required — this is always on.
+
+For each keypress outside list context it resolves what would have run instead: a non-markdown-plus buffer-local mapping → a global mapping → the raw key. Resolution happens per keypress, so lazily-mapping plugins (`InsertEnter` and friends) are still found after setup. That keeps working:
+
+- other plugins' mappings — mini.pairs `<BS>`/`<CR>`, blink.cmp / nvim-cmp `<CR>`/`<Tab>`, LuaSnip and copilot.lua `<Tab>`
+- your own mappings for those keys, expression mappings included
+- native behavior when nothing else is mapped: counts (`3o`), `autoindent`, `formatoptions` comment continuation, `backspace` semantics
+- fenced code blocks, where markdown-plus never acts and always defers
+
+Plugins that *capture* the mapping they displace (blink.cmp's `fallback`, copilot.lua's passthrough) are handled: handing our own `<Plug>` back terminates in native behavior rather than bouncing forever.
+
+### Taking over a key yourself
+
+Map the key yourself and ask whether markdown-plus would have acted, via `require("markdown-plus").in_list_context(kind)` — `kind` is `"enter"` (default), `"backspace"` or `"indent"`. It is read-only and cheap, so it is safe from an expression mapping.
+
+mini.pairs `<BS>` with list-marker deletion preserved:
+
+```lua
+vim.keymap.set("i", "<BS>", function()
+  if require("markdown-plus").in_list_context("backspace") then
+    return "<Plug>(MarkdownPlusListBackspace)"
+  end
+  return require("mini.pairs").bs()
+end, { expr = true, buffer = true })
+```
+
+Completion `<CR>`: confirm when the menu is open, continue the list otherwise:
+
+```lua
+vim.keymap.set("i", "<CR>", function()
+  if vim.fn.pumvisible() == 1 then
+    return "<C-y>"
+  end
+  if require("markdown-plus").in_list_context("enter") then
+    return "<Plug>(MarkdownPlusListEnter)"
+  end
+  return "<CR>"
+end, { expr = true, buffer = true })
+```
+
+`<Tab>`: let a snippet plugin win, keep list indentation:
+
+```lua
+vim.keymap.set("i", "<Tab>", function()
+  if require("markdown-plus").in_list_context("indent") then
+    return "<Plug>(MarkdownPlusListIndent)"
+  end
+  return "<Tab>"
+end, { expr = true, buffer = true })
+```
+
+Each kind answers "would the handler act here?":
+
+- `"enter"` — broadest: on a list item line *and* on a wrapped continuation line under one.
+- `"indent"` — anywhere on a list item line.
+- `"backspace"` — narrowest: only where the marker would actually be removed (cursor in the marker zone, at the start of list content). Mid-content it is `false`, because `<BS>` there belongs to your pairs plugin, not to us.
+
+There is no dedicated `<A-CR>` kind. `continue_list_content` acts on any list item line, which is exactly `"indent"`'s scope — borrow that one when writing an `<A-CR>` recipe.
+
+A pre-existing **buffer-local** mapping stops markdown-plus from installing its default for that key at all, so map buffer-locally (as above) or disable default keymaps first.
+
+See `:help markdown-plus-interop` for the full reference.
+
 ## License
 
 MIT License - see [LICENSE](./LICENSE) file for details.

--- a/doc/markdown-plus.txt
+++ b/doc/markdown-plus.txt
@@ -23,6 +23,7 @@ Table of Contents                            *markdown-plus-table-of-contents*
   - Options                                  |markdown-plus-configuration-options|
 5. Commands                                               |markdown-plus-commands|
 6. API                                                         |markdown-plus-api|
+  - Plugin interop                                      |markdown-plus-interop|
 7. Troubleshooting                                 |markdown-plus-troubleshooting|
 8. Contributing                                       |markdown-plus-contributing|
 9. License                                                 |markdown-plus-license|
@@ -629,8 +630,17 @@ exclude Markdown from that formatter (or disable it) so the two don't fight.
 SMART BACKSPACE ~
 
 The `<BS>` key in insert mode is context-aware:
-- In empty list items: removes the list marker
-- Otherwise: deletes character normally
+- At the start of list content: removes the list marker
+- Otherwise: yields to whatever `<BS>` would have done without markdown-plus —
+  your own mapping, another plugin's (mini.pairs and friends), or Neovim's
+  native backspace including 'backspace' semantics
+
+The same rule applies to every default key markdown-plus shares with other
+plugins: `<CR>`, `<Tab>`, `<S-Tab>`, `<A-CR>` in insert mode and `o` / `O` in
+normal mode. Outside list context markdown-plus hands the key back instead of
+reimplementing the default behavior, so counts (`3o`), 'autoindent',
+'formatoptions' comment continuation and other plugins' mappings all keep
+working. See |markdown-plus-interop|.
 
 
 FORMATTING                                      *markdown-plus-usage-formatting*
@@ -2027,6 +2037,26 @@ markdown-plus.thematic_break.cycle_style()
 
 LIST MODULE                                              *markdown-plus.list*
 
+                                            *markdown-plus.list.in_list_context*
+markdown-plus.list.in_list_context({kind})
+    Whether the cursor is in list context for a given handler kind. Also
+    available as `require('markdown-plus').in_list_context({kind})`.
+
+    Read-only and cheap — it parses the current line (plus a bounded look-back
+    for `'enter'`) and never touches the buffer, so it is safe to call from an
+    expression mapping. Use it to own a default key yourself and still let
+    markdown-plus act in list context. See |markdown-plus-interop|.
+    Parameters: ~
+        {kind}  (string, optional)  One of:
+                `'enter'`      `<CR>`: on a list item line or a wrapped
+                               continuation line (default)
+                `'backspace'`  `<BS>`: in the marker zone of a list item
+                               line, where the marker would be removed
+                `'indent'`     `<Tab>`/`<S-Tab>`: on a list item line
+    Returns: ~
+        {boolean}  true when the matching handler would act. An unknown
+                   {kind} reports an error and returns false.
+
                                               *markdown-plus.list.handle_enter*
 markdown-plus.list.handle_enter()
     Handles Enter key in insert mode for auto-continuing lists or splitting
@@ -2037,7 +2067,8 @@ markdown-plus.list.handle_enter()
 markdown-plus.list.continue_list_content()
     Continue list content on next line. Creates a continuation line with
     proper indentation aligned with the list content start position. Typically
-    bound to Alt+Enter (<A-CR>) in insert mode.
+    bound to Alt+Enter (<A-CR>) in insert mode. Outside list context the key is
+    handed back to your own `<A-CR>` mapping (|markdown-plus-interop|).
 
                                                 *markdown-plus.list.handle_tab*
 markdown-plus.list.handle_tab()
@@ -2404,6 +2435,105 @@ markdown-plus.utils.build_markdown_image(alt, url, {title})
         {title}  (string, optional)  Image title
     Returns: ~
         {string}  Formatted image: `![alt](url)` or `![alt](url "title")`
+
+
+==============================================================================
+PLUGIN INTEROP                                          *markdown-plus-interop*
+
+markdown-plus installs buffer-local defaults for keys other plugins commonly
+own: `<BS>`, `<CR>`, `<Tab>`, `<S-Tab>`, `<A-CR>` (insert) and `o` / `O`
+(normal). In list context markdown-plus acts. Everywhere else it hands the key
+back rather than reimplementing the default behavior.
+
+
+AUTOMATIC FALLBACK ~
+
+No configuration is required — this is always on.
+
+For each keypress outside list context markdown-plus resolves the mapping that
+would have run instead, in this order:
+
+  1. a buffer-local mapping that is not markdown-plus's own
+  2. a global mapping
+  3. the raw key (native Neovim behavior)
+
+Resolution happens on every keypress rather than once at startup, so plugins
+that map lazily — on `InsertEnter`, for example — are still found after
+markdown-plus has already set up the buffer.
+
+What this preserves outside list context:
+- other plugins' mappings (mini.pairs `<BS>`/`<CR>`, blink.cmp and
+  nvim-cmp `<CR>`/`<Tab>` confirm/select, LuaSnip and copilot.lua `<Tab>`)
+- your own mappings for those keys, including expression mappings
+- native behavior when nothing else is mapped: counts (`3o`), 'autoindent',
+  'formatoptions' comment continuation, 'backspace' semantics, abbreviations
+- fenced code blocks, where markdown-plus never acts and always defers
+
+Plugins that *capture* the mapping they displace (blink.cmp's `fallback`,
+copilot.lua's passthrough) are handled: when such a plugin hands markdown-plus
+its own `<Plug>` back, the key terminates in native behavior instead of
+bouncing between the two.
+
+Known limits:
+- A pre-existing *buffer-local* mapping stops markdown-plus from installing its
+  default at all — that mapping simply wins, and list features are not bound to
+  that key in the buffer.
+- A remappable target that reproduces its own left-hand side loses a normal-mode
+  count multiplier (`3o`). Expression and Lua-callback mappings — what modern
+  plugins use — are unaffected.
+
+
+TAKING OVER A KEY YOURSELF                            *markdown-plus-recipes*
+
+When you want your mapping to be the one in charge, map the key yourself and
+ask markdown-plus whether it would have acted with
+|markdown-plus.list.in_list_context|. Disable the default keymaps first (see
+|markdown-plus-configuration-keymaps|) or map buffer-locally, since a
+pre-existing buffer-local mapping wins.
+
+mini.pairs `<BS>` with list-marker deletion preserved:
+>lua
+    vim.keymap.set('i', '<BS>', function()
+      if require('markdown-plus').in_list_context('backspace') then
+        return '<Plug>(MarkdownPlusListBackspace)'
+      end
+      return require('mini.pairs').bs()
+    end, { expr = true, buffer = true })
+<
+Completion `<CR>`: confirm when the menu is open, continue the list otherwise:
+>lua
+    vim.keymap.set('i', '<CR>', function()
+      if vim.fn.pumvisible() == 1 then
+        return '<C-y>'
+      end
+      if require('markdown-plus').in_list_context('enter') then
+        return '<Plug>(MarkdownPlusListEnter)'
+      end
+      return '<CR>'
+    end, { expr = true, buffer = true })
+<
+`<Tab>`: let a snippet plugin win, keep list indentation:
+>lua
+    vim.keymap.set('i', '<Tab>', function()
+      if require('markdown-plus').in_list_context('indent') then
+        return '<Plug>(MarkdownPlusListIndent)'
+      end
+      return '<Tab>'
+    end, { expr = true, buffer = true })
+<
+Each kind answers "would the handler act here?":
+
+- `'enter'`     broadest: on a list item line and on a wrapped continuation
+                line beneath one, where `<CR>` continues the list
+- `'indent'`    anywhere on a list item line
+- `'backspace'` narrowest: only where the marker would actually be removed —
+                the marker zone, at the start of list content. Mid-content it
+                is false, because `<BS>` there belongs to your pairs plugin,
+                not to markdown-plus.
+
+There is no dedicated `<A-CR>` kind. |markdown-plus.list.continue_list_content|
+acts on any list item line, which is exactly `'indent'`'s scope — borrow that
+one when writing an `<A-CR>` recipe.
 
 
 ==============================================================================

--- a/lua/markdown-plus/init.lua
+++ b/lua/markdown-plus/init.lua
@@ -176,6 +176,7 @@ function M.teardown()
 
   clear_root_augroup()
   clear_plugin_default_keymaps()
+  require("markdown-plus.keymap_helper").reset_registered_plugs()
   require("markdown-plus.keymap_fallback").reset()
   reset_module_refs()
   M.config = vim.deepcopy(DEFAULT_CONFIG)
@@ -334,6 +335,17 @@ function M.setup_autocmds()
       M.enable_features_for_buffer()
     end,
   })
+end
+
+---Check whether the cursor is in list context for a given handler kind.
+---
+---Public composition hook: own a key yourself and ask whether markdown-plus would have acted
+---on it. See `markdown-plus.list.context` for details and a recipe. Resolved through `require`
+---rather than `M.list` so it works regardless of feature flags and teardown state.
+---@param kind? markdown-plus.ListContextKind Handler context to query; defaults to `"enter"`
+---@return boolean in_context `true` when the matching handler would act on the current cursor
+function M.in_list_context(kind)
+  return require("markdown-plus.list.context").in_list_context(kind)
 end
 
 return M

--- a/lua/markdown-plus/keymap_helper.lua
+++ b/lua/markdown-plus/keymap_helper.lua
@@ -149,6 +149,19 @@ function M.clear_default_keymaps()
   end
 end
 
+---Forget which `<Plug>` mappings have been registered.
+---
+---`registered_plugs` guards against redundant global re-registration, but it is module state
+---that outlives a `teardown()`. Without this reset the helper would still believe a `<Plug>` is
+---registered after teardown dropped the runtime behind it, so a later `setup()` would skip
+---re-registering and leave the mapping pointing at stale state (or missing entirely).
+---Registration is idempotent, so clearing the table only ever costs one redundant
+---`vim.keymap.set` per plug.
+---@return nil
+function M.reset_registered_plugs()
+  registered_plugs = {}
+end
+
 ---Create a standard <Plug> mapping name
 ---@param feature string Feature name (e.g., "Bold", "NextHeader")
 ---@return string Full <Plug> name without <Plug>() wrapper

--- a/lua/markdown-plus/list/context.lua
+++ b/lua/markdown-plus/list/context.lua
@@ -1,0 +1,118 @@
+-- Public list-context query for markdown-plus.nvim
+--
+-- markdown-plus installs buffer-local defaults for keys other plugins commonly own. The
+-- handlers yield back through `keymap_fallback` when they have nothing to do, which covers
+-- the common case automatically. This module is the other direction: it lets a user or plugin
+-- author own the key themselves and ask us whether *we* would have acted, so they can compose
+-- their own mapping without guessing at our internals.
+--
+-- The predicate is exactly the one the matching handler uses, so
+-- `in_list_context(kind) == false` guarantees the corresponding handler would defer.
+local parser = require("markdown-plus.list.parser")
+local handler_utils = require("markdown-plus.list.handler_utils")
+local shared = require("markdown-plus.list.shared")
+local utils = require("markdown-plus.utils")
+
+local M = {}
+
+---Which handler's notion of "list context" to query.
+---@alias markdown-plus.ListContextKind
+---| "enter" # `<CR>`: on a list item line *or* a wrapped continuation line
+---| "backspace" # `<BS>`: at the start of list content, where the marker is removed
+---| "indent" # `<Tab>`/`<S-Tab>`: on a list item line
+
+---Whether the cursor sits on a line that carries a list marker
+---@return boolean
+local function on_list_item_line()
+  local cursor = utils.get_cursor()
+  local row = cursor[1]
+  return parser.parse_list_line(utils.get_current_line(), row) ~= nil
+end
+
+---Whether `<BS>` would remove the list marker.
+---
+---Narrower than "on a list item line" on purpose: `handle_backspace` only acts in the marker
+---zone and defers *inside* list content, so a recipe keyed on the line alone would route
+---mid-content backspaces into a handler that immediately hands them back — and a pairs plugin
+---sitting behind our own mapping would never fire.
+---@return boolean
+local function would_remove_marker()
+  local cursor = utils.get_cursor()
+  local row, col = cursor[1], cursor[2]
+  local current_line = utils.get_current_line()
+  local list_info = parser.parse_list_line(current_line, row)
+  if not list_info then
+    return false
+  end
+
+  -- Mirrors the guard in `list/normal_handler.lua`'s `handle_backspace`.
+  local marker_end_col = shared.get_content_start_col(list_info)
+  return col <= marker_end_col and col > #list_info.indent
+end
+
+---Whether `<CR>` would continue a list: marker line, or a continuation line beneath one
+---@return boolean
+local function in_enter_context()
+  if on_list_item_line() then
+    return true
+  end
+  local cursor = utils.get_cursor()
+  local row = cursor[1]
+  return handler_utils.find_parent_list_item(row, utils.get_current_line()) ~= nil
+end
+
+---Predicate per kind. Keeping them in a table makes the accepted set the single source of
+---truth for both dispatch and the error message.
+local PREDICATES = {
+  enter = in_enter_context,
+  backspace = would_remove_marker,
+  indent = on_list_item_line,
+}
+
+---Check whether the cursor is in list context for a given handler kind.
+---
+---Public API: stable across minor versions. Read-only and cheap — it parses the current line
+---(plus a bounded look-back for `"enter"`) and never touches the buffer, so it is safe to call
+---from an expression mapping.
+---
+---Each kind answers "would the handler act?", not "would the buffer change?". `"indent"` is
+---true anywhere on a list item line, including for `<S-Tab>` on an item already at root
+---indentation, where the handler consumes the key without outdenting further. Route that key
+---elsewhere if you need it to fall through in that position.
+---
+---```lua
+---vim.keymap.set("i", "<BS>", function()
+---  if require("markdown-plus").in_list_context("backspace") then
+---    return "<Plug>(MarkdownPlusListBackspace)"
+---  end
+---  return require("mini.pairs").bs()
+---end, { expr = true, buffer = true })
+---```
+---@param kind? markdown-plus.ListContextKind Handler context to query; defaults to `"enter"`
+---@return boolean in_context `true` when the matching handler would act on the current cursor
+function M.in_list_context(kind)
+  local predicate = PREDICATES[kind or "enter"]
+  if not predicate then
+    vim.notify(
+      string.format(
+        'markdown-plus: in_list_context() got unknown kind %q (expected "enter", "backspace" or "indent")',
+        tostring(kind)
+      ),
+      vim.log.levels.ERROR
+    )
+    return false
+  end
+
+  -- Deliberately silent on failure. This runs inside expression mappings on every keypress of
+  -- `<BS>`/`<CR>`/`<Tab>`, where a `vim.notify` from a parse error (an unloaded treesitter
+  -- parser mid-edit, say) would fire once per keystroke and bury the editor in messages.
+  -- `false` is the safe answer: the caller falls through to its own non-markdown-plus branch,
+  -- which is exactly what a user who cannot be told about the error wants.
+  local ok, result = pcall(predicate)
+  if not ok then
+    return false
+  end
+  return result
+end
+
+return M

--- a/lua/markdown-plus/list/enter_handler.lua
+++ b/lua/markdown-plus/list/enter_handler.lua
@@ -124,6 +124,11 @@ end
 
 ---Continue list content on next line with proper indentation
 ---Splits the line at cursor and creates a continuation line aligned with content start
+---
+---Outside of list context this yields to whatever `<A-CR>` mapping would otherwise have run
+---(terminal and multicursor plugins commonly own the key). Hand-rolling a line split here made
+---`<A-CR>` behave like `<CR>` on plain lines, which is neither what the user mapped nor what
+---the key does natively.
 ---@return nil
 function M.continue_list_content()
   local current_line = utils.get_current_line()
@@ -134,13 +139,8 @@ function M.continue_list_content()
   local list_info = parser.parse_list_line(current_line, row)
 
   if not list_info then
-    -- Not in a list, simulate default Enter behavior
-    -- Use UTF-8 safe split to handle multibyte characters correctly
-    local line_before, line_after = utils.split_at_cursor(current_line, col)
-
-    utils.set_line(row, line_before)
-    utils.insert_line(row + 1, line_after)
-    utils.set_cursor(row + 1, 0)
+    -- Not in a list at all: defer to the mapping we are shadowing
+    keymap_fallback.run("i", "<A-CR>")
     return
   end
 

--- a/lua/markdown-plus/list/init.lua
+++ b/lua/markdown-plus/list/init.lua
@@ -52,6 +52,9 @@ end
 M.setup_renumber_autocmds = autocmds.setup_renumber_autocmds
 M.teardown = autocmds.teardown
 
+-- Public API: composition hook for users and plugin authors (see `list/context.lua`)
+M.in_list_context = require("markdown-plus.list.context").in_list_context
+
 -- Re-export functions from sub-modules for backwards compatibility
 M.parse_list_line = parser.parse_list_line
 M.is_empty_list_item = parser.is_empty_list_item

--- a/spec/markdown-plus/config_spec.lua
+++ b/spec/markdown-plus/config_spec.lua
@@ -448,6 +448,59 @@ describe("markdown-plus configuration", function()
       assert.are.equal("<Plug>(MarkdownPlusUserMapping)", user_mapping.rhs)
       assert.are.equal("User mapping", user_mapping.desc)
     end)
+
+    -- `registered_plugs` is module-level state that survives `teardown()`. Without a reset the
+    -- helper believes a `<Plug>` is still registered after teardown removed the runtime that
+    -- backs it, and a later `setup()` silently skips re-registering it.
+    it("re-registers <Plug> mappings after reset_registered_plugs", function()
+      local test_config = { keymaps = { enabled = true } }
+      local definition = {
+        {
+          plug = "MarkdownPlusTestReregister",
+          fn = function() end,
+          modes = "n",
+          default_key = "<localleader>tr",
+          desc = "Re-register test",
+        },
+      }
+
+      keymap_helper.setup_keymaps(test_config, definition)
+      assert.is_truthy(next(vim.fn.maparg("<Plug>(MarkdownPlusTestReregister)", "n", false, true)))
+
+      -- Simulate teardown dropping the runtime behind the <Plug>
+      vim.keymap.del("n", "<Plug>(MarkdownPlusTestReregister)")
+      keymap_helper.reset_registered_plugs()
+
+      keymap_helper.setup_keymaps(test_config, definition)
+      local plug_mapping = vim.fn.maparg("<Plug>(MarkdownPlusTestReregister)", "n", false, true)
+      pcall(vim.keymap.del, "n", "<Plug>(MarkdownPlusTestReregister)")
+
+      assert.is_truthy(next(plug_mapping))
+    end)
+
+    it("resets registered <Plug> tracking as part of plugin teardown", function()
+      local test_config = { keymaps = { enabled = true } }
+      local definition = {
+        {
+          plug = "MarkdownPlusTestTeardownPlug",
+          fn = function() end,
+          modes = "n",
+          default_key = "<localleader>tt",
+          desc = "Teardown plug test",
+        },
+      }
+
+      keymap_helper.setup_keymaps(test_config, definition)
+      vim.keymap.del("n", "<Plug>(MarkdownPlusTestTeardownPlug)")
+
+      markdown_plus.teardown()
+      keymap_helper.setup_keymaps(test_config, definition)
+
+      local plug_mapping = vim.fn.maparg("<Plug>(MarkdownPlusTestTeardownPlug)", "n", false, true)
+      pcall(vim.keymap.del, "n", "<Plug>(MarkdownPlusTestTeardownPlug)")
+
+      assert.is_truthy(next(plug_mapping))
+    end)
   end)
 
   describe("lazy-loading behavior", function()

--- a/spec/markdown-plus/interop_recipes_spec.lua
+++ b/spec/markdown-plus/interop_recipes_spec.lua
@@ -1,0 +1,119 @@
+---End-to-end tests for the composition recipes published in README.md and
+---doc/markdown-plus.txt (|markdown-plus-recipes|).
+---
+---The mappings below are copied verbatim from the documentation, with one substitution: the
+---`mini.pairs` call becomes a local stand-in, because the plugin is not a test dependency. Its
+---return value (`<BS><Del>`, deleting both sides of a pair) is the shape `mini.pairs.bs()`
+---produces, so the termcode handling under test is unchanged.
+---
+---Docs that do not run are docs that rot: these recipes are user-facing API surface and must
+---keep working across changes to the fallback and context layers.
+---@diagnostic disable: undefined-field
+local insert_mode = require("spec.helpers.insert_mode")
+
+describe("markdown-plus interop recipes", function()
+  local buf
+
+  ---Stand-in for `require("mini.pairs")` in the documented `<BS>` recipe
+  local mini_pairs = {
+    bs = function()
+      return "<BS><Del>"
+    end,
+  }
+
+  before_each(function()
+    require("markdown-plus").setup({})
+    buf = vim.api.nvim_create_buf(false, true)
+    vim.bo[buf].filetype = "markdown"
+    vim.api.nvim_set_current_buf(buf)
+  end)
+
+  after_each(function()
+    for _, lhs in ipairs({ "<BS>", "<CR>", "<Tab>" }) do
+      pcall(vim.keymap.del, "i", lhs, { buffer = buf })
+    end
+    if vim.api.nvim_buf_is_valid(buf) then
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end
+  end)
+
+  describe("mini.pairs <BS> recipe", function()
+    before_each(function()
+      vim.keymap.set("i", "<BS>", function()
+        if require("markdown-plus").in_list_context("backspace") then
+          return "<Plug>(MarkdownPlusListBackspace)"
+        end
+        return mini_pairs.bs()
+      end, { expr = true, buffer = true })
+    end)
+
+    it("removes the list marker at the start of list content", function()
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "- item" })
+      local result = insert_mode.press("<BS>", 1, 2)
+      assert.are.same({ "item" }, result.lines)
+    end)
+
+    it("runs the pairs handler mid-content inside a list item", function()
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "- ()" })
+      local result = insert_mode.press("<BS>", 1, 3)
+      assert.are.same({ "- " }, result.lines)
+    end)
+
+    it("runs the pairs handler on a plain line", function()
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "()" })
+      local result = insert_mode.press("<BS>", 1, 1)
+      assert.are.same({ "" }, result.lines)
+    end)
+  end)
+
+  describe("completion <CR> recipe", function()
+    before_each(function()
+      vim.keymap.set("i", "<CR>", function()
+        if vim.fn.pumvisible() == 1 then
+          return "<C-y>"
+        end
+        if require("markdown-plus").in_list_context("enter") then
+          return "<Plug>(MarkdownPlusListEnter)"
+        end
+        return "<CR>"
+      end, { expr = true, buffer = true })
+    end)
+
+    it("continues the list in list context", function()
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "- Item" })
+      local result = insert_mode.press("<CR>", 1, 6)
+      assert.are.same({ "- Item", "- " }, result.lines)
+    end)
+
+    it("inserts a plain newline outside list context", function()
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "plain" })
+      local result = insert_mode.press("<CR>", 1, 5)
+      assert.are.same({ "plain", "" }, result.lines)
+    end)
+  end)
+
+  describe("snippet <Tab> recipe", function()
+    before_each(function()
+      vim.keymap.set("i", "<Tab>", function()
+        if require("markdown-plus").in_list_context("indent") then
+          return "<Plug>(MarkdownPlusListIndent)"
+        end
+        return "<Tab>"
+      end, { expr = true, buffer = true })
+    end)
+
+    it("indents the list item in list context", function()
+      vim.bo[buf].shiftwidth = 2
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "- item" })
+      local result = insert_mode.press("<Tab>", 1, 2)
+      assert.are.same({ "  - item" }, result.lines)
+    end)
+
+    it("inserts a literal tab outside list context", function()
+      vim.bo[buf].expandtab = false
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "plain" })
+      local result = insert_mode.press("<Tab>", 1, 5)
+      assert.are.same({ "plain\t" }, result.lines)
+    end)
+  end)
+end)

--- a/spec/markdown-plus/list_context_spec.lua
+++ b/spec/markdown-plus/list_context_spec.lua
@@ -1,0 +1,127 @@
+---Test suite for the public list-context query API.
+---Plugin authors and users compose their own `<BS>`/`<CR>`/`<Tab>` mappings around this, so the
+---signature and return values are a stable contract.
+---@diagnostic disable: undefined-field
+local list = require("markdown-plus.list")
+local markdown_plus = require("markdown-plus")
+
+describe("markdown-plus list context API", function()
+  before_each(function()
+    vim.cmd("enew")
+    vim.bo.filetype = "markdown"
+  end)
+
+  after_each(function()
+    vim.cmd("bdelete!")
+  end)
+
+  ---Fill the buffer and place the cursor
+  ---@param lines string[] Buffer contents
+  ---@param row integer 1-indexed cursor row
+  ---@param col integer 0-indexed cursor column
+  ---@return nil
+  local function fixture(lines, row, col)
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, lines)
+    vim.api.nvim_win_set_cursor(0, { row, col })
+  end
+
+  it("is exposed on the list module and the plugin root", function()
+    assert.are.equal("function", type(list.in_list_context))
+    assert.are.equal("function", type(markdown_plus.in_list_context))
+  end)
+
+  it("reports a bullet item line as list context for every kind", function()
+    fixture({ "- item" }, 1, 2)
+    assert.is_true(list.in_list_context("backspace"))
+    assert.is_true(list.in_list_context("indent"))
+    assert.is_true(list.in_list_context("enter"))
+  end)
+
+  it("reports an ordered item line as list context", function()
+    fixture({ "1. item" }, 1, 3)
+    assert.is_true(list.in_list_context("backspace"))
+  end)
+
+  it("reports a checkbox item line as list context", function()
+    fixture({ "- [ ] task" }, 1, 10)
+    assert.is_true(list.in_list_context("indent"))
+  end)
+
+  -- `backspace` answers "would the marker be removed?", not "is this a list line?".
+  -- `handle_backspace` defers mid-content, so a recipe keyed on the line alone would swallow
+  -- backspaces that belong to a pairs plugin.
+  it("reports mid-content as backspace context only in the marker zone", function()
+    fixture({ "- item" }, 1, 6)
+    assert.is_false(list.in_list_context("backspace"))
+    -- Still a list line for the kinds that act line-wide
+    assert.is_true(list.in_list_context("indent"))
+    assert.is_true(list.in_list_context("enter"))
+  end)
+
+  it("reports the indentation zone as no backspace context", function()
+    fixture({ "  - item" }, 1, 2)
+    assert.is_false(list.in_list_context("backspace"))
+  end)
+
+  it("reports the start of checkbox content as backspace context", function()
+    fixture({ "- [ ] task" }, 1, 6)
+    assert.is_true(list.in_list_context("backspace"))
+  end)
+
+  it("reports a plain line as no list context for every kind", function()
+    fixture({ "plain text" }, 1, 5)
+    assert.is_false(list.in_list_context("backspace"))
+    assert.is_false(list.in_list_context("indent"))
+    assert.is_false(list.in_list_context("enter"))
+  end)
+
+  -- `enter` is the broadest kind: `handle_enter` also continues a list from a wrapped
+  -- continuation line, whereas `handle_backspace`/`handle_tab` only act on the marker line.
+  it("treats a continuation line as enter context but not backspace context", function()
+    fixture({ "- item", "  wrapped text" }, 2, 5)
+    assert.is_true(list.in_list_context("enter"))
+    assert.is_false(list.in_list_context("backspace"))
+    assert.is_false(list.in_list_context("indent"))
+  end)
+
+  it("defaults to the enter kind when none is given", function()
+    fixture({ "- item", "  wrapped text" }, 2, 5)
+    assert.is_true(list.in_list_context())
+
+    fixture({ "plain text" }, 1, 0)
+    assert.is_false(list.in_list_context())
+  end)
+
+  it("delegates from the plugin root to the same predicate", function()
+    fixture({ "- item" }, 1, 2)
+    assert.is_true(markdown_plus.in_list_context("backspace"))
+
+    fixture({ "plain text" }, 1, 5)
+    assert.is_false(markdown_plus.in_list_context("backspace"))
+  end)
+
+  it("notifies and returns false for an unknown kind", function()
+    fixture({ "- item" }, 1, 6)
+    local original_notify = vim.notify
+    local messages = {}
+    vim.notify = function(msg, level)
+      table.insert(messages, { msg = msg, level = level })
+    end
+
+    local result = list.in_list_context("nonsense")
+    vim.notify = original_notify
+
+    assert.is_false(result)
+    assert.are.equal(1, #messages)
+    assert.is_truthy(messages[1].msg:match("^markdown%-plus:"))
+    assert.are.equal(vim.log.levels.ERROR, messages[1].level)
+  end)
+
+  it("does not modify the buffer", function()
+    fixture({ "- item" }, 1, 6)
+    local tick = vim.api.nvim_buf_get_changedtick(0)
+    list.in_list_context("enter")
+    list.in_list_context("backspace")
+    assert.are.equal(tick, vim.api.nvim_buf_get_changedtick(0))
+  end)
+end)

--- a/spec/markdown-plus/list_spec.lua
+++ b/spec/markdown-plus/list_spec.lua
@@ -1496,14 +1496,9 @@ describe("markdown-plus list management", function()
         assert.are.equal(2, cursor[2]) -- At indentation start (after "  ")
       end)
 
-      it("falls back to default Enter when not in a list", function()
-        vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "Regular text here" })
-        vim.api.nvim_win_set_cursor(0, { 1, 8 })
-        list.continue_list_content()
-        local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-        assert.are.equal("Regular ", lines[1])
-        assert.are.equal("text here", lines[2])
-      end)
+      -- Outside a list `<A-CR>` is not ours: it yields through `keymap_fallback` like every
+      -- other default key, rather than hand-rolling a line split. Covered by the
+      -- "keymap fallback" suite below, which drives a real keypress.
     end)
 
     describe("handle_enter with continuation lines", function()
@@ -2025,6 +2020,7 @@ describe("markdown-plus list management", function()
       { key = "<Tab>", plug = "<Plug>(MarkdownPlusListIndent)", handler = "handle_tab" },
       { key = "<S-Tab>", plug = "<Plug>(MarkdownPlusListOutdent)", handler = "handle_shift_tab" },
       { key = "<BS>", plug = "<Plug>(MarkdownPlusListBackspace)", handler = "handle_backspace" },
+      { key = "<A-CR>", plug = "<Plug>(MarkdownPlusListShiftEnter)", handler = "continue_list_content" },
     }
 
     ---Counts of foreign-mapping invocations, keyed by lhs
@@ -2088,6 +2084,56 @@ describe("markdown-plus list management", function()
         local result = insert_mode.press("<CR>", 2, 2)
         assert.are.equal(1, calls("<CR>"))
         assert.are.same({ "```lua", "code", "```" }, result.lines)
+      end)
+    end)
+
+    -- `<A-CR>` (continue list content) used to hand-roll a line split outside list context,
+    -- which clobbered any terminal/multicursor plugin owning the key. It now defers like the
+    -- rest of the default surface.
+    describe("<A-CR>", function()
+      it("runs the foreign mapping instead of splitting the line outside a list", function()
+        vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "Regular text here" })
+        local result = insert_mode.press("<A-CR>", 1, 8)
+        assert.are.equal(1, calls("<A-CR>"))
+        assert.are.same({ "Regular text here" }, result.lines)
+      end)
+
+      it("continues list content and does not run the foreign mapping in list context", function()
+        vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "- First line text" })
+        local result = insert_mode.press("<A-CR>", 1, 12)
+        assert.are.equal(0, calls("<A-CR>"))
+        assert.are.same({ "- First line", "  text" }, result.lines)
+      end)
+
+      it("runs the foreign mapping inside a fenced code block", function()
+        vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "```lua", "code", "```" })
+        local result = insert_mode.press("<A-CR>", 2, 2)
+        assert.are.equal(1, calls("<A-CR>"))
+        assert.are.same({ "```lua", "code", "```" }, result.lines)
+      end)
+
+      -- With nothing to defer to, the fallback degrades to the raw key. Vanilla Neovim ignores
+      -- the Alt modifier on `<CR>` and splits the line, so the visible result matches the
+      -- hand-rolled split this replaced — but it now comes from Neovim, honouring 'autoindent',
+      -- 'formatoptions' and abbreviations, which the hand-roll silently dropped.
+      it("degrades to native behavior when no foreign mapping exists", function()
+        pcall(vim.keymap.del, "i", "<A-CR>")
+        vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "Regular text here" })
+        local result = insert_mode.press("<A-CR>", 1, 8)
+        assert.are.same({ "Regular ", "text here" }, result.lines)
+      end)
+
+      -- The hand-rolled split ignored 'autoindent'; the native path restores it.
+      it("preserves 'autoindent' on the native fallback", function()
+        pcall(vim.keymap.del, "i", "<A-CR>")
+        local saved_autoindent = vim.bo[buf].autoindent
+        vim.bo[buf].autoindent = true
+        vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "    indented text" })
+
+        local result = insert_mode.press("<A-CR>", 1, 12)
+        vim.bo[buf].autoindent = saved_autoindent
+
+        assert.are.same({ "    indented", "    text" }, result.lines)
       end)
     end)
 


### PR DESCRIPTION
## Summary

Top layer of the #376 stack: public API for composing keymaps with the plugin, the last hand-rolled key (`<A-CR>`) wired through the fallback, teardown hygiene, and user-facing interop documentation.

## Changes

- **New `lua/markdown-plus/list/context.lua`** + root re-export: `require("markdown-plus").in_list_context(kind)` with kinds `"enter" | "backspace" | "indent"` (default `"enter"`). Each predicate is exactly the guard its handler uses — `"backspace"` is true only where `<BS>` would remove the marker, so recipes routing on it can never regress pairs behavior mid-content. Read-only, works with `features.list` disabled, unknown kind notifies and returns `false`
- **`list/enter_handler.lua`**: `continue_list_content` (`<A-CR>`) non-list branch defers via the fallback. With no foreign mapping the result is a native split (now honoring `'autoindent'`); with one — e.g. copilot.lua's panel `<M-CR>` — the user's mapping runs, matching vanilla
- **`keymap_helper.reset_registered_plugs()`** called from teardown so a teardown → setup cycle re-registers cleanly
- **Docs**: vimdoc gains `*markdown-plus-interop*` (automatic fallback: resolution order, lazy-loaded plugins, capturing plugins, known limits) and `*markdown-plus-recipes*` (taking over a key yourself: mini.pairs `<BS>`, completion `<CR>`, `<Tab>`); README gains the synchronized "Interop with completion/pairs plugins" section
- **New `spec/markdown-plus/interop_recipes_spec.lua`**: installs each documented recipe *verbatim* and drives real keypresses — the docs are executable and cannot silently rot

## Test plan

- [x] `make check` green
- [x] 1559 passing / 0 failed (net +26 over layer 3)
- [x] `helptags` parses clean; recipe snippets byte-synchronized across README / vimdoc / docstring
- [x] Manual testing: 6-case guide (API queries, `<A-CR>`, teardown cycle, docs render, whole-surface smoke with blink.cmp/copilot.lua)

Closes #376
