### PR TITLE
fix(table): defer insert-mode navigation to existing mappings via keymap fallback (#376)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 # ...but the wiki source of truth (published by wiki-sync.yml) is tracked.
 docs/*
 !docs/wiki/
+!docs/manual-testing/
 
 # Internal tools and configurations
 demo

--- a/README.md
+++ b/README.md
@@ -155,10 +155,13 @@ vim.keymap.set("i", "<CR>", function()
 end, { expr = true, buffer = true })
 ```
 
-`<Tab>`: let a snippet plugin win, keep list indentation:
+`<Tab>`: let a snippet jump win, keep list indentation:
 
 ```lua
 vim.keymap.set("i", "<Tab>", function()
+  if vim.snippet.active({ direction = 1 }) then
+    return "<Cmd>lua vim.snippet.jump(1)<CR>"
+  end
   if require("markdown-plus").in_list_context("indent") then
     return "<Plug>(MarkdownPlusListIndent)"
   end
@@ -166,11 +169,24 @@ vim.keymap.set("i", "<Tab>", function()
 end, { expr = true, buffer = true })
 ```
 
+> [!IMPORTANT]
+> Ask the snippet engine **explicitly**, as above. A buffer-local mapping shadows the global
+> `<Tab>` your snippet plugin installed, and returning `"<Tab>"` from it does not fall through to
+> that global mapping — Neovim resolves the buffer-local one first, and its own recursion guard
+> then terminates in a literal tab. Swap the two `vim.snippet` calls for your plugin's equivalents
+> (`require("luasnip").jumpable(1)` / `.jump(1)`, and so on) if you do not use the built-in engine.
+>
+> This is only a concern when *you* own the key. markdown-plus's own default `<Tab>` resolves and
+> runs the mapping it displaced, global ones included — that is what the section above describes.
+
 Each kind answers "would the handler act here?":
 
 - `"enter"` — broadest: on a list item line *and* on a wrapped continuation line under one.
 - `"indent"` — anywhere on a list item line.
 - `"backspace"` — narrowest: only where the marker would actually be removed (cursor in the marker zone, at the start of list content). Mid-content it is `false`, because `<BS>` there belongs to your pairs plugin, not to us.
+
+Every kind is `false` inside a fenced code block, whatever the line looks like — a `- item` in a
+` ```markdown ` fence included. markdown-plus never acts there, so neither does the predicate.
 
 There is no dedicated `<A-CR>` kind. `continue_list_content` acts on any list item line, which is exactly `"indent"`'s scope — borrow that one when writing an `<A-CR>` recipe.
 

--- a/README.md
+++ b/README.md
@@ -112,16 +112,17 @@ opts = {
 
 Use `<Plug>(MarkdownPlus...)` mappings for custom remaps instead of undocumented top-level `keymaps.*` action keys.
 
-## Interop with completion/pairs plugins
+## Interop with other plugins
 
-markdown-plus maps keys other plugins commonly own: `<BS>`, `<CR>`, `<Tab>`, `<S-Tab>`, `<A-CR>` (insert) and `o` / `O` (normal). In list context markdown-plus acts. **Everywhere else it hands the key back** instead of reimplementing the default behavior. No configuration required — this is always on.
+markdown-plus maps keys other plugins commonly own: `<BS>`, `<CR>`, `<Tab>`, `<S-Tab>`, `<A-CR>` (insert), `o` / `O` (normal) and the table cell navigation keys `<A-h>` / `<A-j>` / `<A-k>` / `<A-l>` (insert). In its own context — a list for the list keys, a table for the navigation keys — markdown-plus acts. **Everywhere else it hands the key back** instead of reimplementing the default behavior. No configuration required — this is always on.
 
-For each keypress outside list context it resolves what would have run instead: a non-markdown-plus buffer-local mapping → a global mapping → the raw key. Resolution happens per keypress, so lazily-mapping plugins (`InsertEnter` and friends) are still found after setup. That keeps working:
+For each such keypress outside markdown-plus's own context it resolves what would have run instead: a non-markdown-plus buffer-local mapping → a global mapping → the raw key. Resolution happens per keypress, so lazily-mapping plugins (`InsertEnter` and friends) are still found after setup. That keeps working:
 
 - other plugins' mappings — mini.pairs `<BS>`/`<CR>`, blink.cmp / nvim-cmp `<CR>`/`<Tab>`, LuaSnip and copilot.lua `<Tab>`
 - your own mappings for those keys, expression mappings included
 - native behavior when nothing else is mapped: counts (`3o`), `autoindent`, `formatoptions` comment continuation, `backspace` semantics
 - fenced code blocks, where markdown-plus never acts and always defers
+- `<A-h/j/k/l>` outside a table, where your window-mover, snippet or terminal mapping runs instead (with no mapping at all, the key still falls back to plain cursor movement)
 
 Plugins that *capture* the mapping they displace (blink.cmp's `fallback`, copilot.lua's passthrough) are handled: handing our own `<Plug>` back terminates in native behavior rather than bouncing forever.
 
@@ -173,7 +174,7 @@ Each kind answers "would the handler act here?":
 
 There is no dedicated `<A-CR>` kind. `continue_list_content` acts on any list item line, which is exactly `"indent"`'s scope — borrow that one when writing an `<A-CR>` recipe.
 
-A pre-existing **buffer-local** mapping stops markdown-plus from installing its default for that key at all, so map buffer-locally (as above) or disable default keymaps first.
+A pre-existing **buffer-local** mapping stops markdown-plus from installing its default for that key at all, so map buffer-locally (as above) or disable default keymaps first. To leave the table navigation keys entirely unmapped, set `table = { keymaps = { insert_mode_navigation = false } }`.
 
 See `:help markdown-plus-interop` for the full reference.
 

--- a/doc/markdown-plus.txt
+++ b/doc/markdown-plus.txt
@@ -2053,6 +2053,10 @@ markdown-plus.list.in_list_context({kind})
                 `'backspace'`  `<BS>`: in the marker zone of a list item
                                line, where the marker would be removed
                 `'indent'`     `<Tab>`/`<S-Tab>`: on a list item line
+
+    Every kind is false inside a fenced code block, whatever the line looks
+    like: the handlers defer there unconditionally, so a `- item` inside a
+    markdown fence is not a context markdown-plus acts in.
     Returns: ~
         {boolean}  true when the matching handler would act. An unknown
                    {kind} reports an error and returns false.
@@ -2520,15 +2524,30 @@ Completion `<CR>`: confirm when the menu is open, continue the list otherwise:
       return '<CR>'
     end, { expr = true, buffer = true })
 <
-`<Tab>`: let a snippet plugin win, keep list indentation:
+`<Tab>`: let a snippet jump win, keep list indentation:
 >lua
     vim.keymap.set('i', '<Tab>', function()
+      if vim.snippet.active({ direction = 1 }) then
+        return '<Cmd>lua vim.snippet.jump(1)<CR>'
+      end
       if require('markdown-plus').in_list_context('indent') then
         return '<Plug>(MarkdownPlusListIndent)'
       end
       return '<Tab>'
     end, { expr = true, buffer = true })
 <
+IMPORTANT: ask the snippet engine *explicitly*, as above. A buffer-local
+mapping shadows the global `<Tab>` your snippet plugin installed, and
+returning `'<Tab>'` from it does not fall through to that global mapping —
+Neovim resolves the buffer-local mapping first, and its own recursion guard
+then terminates in a literal tab. Swap the two |vim.snippet| calls for your
+plugin's equivalents (`require('luasnip').jumpable(1)` / `.jump(1)`, and so
+on) if you do not use the built-in engine.
+
+This is only a concern when *you* own the key. markdown-plus's own default
+`<Tab>` resolves and runs the mapping it displaced, global ones included —
+see |markdown-plus-interop|.
+
 Each kind answers "would the handler act here?":
 
 - `'enter'`     broadest: on a list item line and on a wrapped continuation
@@ -2538,6 +2557,10 @@ Each kind answers "would the handler act here?":
                 the marker zone, at the start of list content. Mid-content it
                 is false, because `<BS>` there belongs to your pairs plugin,
                 not to markdown-plus.
+
+Every kind is false inside a fenced code block, whatever the line looks
+like — a `- item` inside a markdown fence included. markdown-plus never acts
+there, so neither does the predicate.
 
 There is no dedicated `<A-CR>` kind. |markdown-plus.list.continue_list_content|
 acts on any list item line, which is exactly `'indent'`'s scope — borrow that

--- a/doc/markdown-plus.txt
+++ b/doc/markdown-plus.txt
@@ -2441,17 +2441,19 @@ markdown-plus.utils.build_markdown_image(alt, url, {title})
 PLUGIN INTEROP                                          *markdown-plus-interop*
 
 markdown-plus installs buffer-local defaults for keys other plugins commonly
-own: `<BS>`, `<CR>`, `<Tab>`, `<S-Tab>`, `<A-CR>` (insert) and `o` / `O`
-(normal). In list context markdown-plus acts. Everywhere else it hands the key
-back rather than reimplementing the default behavior.
+own: `<BS>`, `<CR>`, `<Tab>`, `<S-Tab>`, `<A-CR>` (insert), `o` / `O` (normal)
+and the table cell navigation keys `<A-h>` `<A-j>` `<A-k>` `<A-l>` (insert).
+In its own context — a list for the list keys, a table for the navigation keys
+— markdown-plus acts. Everywhere else it hands the key back rather than
+reimplementing the default behavior.
 
 
 AUTOMATIC FALLBACK ~
 
 No configuration is required — this is always on.
 
-For each keypress outside list context markdown-plus resolves the mapping that
-would have run instead, in this order:
+For each such keypress outside markdown-plus's own context it resolves the
+mapping that would have run instead, in this order:
 
   1. a buffer-local mapping that is not markdown-plus's own
   2. a global mapping
@@ -2461,13 +2463,19 @@ Resolution happens on every keypress rather than once at startup, so plugins
 that map lazily — on `InsertEnter`, for example — are still found after
 markdown-plus has already set up the buffer.
 
-What this preserves outside list context:
+What this preserves outside that context:
 - other plugins' mappings (mini.pairs `<BS>`/`<CR>`, blink.cmp and
   nvim-cmp `<CR>`/`<Tab>` confirm/select, LuaSnip and copilot.lua `<Tab>`)
 - your own mappings for those keys, including expression mappings
 - native behavior when nothing else is mapped: counts (`3o`), 'autoindent',
   'formatoptions' comment continuation, 'backspace' semantics, abbreviations
 - fenced code blocks, where markdown-plus never acts and always defers
+- `<A-h/j/k/l>` outside a table, where your own window-mover, snippet or
+  terminal mapping runs instead. With nothing mapped these keys still fall
+  back to plain cursor movement (`<Left>` `<Down>` `<Up>` `<Right>`), which is
+  their documented no-table behavior; set >lua
+      table = { keymaps = { insert_mode_navigation = false } }
+<  to leave them entirely alone.
 
 Plugins that *capture* the mapping they displace (blink.cmp's `fallback`,
 copilot.lua's passthrough) are handled: when such a plugin hands markdown-plus

--- a/docs/manual-testing/phase1.md
+++ b/docs/manual-testing/phase1.md
@@ -1,0 +1,399 @@
+# Manual Testing Guide — Issue #376 Phase 1
+
+**Changes**: New `keymap_fallback` module; insert-mode `<BS>` now defers to pre-existing global/foreign mappings (mini.pairs etc.) and native Vim behavior instead of hand-rolled deletion. List-marker removal behavior unchanged.
+**Date**: 2026-07-27
+**Branch**: main (uncommitted working tree)
+**Tracking doc**: `docs/plans/376-keymap-fallback-tracking.md` (internal, not published)
+
+---
+
+## Prerequisites
+
+1. Neovim 0.11+ with your normal config, plus this working tree on `runtimepath` (e.g. `:set rtp+=/path/to/markdown-plus.nvim` in a scratch config, or point your plugin manager `dir =` at it). Make sure a _released_ copy of markdown-plus isn't loaded alongside.
+2. **mini.pairs** (or another autopairs plugin mapping `<BS>` in insert mode) installed and enabled — needed for the interop cases. If you don't want a real plugin, put this simulated "foreign mapping" in your config instead:
+   ```lua
+   -- simulated mini.pairs-style global <BS>
+   vim.keymap.set("i", "<BS>", function()
+     vim.g.foreign_bs_fired = (vim.g.foreign_bs_fired or 0) + 1
+     return "<BS>"
+   end, { expr = true, desc = "test foreign BS" })
+   ```
+   Check hits with `:echo g:foreign_bs_fired`.
+3. Open a markdown file: `nvim /tmp/376-test.md`.
+4. `:checkhealth markdown-plus` — should be clean before starting.
+
+`|` in the steps below marks the cursor position. All `<BS>` presses are in **insert mode** unless stated.
+
+---
+
+## Test Cases
+
+### 1. Empty list item — marker removal unchanged
+
+**Category**: Happy Path / Regression | **Priority**: P0
+
+**Steps**:
+
+1. Type a list: `- first item`, press Enter → new line reads `- `.
+2. With cursor after the marker (`- |`), press `<BS>`.
+
+**Expected Result**: List marker removed, line becomes empty (indent only). Foreign `<BS>` mapping does NOT fire for this press (`g:foreign_bs_fired` unchanged, or no pair behavior).
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 2. Start of list content — marker removal keeps content
+
+**Category**: Happy Path / Regression | **Priority**: P0
+
+**Steps**:
+
+1. Line: `- hello`, cursor at start of content (`- |hello`), insert mode.
+2. Press `<BS>`.
+
+**Expected Result**: Marker removed, line becomes `hello`, cursor before `h`. Foreign mapping does not fire.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 3. mini.pairs — paired deletion in plain text (the reported bug)
+
+**Category**: Happy Path | **Priority**: P0
+
+**Steps**:
+
+1. On a non-list line, in insert mode type `(` — autopairs gives `(|)`.
+2. Press `<BS>`.
+
+**Expected Result**: **Both** parens deleted (pair deletion works again). Before this fix only manual deletion happened.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 4. mini.pairs — paired deletion inside list item content
+
+**Category**: Happy Path | **Priority**: P0
+
+**Steps**:
+
+1. Line: `- note `, cursor at end, insert mode, type `(` → `- note (|)`.
+2. Press `<BS>`.
+
+**Expected Result**: Both parens deleted → `- note `. (New: fallback also applies inside list _content_, not only outside lists.)
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 5. Plain text backspace — native behavior
+
+**Category**: Happy Path | **Priority**: P0
+
+**Steps**:
+
+1. Non-list line `hello world`, cursor at end, insert mode.
+2. Press `<BS>` three times.
+
+**Expected Result**: `hello wo`. Nothing unusual — one char per press, no lag, cursor correct.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 6. NEW BEHAVIOR — col 0 of a list line joins with previous line
+
+**Category**: Edge Case | **Priority**: P0
+
+**Steps**:
+
+1. Two lines:
+   ```
+   some text
+   - item
+   ```
+2. Cursor at column 0 of `- item` (`|- item`), insert mode (`i` at line start).
+3. Press `<BS>`.
+
+**Expected Result**: Lines join → `some text- item`. **This was a silent no-op before Phase 1** — now it follows normal Vim `'backspace'` behavior. Confirm you're OK with this change.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 7. Respects your 'backspace' option
+
+**Category**: Edge Case | **Priority**: P1
+
+**Steps**:
+
+1. `:set backspace=` (empty).
+2. Insert mode at the start of any line with a line above; press `<BS>`.
+3. Restore afterwards: `:set backspace=indent,eol,start`.
+
+**Expected Result**: No join, no deletion past insert start — the option is honored (previously the plugin always deleted regardless).
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 8. Buffer start — nothing to delete
+
+**Category**: Edge Case | **Priority**: P1
+
+**Steps**:
+
+1. Cursor line 1, col 0 of the file, insert mode.
+2. Press `<BS>`.
+
+**Expected Result**: No error, no notification, nothing deleted.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 9. Unicode deletion
+
+**Category**: Edge Case / Regression | **Priority**: P1
+
+**Steps**:
+
+1. Line: `- café`, cursor at end, insert mode.
+2. Press `<BS>` once.
+
+**Expected Result**: `- caf` — the whole `é` deleted in one press, no mojibake/half-character.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 10. Nested list marker removal
+
+**Category**: Regression | **Priority**: P1
+
+**Steps**:
+
+1. Lines:
+   ```
+   - parent
+     - child
+   ```
+2. On the child line, cursor at start of content (`  - |child`), press `<BS>`.
+
+**Expected Result**: Marker removed → `  child` (indent preserved). Foreign mapping not fired.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 11. KNOWN LIMITATION — inside fenced code block, pairs NOT honored yet
+
+**Category**: Edge Case | **Priority**: P1
+
+**Steps**:
+
+1. Create a fenced block and go inside:
+   ````
+   ```lua
+   x = (|)
+   ```
+   ````
+   (type the parens with autopairs active)
+2. Press `<BS>`.
+
+
+**Expected Result**: Only ONE paren deleted (raw native backspace) — the code-block path still bypasses foreign mappings. **This is expected until Phase 2.** Record here how disruptive this feels in practice.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 12. Pre-existing buffer-local <BS> mapping wins
+
+**Category**: Regression | **Priority**: P1
+
+**Steps**:
+
+1. In a NEW markdown buffer, BEFORE the FileType autocmd runs is hard to arrange manually — instead: open any non-markdown buffer, run
+   `:lua vim.keymap.set("i", "<BS>", function() vim.notify("mine!") end, { buffer = true })`
+   then `:set filetype=markdown`.
+2. Insert mode, press `<BS>`.
+
+**Expected Result**: `mine!` notification — the plugin did not override your buffer-local mapping (unchanged pre-existing behavior).
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 13. Lazy-loaded pairs plugin still found
+
+**Category**: Edge Case | **Priority**: P1
+
+**Steps**:
+
+1. If mini.pairs is lazy-loaded (e.g. on `InsertEnter`): open the markdown file fresh, do NOT enter insert mode yet, then enter insert mode, type `(`, press `<BS>`.
+2. If your pairs plugin loads eagerly: simulate instead — open the markdown buffer first, THEN define the simulated foreign mapping from Prerequisites, then test `<BS>` on a non-list line.
+
+**Expected Result**: Foreign mapping honored even though it was created AFTER markdown-plus set up the buffer (resolution is per-keypress, not snapshotted).
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+> Confirmed after clarification: mapping defined after buffer setup is still honored (per-keypress resolution).
+
+---
+
+### 14. Foreign mapping that errors — graceful degradation
+
+**Category**: Error Handling | **Priority**: P1
+
+**Steps**:
+
+1. `:lua vim.keymap.set("i", "<BS>", function() error("boom") end, { desc = "broken foreign BS" })` (global).
+2. In the markdown buffer, non-list line, insert mode, press `<BS>`.
+3. Clean up: `:lua vim.keymap.del("i", "<BS>")`.
+
+**Expected Result**: A `markdown-plus:`-prefixed error notification (no raw stack-trace crash, no stuck insert mode); the key still degrades to a plain backspace.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 15. Other list keys untouched
+
+**Category**: Regression | **Priority**: P0
+
+**Steps**:
+
+1. On `- item`, press Enter at end of line → auto-continues `- `.
+2. Press `<Tab>` on the new item → indents.
+3. Press `<S-Tab>` → outdents.
+4. Normal mode `o` on a list line → new list item below.
+
+**Expected Result**: All list behaviors exactly as before Phase 1. (Note: `<CR>`/`<Tab>`/`<S-Tab>` still shadow cmp/pairs mappings — that's Phase 2, not a Phase 1 regression.)
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 16. Non-markdown buffers unaffected
+
+**Category**: Regression | **Priority**: P0
+
+**Steps**:
+
+1. Open a `.lua` or `.txt` file, insert mode, use `<BS>` normally; with autopairs, type `(` then `<BS>`.
+
+**Expected Result**: Identical to your normal (non-markdown) editing — plugin buffer-local maps absent (`:imap <BS>` shows no MarkdownPlus entry).
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 17. Rapid/held backspace — performance
+
+**Category**: Performance | **Priority**: P2
+
+**Steps**:
+
+1. In a large markdown file (a few hundred lines), insert mode at end of a long paragraph.
+2. Hold `<BS>` for ~3 seconds.
+
+**Expected Result**: Smooth continuous deletion, no visible lag or stutter (fallback resolution runs per keypress).
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 18. Health + startup clean
+
+**Category**: Regression | **Priority**: P2
+
+**Steps**:
+
+1. Fresh `nvim /tmp/376-test.md`, then `:checkhealth markdown-plus` and `:messages`.
+
+**Expected Result**: Health OK, no new warnings/errors in messages.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+## Summary
+
+**Overall Result**: [x] PASS [ ] FAIL
+**Tested By**: YousefHadder (2026-07-27)
+**General Notes**:
+
+> (overall observations, concerns, follow-ups — especially: is the case-6 col-0 join acceptable, and how painful is the case-11 code-block limitation before Phase 2?)

--- a/docs/manual-testing/phase2.md
+++ b/docs/manual-testing/phase2.md
@@ -1,0 +1,360 @@
+# Manual Testing Guide — Issue #376 Phase 2
+
+**Changes**: `<CR>`, `<Tab>`, `<S-Tab>` non-list paths and the code-block fall-through (`skip_in_codeblock`) now defer to your real mappings (cmp/blink, mini.pairs, snippets) or native Vim behavior via `keymap_fallback`, instead of hand-rolled/raw-key behavior. Fixes the Phase-1 code-block limitation (`<BS>` pairs now work inside fences). `o`/`O` inside code blocks resolve normal-mode foreign mappings.
+**Date**: 2026-07-28
+**Branch**: main (uncommitted working tree; Phase 1 committed as 74b3596)
+**Tracking doc**: `docs/plans/376-keymap-fallback-tracking.md` (internal, not published)
+
+---
+
+## Prerequisites
+
+Same setup as Phase 1 (Phase 1 (`phase1.md`)): this working tree on `runtimepath`, mini.pairs (or simulated foreign mapping) active, `nvim /tmp/376-test.md`.
+
+Optional counters for keys beyond `<BS>` (run in Neovim before testing):
+
+```lua
+-- WARNING: these are *global* mappings and they overwrite whatever your completion /
+-- snippet plugin already mapped for these keys. blink.cmp and copilot.lua re-apply their
+-- own buffer-local mappings on InsertEnter, so restart Neovim when you are done counting.
+_G.foreign_fired = {}
+for _, key in ipairs({ "<CR>", "<Tab>", "<S-Tab>" }) do
+  vim.keymap.set("i", key, function()
+    -- vim.g returns a copy, so the counters must live in a plain Lua table
+    _G.foreign_fired[key] = (_G.foreign_fired[key] or 0) + 1
+    return key
+  end, { expr = true, desc = "test foreign " .. key })
+end
+```
+
+
+Check with `:lua vim.print(_G.foreign_fired)`. NOTE: if you use nvim-cmp/blink.cmp, its own `<CR>`/`<Tab>` config plays the foreign-mapping role — you can test with your real completion plugin instead of counters.
+
+`|` marks cursor. Insert mode unless stated.
+
+---
+
+## Test Cases
+
+### 1. List auto-continue unchanged
+
+**Category**: Regression | **Priority**: P0
+
+**Steps**:
+
+1. Line `- item`, cursor at end, press `<CR>`.
+2. On the new `- ` line, press `<CR>` again.
+
+- item
+
+**Expected Result**: First press auto-continues (`- `), second press removes the empty marker and breaks out. Foreign `<CR>` counter unchanged for both presses.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 2. List indent/outdent unchanged
+
+**Category**: Regression | **Priority**: P0
+
+**Steps**:
+
+1. On a list item in insert mode, press `<Tab>` → indents; press `<S-Tab>` → outdents. Verify numbered lists renumber correctly.
+
+
+**Expected Result**: Identical to before. Foreign `<Tab>`/`<S-Tab>` counters unchanged.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 3. `<CR>` on non-list line — real Enter behavior restored
+
+**Category**: Happy Path | **Priority**: P0
+
+**Steps**:
+
+1. Non-list paragraph line, cursor mid-line, press `<CR>`.
+2. If using cmp/blink: open a completion menu on a non-list line and confirm an entry with `<CR>`.
+
+hello
+world
+**Expected Result**: Line splits at cursor like plain Vim; completion confirm works (previously the plugin hand-split and bypassed your `<CR>` mapping). Foreign counter increments (or cmp confirm fires).
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 4. `<CR>` autoindent / comment continuation on non-list lines
+
+**Category**: Happy Path | **Priority**: P0
+
+**Steps**:
+
+1. Indented non-list line (e.g. `    some text`), cursor at end, press `<CR>`.
+2. Type an abbreviation you have defined (if any), then `<CR>`.
+    some text
+    hello
+
+**Expected Result**: New line keeps indent (`'autoindent'` honored); abbreviations expand. Previously cursor was forced to column 0 and abbreviations were skipped.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 5. `<Tab>` / `<S-Tab>` on non-list lines reach your mappings
+
+**Category**: Happy Path | **Priority**: P0
+
+**Steps**:
+
+1. Non-list line, insert mode, press `<Tab>`, then `<S-Tab>`.
+2. If you use a snippet/completion `<Tab>` mapping: verify it triggers (e.g. snippet jump, cmp select).
+
+**Expected Result**: Foreign counters increment / your snippet-completion `<Tab>` works. Without foreign mapping: a literal tab / dedent as native.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 6. Code block — `<BS>` pair deletion NOW WORKS (Phase-1 case 11 fixed)
+
+**Category**: Happy Path | **Priority**: P0
+
+**Steps**:
+
+1. Inside a fenced block:
+   ````
+   ```lua
+   x = (|)
+   ```
+   ````
+   (parens typed with autopairs)
+2. Press `<BS>`.
+
+```lua
+x =
+```
+**Expected Result**: **Both** parens deleted — pairs honored inside fences now.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 7. Code block — `<CR>` and `<Tab>` honor foreign mappings
+
+**Category**: Happy Path | **Priority**: P1
+
+**Steps**:
+
+1. Inside the same fenced block, press `<CR>` mid-line, then `<Tab>`.
+2. With mini.pairs: type `{` at end of a line in the block, press `<CR>` — pairs' smart brace-expand should fire if you use that feature.
+
+**Expected Result**: Foreign counters increment; native behavior when no foreign map. No list logic fires inside the fence.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 8. Code block — `o` / `O` still work in normal mode
+
+**Category**: Regression | **Priority**: P1
+
+**Steps**:
+
+1. Normal mode on a line inside the fenced block, press `o`, escape, press `O`.
+
+```
+
+line
+
+
+```
+**Expected Result**: Plain new line below/above, insert mode entered — exactly as before Phase 2. (If you have a custom normal-mode `o` mapping, it now fires inside fences.)
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 9. `o` / `O` on list lines unchanged
+
+**Category**: Regression | **Priority**: P0
+
+**Steps**:
+
+1. Normal mode on `- item` (outside any fence), press `o` → new list item below. Escape, press `O` → item above.
+-
+- item
+-
+**Expected Result**: List continuation exactly as before.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 10. `<A-CR>` KNOWN LIMITATION — non-list hand-roll remains
+
+**Category**: Edge Case | **Priority**: P2
+
+**Steps**:
+
+1. Non-list line, insert mode, press `<A-CR>` (list "continue content" key).
+
+hello world
+
+**Expected Result**: Plain line split with cursor at column 0 (old hand-rolled behavior — deliberately unchanged; decision deferred to Phase 4). In a code block it defers like other keys.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 11. Erroring foreign `<CR>` mapping — graceful degradation
+
+**Category**: Error Handling | **Priority**: P1
+
+**Steps**:
+
+1. `:lua vim.keymap.set("i", "<CR>", function() error("boom") end)` (global).
+2. Non-list line, insert mode, press `<CR>`.
+3. Clean up: `:lua vim.keymap.del("i", "<CR>")`.
+
+hello world
+
+**Expected Result**: `markdown-plus:`-prefixed error notification, key degrades to plain newline, no stuck insert mode.
+
+**Result**: [ ] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 11b. Capturing completion plugins — no freeze (blink.cmp / copilot.lua)
+
+**Category**: Error Handling | **Priority**: P0
+
+Plugins like blink.cmp and copilot.lua *replace* our buffer-local `<Tab>`/`<S-Tab>`
+and capture the mapping they displaced (our `<Plug>(MarkdownPlus…)`) as **their**
+fallback. Without a loop breaker this ping-pongs forever and hard-freezes Neovim.
+
+**Steps**:
+
+1. Use your real config, with blink.cmp and/or copilot.lua enabled.
+2. Open a markdown file, put the cursor on a non-list line (inside a fenced code block is fine).
+3. Insert mode, press `<Tab>` several times, then `<S-Tab>` several times.
+4. `:imap <Tab>` — expect the completion plugin's mapping, not ours.
+
+**Expected Result**: Every press resolves immediately. No freeze, no hang, no
+runaway CPU. When the completion plugin has nothing to do, the key degrades to its
+raw/native behavior.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 12. Non-markdown buffers unaffected
+
+**Category**: Regression | **Priority**: P0
+
+**Steps**:
+
+1. `.lua`/`.txt` file: `<CR>`, `<Tab>`, `<S-Tab>`, `o`, `O` behave as your normal config; `:imap <CR>` shows no MarkdownPlus entry.
+
+**Expected Result**: Identical to normal editing.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 13. Typing flow — no lag, no key reordering
+
+**Category**: Performance | **Priority**: P2
+
+**Steps**:
+
+1. Type a few fast paragraphs with mixed `<CR>`/`<Tab>`/`<BS>` in and out of lists and fences.
+
+**Expected Result**: No lag, no characters appearing out of order, no stray keys.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 14. Health + startup clean
+
+**Category**: Regression | **Priority**: P2
+
+**Steps**:
+
+1. Fresh `nvim /tmp/376-test.md`, `:checkhealth markdown-plus`, `:messages`.
+
+**Expected Result**: Health OK, no new warnings/errors.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+## Summary
+
+**Overall Result**: [x] PASS [ ] FAIL
+**Tested By**:
+**General Notes**:
+
+> (especially: does `<CR>` with your completion plugin feel right on non-list lines, and any surprises inside code fences?)

--- a/docs/manual-testing/phase3.md
+++ b/docs/manual-testing/phase3.md
@@ -1,0 +1,241 @@
+# Manual Testing Guide — Issue #376 Phase 3
+
+**Changes**: Normal-mode `o`/`O` on **non-list** lines now defer to your own `o`/`O` mapping (if any) or native Vim behavior via `keymap_fallback`, instead of a hand-rolled blank-line insert. Restores `'autoindent'`, `'formatoptions'` comment continuation, counts (`3o`), and user mappings. List-line behavior (marker continuation, smart outdent) unchanged.
+**Date**: 2026-07-28
+**Branch**: main (uncommitted working tree; Phases 1-2 committed as 74b3596, 1793cc1)
+**Tracking doc**: `docs/plans/376-keymap-fallback-tracking.md` (internal, not published)
+
+---
+
+## Prerequisites
+
+Same setup as previous phases: this working tree on `runtimepath`, `nvim /tmp/376-test.md`.
+
+Optional foreign-mapping counter (normal mode this time):
+
+```lua
+_G.o_fired = 0
+vim.keymap.set("n", "o", function()
+  _G.o_fired = _G.o_fired + 1
+  return "o"
+end, { expr = true, desc = "test foreign o" })
+```
+
+Check with `:lua vim.print(_G.o_fired)`. Remove with `:lua vim.keymap.del("n", "o")`.
+
+`|` marks cursor. Normal mode unless stated.
+
+---
+
+## Test Cases
+
+### 1. `o` / `O` on list lines unchanged
+
+**Category**: Regression | **Priority**: P0
+
+**Steps**:
+
+
+1. On `- item`, press `o` → new list item below, insert mode after marker. Escape.
+2. Press `O` → list item above.
+3. Numbered list: on `1. item`, press `o` → `2. ` and renumbering correct.
+
+-
+- item
+-
+**Expected Result**: Identical to before. Foreign `o` counter unchanged.
+
+**Result**: [ ] PASS [x] FAIL
+
+**Notes**:
+
+> counter printed 1
+---
+
+### 2. `o` / `O` on non-list lines — native behavior
+
+**Category**: Happy Path | **Priority**: P0
+
+**Steps**:
+
+1. Plain paragraph line, press `o` → type `x` → Escape. Then `O` → type `y` → Escape.
+
+y
+hello world
+x
+**Expected Result**: Line with `x` below, line with `y` above, insert mode entered each time — same as vanilla Vim.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+> counter printed 3
+---
+
+### 3. `'autoindent'` preserved on non-list `o`
+
+**Category**: Happy Path | **Priority**: P0
+
+**Steps**:
+
+1. Indented non-list line `    some text`, cursor on it, press `o`, type `more`.
+
+    some text
+    more
+**Expected Result**: New line is `    more` — indent kept. Before Phase 3: cursor forced to column 0.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 4. Count works: `3o` opens three lines
+
+**Category**: Happy Path | **Priority**: P0
+
+**Steps**:
+
+1. Non-list line, press `3o`, type `x`, press Escape.
+
+
+hello world
+x
+x
+x
+
+**Expected Result**: Three new lines each containing `x` (count applies when leaving insert mode — vanilla Vim behavior). Before Phase 3: one line only.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 5. Your own `o` mapping fires on non-list lines
+
+**Category**: Happy Path | **Priority**: P1
+
+**Steps**:
+
+1. Install the counter mapping from Prerequisites.
+2. Non-list line, press `o`, Escape. Check `:lua vim.print(_G.o_fired)` → increments.
+3. List line `- item`, press `o`, Escape → counter does NOT increment (list logic wins).
+4. Clean up the mapping.
+
+- item
+-
+hello world
+
+- item
+-
+**Expected Result**: Foreign map honored outside lists, list continuation preserved inside.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+> counter printed 2 then 3
+
+---
+
+### 6. Comment continuation (`'formatoptions'`)
+
+**Category**: Edge Case | **Priority**: P2
+
+**Steps**:
+
+1. In a fenced ```lua block, line `-- comment`, press `o` (with your normal `formatoptions` including `o` flag).
+
+```
+-- comment
+
+```
+**Expected Result**: Whatever your vanilla Vim config does (comment leader continued if configured). Plugin no longer suppresses it on non-list lines.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 7. Code block `o` / `O` (regression from Phase 2)
+
+**Category**: Regression | **Priority**: P1
+
+**Steps**:
+
+1. Inside a fenced code block, press `o`, Escape, `O`, Escape.
+
+```
+
+
+
+```
+**Expected Result**: Plain lines opened, insert mode entered, no list logic. Same as Phase 2 testing.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 8. Non-markdown buffers unaffected
+
+**Category**: Regression | **Priority**: P0
+
+**Steps**:
+
+1. `.lua`/`.txt` file: `o`, `O`, `3o` behave exactly as your normal config; `:nmap o` shows no MarkdownPlus entry.
+
+**Expected Result**: Identical to normal editing.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 9. Health + startup clean
+
+**Category**: Regression | **Priority**: P2
+
+**Steps**:
+
+1. Fresh `nvim /tmp/376-test.md`, `:checkhealth markdown-plus`, `:messages`.
+
+**Expected Result**: Health OK, no new warnings/errors.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+## Known gaps (documented, not bugs to report)
+
+- Count on a *list* line still creates one item (pre-existing, unchanged).
+- Count is not re-applied on rare degradation paths (fallback bounce, erroring foreign map) — avoids double-apply risk.
+- Foreign `o` mapping with a string rhs (`:nmap o ggo` style) loses the count; Lua-callback mappings (all real plugins) see it fine.
+
+---
+
+## Summary
+
+**Overall Result**: [ ] PASS [ ] FAIL
+**Tested By**:
+**General Notes**:
+
+>

--- a/docs/manual-testing/phase4.md
+++ b/docs/manual-testing/phase4.md
@@ -1,0 +1,155 @@
+# Manual Testing Guide — Issue #376 Phase 4 (final)
+
+**Changes**: Public API `in_list_context(kind)`; `<A-CR>` now defers to your mappings on non-list lines (last hand-rolled key); `<Plug>` registration state reset on plugin teardown; new "Interop" docs in README + vimdoc.
+**Date**: 2026-07-29
+**Branch**: main (uncommitted working tree; Phases 1-3 committed as 74b3596, 1793cc1, d83e4ed)
+**Tracking doc**: `docs/plans/376-keymap-fallback-tracking.md` (internal, not published)
+
+---
+
+## Prerequisites
+
+Same as previous phases. `nvim /tmp/376-test.md`.
+
+---
+
+## Test Cases
+
+### 1. Public API — list context queries
+
+**Category**: Happy Path | **Priority**: P0
+
+**Steps**:
+
+1. Cursor on `- item` line, run:
+   `:lua print(require("markdown-plus").in_list_context())` → expect `true`
+2. Cursor on a plain paragraph line, same command → expect `false`
+3. On the list line: `:lua print(require("markdown-plus").in_list_context("indent"))` → `true`;
+   `"backspace"` kind is **marker-zone only** (true only where `<BS>` would remove the marker):
+   cursor on the first content char (`- |item`, normal-mode cursor on `i`) →
+   `:lua print(require("markdown-plus").in_list_context("backspace"))` → `true`;
+   cursor mid-content or at col 0 → `false` (correct — `<BS>` defers there).
+4. Bad kind: `:lua print(require("markdown-plus").in_list_context("bogus"))` → error notification + `false`, no crash.
+
+- item
+**Expected Result**: As above; buffer unchanged by any call.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+> step 3 second command gave false instead of true on a list line
+> RESOLVED: guide expectation was stale — "backspace" kind is marker-zone-only after review
+> blocker fix; false mid-content/col-0 is correct. Spec-covered (13/13 in list_context_spec).
+
+---
+
+### 2. `<A-CR>` on non-list line defers
+
+**Category**: Happy Path | **Priority**: P0
+
+**Steps**:
+
+1. Non-list line, insert mode, press `<A-CR>` (terminal permitting; if your terminal swallows Alt+Enter, run `:lua vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("i<A-CR>", true, false, true), "m", false)` instead).
+
+hello world
+**Expected Result**: Plain newline via native behavior / your own `<A-CR>` mapping if you have one. (Before: hand-rolled split with cursor forced to column 0.)
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+> failed with error [Copilot.lua] 'filetype' markdown rejected by internal_filetypes[markdown]
+> RESOLVED — ACCEPTED as correct interop: copilot.lua maps global insert <M-CR> (panel.open)
+> and disables markdown by default; it logs the error itself and consumes the key. Identical
+> to vanilla nvim without markdown-plus. Pre-Phase-4 our buffer-local <A-CR> masked copilot's
+> key — that masking was the #376 bug class. User remedies documented in interop docs
+> (remap copilot panel.open, or copilot filetypes = { markdown = true }).
+
+
+---
+
+### 3. `<A-CR>` list behavior unchanged
+
+**Category**: Regression | **Priority**: P0
+
+**Steps**:
+
+1. On `- some item text`, cursor mid-content, insert mode, press `<A-CR>`.
+
+- some
+  item text
+**Expected Result**: Content continuation exactly as before Phase 4 (continuation line under the item, no new marker).
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 4. Teardown/re-setup clean
+
+**Category**: Regression | **Priority**: P1
+
+**Steps**:
+
+1. `:lua require("markdown-plus").teardown()` (if teardown is exposed; else skip)
+2. `:lua require("markdown-plus").setup({})`, reopen the markdown file.
+3. `:imap <CR>` → MarkdownPlus mapping present again; keys behave normally.
+
+**Expected Result**: Second setup re-registers all defaults, no errors.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 5. Docs render
+
+**Category**: Docs | **Priority**: P1
+
+**Steps**:
+
+1. `:helptags ALL` then `:help markdown-plus-interop`, `:help markdown-plus-recipes`, `:help markdown-plus.list.in_list_context`.
+2. Skim README "Interop with completion/pairs plugins" section — recipes look right, match vimdoc.
+
+**Expected Result**: All tags resolve; recipes consistent between files.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+### 6. Whole-surface smoke (regression)
+
+**Category**: Regression | **Priority**: P0
+
+**Steps**:
+
+1. Quick pass with your real config: lists (`<CR>` continue, `<Tab>`/`<S-Tab>` indent, `<BS>` marker removal, `o`/`O`, checkboxes), pairs in and out of code fences, `3o`, blink/copilot `<Tab>` — no freezes, no surprises.
+
+**Expected Result**: Everything from Phases 1-3 still good.
+
+**Result**: [x] PASS [ ] FAIL
+
+**Notes**:
+
+>
+
+---
+
+## Summary
+
+**Overall Result**: [ ] PASS [ ] FAIL
+**Tested By**:
+**General Notes**:
+
+>

--- a/docs/wiki/4.Usage.md
+++ b/docs/wiki/4.Usage.md
@@ -5,6 +5,12 @@ The plugin automatically activates when you open a markdown file (`.md` extensio
 > [!TIP]
 > For v2.0 mapping changes and migration steps, see the [v2.0 Migration Guide](https://github.com/YousefHadder/markdown-plus.nvim/wiki/9.v2.0-Migration-Guide).
 
+Keys shared with other plugins (`<BS>`, `<CR>`, `<Tab>`, `<S-Tab>`, `<A-CR>`, `o`, `O`, and the table navigation
+keys `<A-h>` / `<A-j>` / `<A-k>` / `<A-l>`) only act inside markdown-plus's own context — a list, or a table for
+the navigation keys. Outside it they defer to your own mapping, another plugin's mapping, or native Neovim
+behavior. See the [Keymaps Reference](https://github.com/YousefHadder/markdown-plus.nvim/wiki/5.Keymaps) and
+[Customizing Keymaps](https://github.com/YousefHadder/markdown-plus.nvim/wiki/6.Customizing-Keymaps#interop-with-other-plugins).
+
 ## List Management Examples
 
 ### Auto-continue Lists

--- a/docs/wiki/5.Keymaps.md
+++ b/docs/wiki/5.Keymaps.md
@@ -2,6 +2,14 @@
 
 Default mappings use the `<localleader>` namespace in v2.0.
 
+> [!NOTE]
+> **Shared keys fall back automatically.** Some defaults live on keys other plugins commonly own:
+> `<BS>`, `<CR>`, `<Tab>`, `<S-Tab>`, `<A-CR>`, `o`, `O`, and the table navigation keys
+> `<A-h>` / `<A-j>` / `<A-k>` / `<A-l>`. markdown-plus only acts in its own context — a list for the
+> list keys, a table for the navigation keys. Everywhere else the key is handed back to your own
+> mapping, to another plugin's mapping, or to native Neovim behavior. No configuration required.
+> See [Customizing Keymaps](https://github.com/YousefHadder/markdown-plus.nvim/wiki/6.Customizing-Keymaps#interop-with-other-plugins).
+
 ## List Management
 
 ### Insert mode
@@ -145,7 +153,7 @@ ordered types are renumbered automatically.
 | `<localleader>tt` | Transpose table |
 | `<localleader>tsa` / `tsd` | Sort by column ascending / descending |
 | `<localleader>tvx` / `tvi` | Convert to CSV / from CSV |
-| `<A-h>` `<A-j>` `<A-k>` `<A-l>` | Insert-mode table navigation |
+| `<A-h>` `<A-j>` `<A-k>` `<A-l>` | Insert-mode table navigation (outside a table the key is handed back; see the note at the top) |
 
 ## Footnotes
 

--- a/docs/wiki/6.Customizing-Keymaps.md
+++ b/docs/wiki/6.Customizing-Keymaps.md
@@ -62,6 +62,88 @@ vim.keymap.set("n", "<C-b>", "<Plug>(MarkdownPlusBold)")
 
 Defaults are only set when the target `<Plug>` is not already mapped, so your custom mappings win.
 
+## Interop with other plugins
+
+markdown-plus maps keys other plugins commonly own: `<BS>`, `<CR>`, `<Tab>`, `<S-Tab>`, `<A-CR>` (insert),
+`o` / `O` (normal) and the table cell navigation keys `<A-h>` / `<A-j>` / `<A-k>` / `<A-l>` (insert).
+In its own context — a list for the list keys, a table for the navigation keys — markdown-plus acts.
+**Everywhere else it hands the key back** instead of reimplementing the default behavior. No configuration
+required — this is always on.
+
+For each such keypress outside markdown-plus's own context it resolves what would have run instead: a non-markdown-plus
+buffer-local mapping → a global mapping → the raw key. Resolution happens per keypress, so lazily-mapping
+plugins (`InsertEnter` and friends) are still found after setup. That keeps working:
+
+- other plugins' mappings — mini.pairs `<BS>`/`<CR>`, blink.cmp / nvim-cmp `<CR>`/`<Tab>`, LuaSnip and copilot.lua `<Tab>`
+- your own mappings for those keys, expression mappings included
+- native behavior when nothing else is mapped: counts (`3o`), `autoindent`, `formatoptions` comment continuation, `backspace` semantics
+- fenced code blocks, where markdown-plus never acts and always defers
+- `<A-h/j/k/l>` outside a table, where your window-mover, snippet or terminal mapping runs instead (with no mapping at all, the key still falls back to plain cursor movement)
+
+Plugins that *capture* the mapping they displace (blink.cmp's `fallback`, copilot.lua's passthrough) are
+handled: handing our own `<Plug>` back terminates in native behavior rather than bouncing forever.
+
+### Taking over a key yourself
+
+Map the key yourself and ask whether markdown-plus would have acted, via
+`require("markdown-plus").in_list_context(kind)` — `kind` is `"enter"` (default), `"backspace"` or
+`"indent"`. It is read-only and cheap, so it is safe from an expression mapping.
+
+mini.pairs `<BS>` with list-marker deletion preserved:
+
+```lua
+vim.keymap.set("i", "<BS>", function()
+  if require("markdown-plus").in_list_context("backspace") then
+    return "<Plug>(MarkdownPlusListBackspace)"
+  end
+  return require("mini.pairs").bs()
+end, { expr = true, buffer = true })
+```
+
+Completion `<CR>`: confirm when the menu is open, continue the list otherwise:
+
+```lua
+vim.keymap.set("i", "<CR>", function()
+  if vim.fn.pumvisible() == 1 then
+    return "<C-y>"
+  end
+  if require("markdown-plus").in_list_context("enter") then
+    return "<Plug>(MarkdownPlusListEnter)"
+  end
+  return "<CR>"
+end, { expr = true, buffer = true })
+```
+
+`<Tab>`: let a snippet plugin win, keep list indentation:
+
+```lua
+vim.keymap.set("i", "<Tab>", function()
+  if require("markdown-plus").in_list_context("indent") then
+    return "<Plug>(MarkdownPlusListIndent)"
+  end
+  return "<Tab>"
+end, { expr = true, buffer = true })
+```
+
+### `in_list_context(kind)` reference
+
+Each kind answers "would the handler act here?":
+
+| `kind` | True when |
+|---|---|
+| `"enter"` | Broadest: on a list item line *and* on a wrapped continuation line under one. |
+| `"indent"` | Anywhere on a list item line. |
+| `"backspace"` | Narrowest: only where the marker would actually be removed (cursor in the marker zone, at the start of list content). Mid-content it is `false`, because `<BS>` there belongs to your pairs plugin, not to us. |
+
+There is no dedicated `<A-CR>` kind. `continue_list_content` acts on any list item line, which is exactly
+`"indent"`'s scope — borrow that one when writing an `<A-CR>` recipe.
+
+A pre-existing **buffer-local** mapping stops markdown-plus from installing its default for that key at all,
+so map buffer-locally (as above) or disable default keymaps first. To keep the table navigation keys
+entirely unmapped, set `table = { keymaps = { insert_mode_navigation = false } }`.
+
+See `:help markdown-plus-interop` for the full reference.
+
 ## Discover available `<Plug>` mappings
 
 Use vimdoc for the complete up-to-date list:

--- a/docs/wiki/6.Customizing-Keymaps.md
+++ b/docs/wiki/6.Customizing-Keymaps.md
@@ -60,7 +60,16 @@ require("markdown-plus").setup({
 vim.keymap.set("n", "<C-b>", "<Plug>(MarkdownPlusBold)")
 ```
 
-Defaults are only set when the target `<Plug>` is not already mapped, so your custom mappings win.
+Defaults are buffer-local, and markdown-plus skips one only when a **buffer-local** mapping for that
+same key already exists as it sets the buffer up. A *global* mapping of your own does not stop the
+default from being installed — the buffer-local default shadows it.
+
+For the keys markdown-plus shares with other plugins (`<BS>`, `<CR>`, `<Tab>`, `<S-Tab>`, `<A-CR>`,
+`o` / `O`, `<A-h/j/k/l>`) that shadowing costs you nothing: outside markdown-plus's own context the
+key is handed straight back to whatever mapping it displaced, global ones included — see
+[Interop with other plugins](#interop-with-other-plugins) below. For any other key, map
+buffer-locally (from a `FileType markdown` autocommand) or set `keymaps = { enabled = false }` if
+your mapping must win.
 
 ## Interop with other plugins
 
@@ -114,16 +123,29 @@ vim.keymap.set("i", "<CR>", function()
 end, { expr = true, buffer = true })
 ```
 
-`<Tab>`: let a snippet plugin win, keep list indentation:
+`<Tab>`: let a snippet jump win, keep list indentation:
 
 ```lua
 vim.keymap.set("i", "<Tab>", function()
+  if vim.snippet.active({ direction = 1 }) then
+    return "<Cmd>lua vim.snippet.jump(1)<CR>"
+  end
   if require("markdown-plus").in_list_context("indent") then
     return "<Plug>(MarkdownPlusListIndent)"
   end
   return "<Tab>"
 end, { expr = true, buffer = true })
 ```
+
+> [!IMPORTANT]
+> Ask the snippet engine **explicitly**, as above. A buffer-local mapping shadows the global
+> `<Tab>` your snippet plugin installed, and returning `"<Tab>"` from it does not fall through to
+> that global mapping — Neovim resolves the buffer-local one first, and its own recursion guard
+> then terminates in a literal tab. Swap the two `vim.snippet` calls for your plugin's equivalents
+> (`require("luasnip").jumpable(1)` / `.jump(1)`, and so on) if you do not use the built-in engine.
+>
+> This is only a concern when *you* own the key. markdown-plus's own default `<Tab>` resolves and
+> runs the mapping it displaced, global ones included — that is what the section above describes.
 
 ### `in_list_context(kind)` reference
 
@@ -134,6 +156,9 @@ Each kind answers "would the handler act here?":
 | `"enter"` | Broadest: on a list item line *and* on a wrapped continuation line under one. |
 | `"indent"` | Anywhere on a list item line. |
 | `"backspace"` | Narrowest: only where the marker would actually be removed (cursor in the marker zone, at the start of list content). Mid-content it is `false`, because `<BS>` there belongs to your pairs plugin, not to us. |
+
+Every kind is `false` inside a fenced code block, whatever the line looks like — a `- item` in a
+` ```markdown ` fence included. markdown-plus never acts there, so neither does the predicate.
 
 There is no dedicated `<A-CR>` kind. `continue_list_content` acts on any list item line, which is exactly
 `"indent"`'s scope — borrow that one when writing an `<A-CR>` recipe.

--- a/lua/markdown-plus/keymap_fallback.lua
+++ b/lua/markdown-plus/keymap_fallback.lua
@@ -66,6 +66,11 @@ local normalized_cache = {}
 ---@field count? integer Normal-mode count (`v:count1`) to re-apply to the keys the fallback
 ---feeds — the resolved target's own keys, or the raw key when it degrades. Pass only from
 ---normal-mode handlers that have not acted on the count themselves.
+---@field fallback_key? string Key to feed instead of `lhs` on every degradation path (no
+---target, bounce, target error). For defaults that sit on a key with no native meaning of its
+---own — table navigation's `<A-l>` is inert in insert mode — degrading to the literal lhs
+---would swallow the press; naming the key the handler documents as its no-context behavior
+---(`<Right>`) keeps it. Resolution and the recursion rule still use `lhs`.
 
 ---Normalize a keymap left-hand side to its internal byte representation for comparison
 ---@param lhs string Left-hand side in any notation (e.g. "<BS>", "<F5>", "x")
@@ -173,18 +178,21 @@ local function feed(keys, noremap)
   vim.api.nvim_feedkeys(keys, noremap and "ni" or "mi", false)
 end
 
----Feed the literal `lhs` as a last resort when no target could be run.
+---Feed a literal key as a last resort when no target could be run.
+---
+---`key` is normally the lhs itself, but callers pass `opts.fallback_key` instead when the lhs
+---has no native meaning worth degrading to (see `markdown-plus.FallbackOpts`).
 ---
 ---A normal-mode count is consumed by *our* mapping, so feeding the bare key would drop it and
 ---turn `3o` into a single open-line. Re-prefixing the digits restores the native behavior.
 ---Only callers that know the count is still unspent pass one: on the error path a foreign target
 ---may already have acted on it, and re-applying would double it.
----@param lhs string Left-hand side to feed
+---@param key string Key to feed
 ---@param count? integer Normal-mode count to re-apply; ignored when nil or 1
 ---@return nil
-local function feed_raw(lhs, count)
+local function feed_raw(key, count)
   local prefix = (count and count > 1) and tostring(count) or ""
-  feed(prefix .. normalize(lhs), true)
+  feed(prefix .. normalize(key), true)
 end
 
 ---Feed keys produced by a *remappable* target, applying Vim's own recursion rule.
@@ -225,15 +233,20 @@ end
 ---the leading-lhs comparison that keeps a target reproducing its own lhs from looping, and a
 ---remapped key after the digits could re-enter us. Remappable string-rhs `o`-style maps
 ---therefore lose the multiplier; no real plugin uses that shape.
+---
+---`degrade` shares that carve-out: `feed_mapped` protects a target whose rhs starts with its own
+---lhs by feeding the literal `lhs`, never the substitute, because the substitute would not match
+---the leading-lhs comparison the loop guard depends on. Vanilla Neovim feeds the lhs there too.
 ---@param keys string Key sequence with termcodes already expanded
 ---@param target markdown-plus.FallbackTarget Resolved target
 ---@param lhs string Left-hand side the target was resolved for
 ---@param count? integer Normal-mode count to re-apply; ignored when nil or 1
+---@param degrade? string Key to feed instead of `lhs` when degrading (`opts.fallback_key`)
 ---@return nil
-local function feed_target(keys, target, lhs, count)
+local function feed_target(keys, target, lhs, count, degrade)
   if routes_back_to_us(keys) then
     -- The bounce replaces the target's execution entirely, so the raw key carries the count.
-    feed_raw(lhs, count)
+    feed_raw(degrade or lhs, count)
     return
   end
   if target.noremap then
@@ -282,32 +295,34 @@ end
 ---@param target markdown-plus.FallbackTarget Resolved target
 ---@param lhs string Left-hand side the target was resolved for
 ---@param count? integer Normal-mode count to re-apply to the produced keys
+---@param degrade? string Key to feed instead of `lhs` when degrading (`opts.fallback_key`)
 ---@return nil
-local function feed_expr_result(result, target, lhs, count)
+local function feed_expr_result(result, target, lhs, count, degrade)
   if type(result) ~= "string" or result == "" then
     return
   end
   local keys = target.replace_keycodes and vim.api.nvim_replace_termcodes(result, true, true, true) or result
-  feed_target(keys, target, lhs, count)
+  feed_target(keys, target, lhs, count, degrade)
 end
 
 ---Run a Lua callback target
 ---@param target markdown-plus.FallbackTarget Resolved target
 ---@param lhs string Left-hand side, used for error reporting and the raw-key fallback
 ---@param count? integer Normal-mode count to re-apply to the produced keys
+---@param degrade? string Key to feed instead of `lhs` when degrading (`opts.fallback_key`)
 ---@return nil
-local function run_callback(target, lhs, count)
+local function run_callback(target, lhs, count, degrade)
   local ok, result = pcall(target.callback)
   if not ok then
     notify_failure(lhs, result)
     -- Deliberately countless: a target that threw partway may already have acted on the count,
     -- so re-prefixing it here risks doubling. Unlike the `feed_mapped` punt, which drops the
     -- count because prefixing is *unsafe*, this one drops it because it may be *already spent*.
-    feed_raw(lhs)
+    feed_raw(degrade or lhs)
     return
   end
   if target.expr then
-    feed_expr_result(result, target, lhs, count)
+    feed_expr_result(result, target, lhs, count, degrade)
   end
 end
 
@@ -315,23 +330,24 @@ end
 ---@param target markdown-plus.FallbackTarget Resolved target
 ---@param lhs string Left-hand side, used for error reporting and the raw-key fallback
 ---@param count? integer Normal-mode count to re-apply to the produced keys
+---@param degrade? string Key to feed instead of `lhs` when degrading (`opts.fallback_key`)
 ---@return nil
-local function run_rhs(target, lhs, count)
+local function run_rhs(target, lhs, count, degrade)
   if target.expr then
     local ok, result = pcall(vim.api.nvim_eval, target.rhs)
     if not ok then
       notify_failure(lhs, result)
       -- Countless for the same reason as the callback error path above: possibly already spent.
-      feed_raw(lhs)
+      feed_raw(degrade or lhs)
       return
     end
-    feed_expr_result(result, target, lhs, count)
+    feed_expr_result(result, target, lhs, count, degrade)
     return
   end
 
   -- `from_part = false` here: an rhs is a full key sequence, unlike an lhs, where
   -- `normalize()` passes `from_part = true` to keep partial-key semantics for comparison.
-  feed_target(vim.api.nvim_replace_termcodes(target.rhs, true, false, true), target, lhs, count)
+  feed_target(vim.api.nvim_replace_termcodes(target.rhs, true, false, true), target, lhs, count, degrade)
 end
 
 ---Execute the mapping markdown-plus is deferring to, or feed the raw key when there is none.
@@ -346,18 +362,22 @@ end
 ---on the raw-key degradation.
 ---
 ---Remappable targets are the known gap: see `feed_target`.
+---
+---Every path that terminates in a raw key honours `opts.fallback_key` when one is given, so a
+---default whose lhs is inert on its own still ends in the behavior its handler documents.
 ---@param mode string Mapping mode ("i", "n", ...)
 ---@param lhs string Left-hand side (e.g. "<BS>")
 ---@param opts? markdown-plus.FallbackOpts Optional behavior overrides
 ---@return nil
 function M.run(mode, lhs, opts)
+  local degrade = opts and opts.fallback_key
   local guard_key = mode .. ":" .. vim.api.nvim_get_current_buf() .. ":" .. lhs
   if in_flight[guard_key] == buffer_tick() then
     -- Re-entered inside the same key-processing burst with nothing to show for the previous
     -- fallback: the target we deferred to routed the key straight back into us. Consume the
     -- guard so the chain ends here, and terminate with the raw key.
     in_flight[guard_key] = nil
-    feed_raw(lhs)
+    feed_raw(degrade or lhs)
     return
   end
 
@@ -365,20 +385,20 @@ function M.run(mode, lhs, opts)
   local count = opts and opts.count
 
   if not target then
-    feed_raw(lhs, count)
+    feed_raw(degrade or lhs, count)
     return
   end
 
   arm_guard(guard_key)
   local ok, err = pcall(function()
     if target.callback then
-      run_callback(target, lhs, count)
+      run_callback(target, lhs, count, degrade)
     elseif type(target.rhs) == "string" and target.rhs ~= "" then
-      run_rhs(target, lhs, count)
+      run_rhs(target, lhs, count, degrade)
     else
       -- Target with an empty rhs: nothing to run, so this is the raw-key path and still owns
       -- the count.
-      feed_raw(lhs, count)
+      feed_raw(degrade or lhs, count)
     end
   end)
 

--- a/lua/markdown-plus/keymap_fallback.lua
+++ b/lua/markdown-plus/keymap_fallback.lua
@@ -371,18 +371,24 @@ end
 ---@return nil
 function M.run(mode, lhs, opts)
   local degrade = opts and opts.fallback_key
+  local count = opts and opts.count
   local guard_key = mode .. ":" .. vim.api.nvim_get_current_buf() .. ":" .. lhs
   if in_flight[guard_key] == buffer_tick() then
     -- Re-entered inside the same key-processing burst with nothing to show for the previous
     -- fallback: the target we deferred to routed the key straight back into us. Consume the
     -- guard so the chain ends here, and terminate with the raw key.
+    --
+    -- The count comes along: an unchanged changedtick says the target changed no buffer text,
+    -- so a multiplier the user typed cannot have been spent as an edit — unlike the
+    -- target-error path, where a target may have acted partway before throwing. The tick says
+    -- nothing about non-textual work (a cursor move, a popup), which is accepted: a count
+    -- applied to the raw key is the same thing vanilla Neovim does with an untouched buffer.
     in_flight[guard_key] = nil
-    feed_raw(degrade or lhs)
+    feed_raw(degrade or lhs, count)
     return
   end
 
   local target = M.resolve(mode, lhs)
-  local count = opts and opts.count
 
   if not target then
     feed_raw(degrade or lhs, count)

--- a/lua/markdown-plus/list/context.lua
+++ b/lua/markdown-plus/list/context.lua
@@ -6,7 +6,8 @@
 -- author own the key themselves and ask us whether *we* would have acted, so they can compose
 -- their own mapping without guessing at our internals.
 --
--- The predicate is exactly the one the matching handler uses, so
+-- The predicate is exactly the one the matching handler uses — including the
+-- `skip_in_codeblock` wrapper every list keymap is registered through — so
 -- `in_list_context(kind) == false` guarantees the corresponding handler would defer.
 local parser = require("markdown-plus.list.parser")
 local handler_utils = require("markdown-plus.list.handler_utils")
@@ -75,6 +76,10 @@ local PREDICATES = {
 ---(plus a bounded look-back for `"enter"`) and never touches the buffer, so it is safe to call
 ---from an expression mapping.
 ---
+---Every kind is `false` inside a fenced code block, whatever the line looks like: the handlers
+---are wrapped in `skip_in_codeblock` and defer there unconditionally, so a `- item` in a
+---```markdown fence is not a context we act in.
+---
 ---Each kind answers "would the handler act?", not "would the buffer change?". `"indent"` is
 ---true anywhere on a list item line, including for `<S-Tab>` on an item already at root
 ---indentation, where the handler consumes the key without outdenting further. Route that key
@@ -108,7 +113,17 @@ function M.in_list_context(kind)
   -- parser mid-edit, say) would fire once per keystroke and bury the editor in messages.
   -- `false` is the safe answer: the caller falls through to its own non-markdown-plus branch,
   -- which is exactly what a user who cannot be told about the error wants.
-  local ok, result = pcall(predicate)
+  --
+  -- The code-block check shares that pcall: every list keymap is registered through
+  -- `handlers.skip_in_codeblock`, so a fenced line is never a context we act in — and the
+  -- predicates below only look at the line's shape, which happily matches `- item` inside a
+  -- ```markdown fence.
+  local ok, result = pcall(function()
+    if utils.is_in_code_block() then
+      return false
+    end
+    return predicate()
+  end)
   if not ok then
     return false
   end

--- a/lua/markdown-plus/list/handlers.lua
+++ b/lua/markdown-plus/list/handlers.lua
@@ -25,13 +25,13 @@ end
 ---raw key unconditionally — as this did before — silently disabled every foreign mapping
 ---for these keys inside fenced code blocks.
 ---@param handler function The original handler function
----@param fallback_key string The key to fall through to (e.g., "<CR>", "<Tab>")
+---@param lhs string The key this handler is mapped from and yields back (e.g., "<CR>", "<Tab>")
 ---@param mode? string Mapping mode the key is registered in (defaults to "i")
 ---@return function Wrapped handler (not an expr mapping)
-function M.skip_in_codeblock(handler, fallback_key, mode)
+function M.skip_in_codeblock(handler, lhs, mode)
   return function()
     if utils.is_in_code_block() then
-      keymap_fallback.run(mode or "i", fallback_key)
+      keymap_fallback.run(mode or "i", lhs)
       return
     end
     handler()

--- a/lua/markdown-plus/table/keymaps.lua
+++ b/lua/markdown-plus/table/keymaps.lua
@@ -11,17 +11,28 @@ local keymap_helper = require("markdown-plus.keymap_helper")
 
 local plug_mappings_registered = false
 
----@param direction "left"|"right"|"up"|"down"
----@param fallback_key string
----@return fun()
-local function insert_nav_with_fallback(direction, fallback_key)
+---Build an insert-mode cell-navigation handler that yields the key when it has no table to move in.
+---
+---`<A-h/j/k/l>` are commonly owned by other plugins (window movers, snippet engines, terminal
+---mappings). Outside a table markdown-plus has nothing to do with the key, so it defers through
+---`keymap_fallback` and lets the user's or another plugin's mapping run. A successful cell move
+---still consumes the key.
+---
+---`opts.fallback_key` carries the arrow: a bare `<A-l>` means nothing in insert mode, so every
+---degradation path (nothing mapped, a target that bounces our own `<Plug>` back, a target that
+---errors) must end in the plain cursor movement this handler documents rather than in a swallowed
+---keypress.
+---@param direction "left"|"right"|"up"|"down" Cell direction to attempt
+---@param lhs string Default key this navigation is mapped from (e.g. "<A-l>")
+---@param arrow_key string Native key degradation falls back to (e.g. "<Right>")
+---@return fun() handler Insert-mode handler
+local function insert_nav_with_fallback(direction, lhs, arrow_key)
   return function()
     local navigation = require("markdown-plus.table.navigation")
-    local success = navigation["move_" .. direction]()
-    if not success then
-      local key = vim.api.nvim_replace_termcodes(fallback_key, true, false, true)
-      vim.api.nvim_feedkeys(key, "n", false)
+    if navigation["move_" .. direction]() then
+      return
     end
+    require("markdown-plus.keymap_fallback").run("i", lhs, { fallback_key = arrow_key })
   end
 end
 
@@ -281,28 +292,28 @@ local function get_keymap_defs(prefix, include_insert_defaults)
     -- Insert mode navigation (with fallback behavior)
     {
       plug = keymap_helper.plug_name("TableNavLeft"),
-      fn = insert_nav_with_fallback("left", "<Left>"),
+      fn = insert_nav_with_fallback("left", "<A-h>", "<Left>"),
       modes = "i",
       default_key = include_insert_defaults and "<A-h>" or nil,
       desc = "Navigate to cell left or move cursor left",
     },
     {
       plug = keymap_helper.plug_name("TableNavRight"),
-      fn = insert_nav_with_fallback("right", "<Right>"),
+      fn = insert_nav_with_fallback("right", "<A-l>", "<Right>"),
       modes = "i",
       default_key = include_insert_defaults and "<A-l>" or nil,
       desc = "Navigate to cell right or move cursor right",
     },
     {
       plug = keymap_helper.plug_name("TableNavUp"),
-      fn = insert_nav_with_fallback("up", "<Up>"),
+      fn = insert_nav_with_fallback("up", "<A-k>", "<Up>"),
       modes = "i",
       default_key = include_insert_defaults and "<A-k>" or nil,
       desc = "Navigate to cell above or move cursor up",
     },
     {
       plug = keymap_helper.plug_name("TableNavDown"),
-      fn = insert_nav_with_fallback("down", "<Down>"),
+      fn = insert_nav_with_fallback("down", "<A-j>", "<Down>"),
       modes = "i",
       default_key = include_insert_defaults and "<A-j>" or nil,
       desc = "Navigate to cell below or move cursor down",

--- a/spec/helpers/insert_mode.lua
+++ b/spec/helpers/insert_mode.lua
@@ -23,6 +23,31 @@ function M.__capture()
   }
 end
 
+---Read the state captured by the most recent `__capture()`, falling back to the buffer's
+---current state. For specs that drive their own key-processing burst (one that has to set
+---something up *inside* insert mode, which `press()` cannot express) and still want the
+---mid-insert snapshot.
+---
+---Consumes the slot: a burst whose `<Cmd>` capture never ran must fall back to the live buffer,
+---not silently hand back the snapshot an earlier test left behind. Call `__reset()` before the
+---burst so the fallback is reached for the right reason.
+---@return markdown-plus.spec.InsertResult
+function M.__captured()
+  local result = captured
+  captured = nil
+  return result
+    or {
+      lines = vim.api.nvim_buf_get_lines(0, 0, -1, false),
+      cursor = vim.api.nvim_win_get_cursor(0),
+    }
+end
+
+---Discard any captured state, so a stale snapshot cannot leak into the next burst.
+---@return nil
+function M.__reset()
+  captured = nil
+end
+
 ---Compute the keys needed to enter insert mode with the cursor at `col`.
 ---@param line string Line contents
 ---@param col integer 0-indexed byte column for the insert cursor
@@ -49,7 +74,10 @@ function M.press(keys, row, col)
   require("markdown-plus.keymap_fallback").reset()
 
   -- Backspace behavior across line starts and the insert-start boundary depends on
-  -- 'backspace'. Pin it so specs do not inherit whatever the ambient config happens to set.
+  -- 'backspace'. Pin it so specs do not inherit whatever the ambient config happens to set —
+  -- and restore it afterwards, since this is a *global* option and leaking it would silently
+  -- change the meaning of every later spec in the same Neovim instance.
+  local saved_backspace = vim.o.backspace
   vim.o.backspace = "indent,eol,start"
 
   local line = vim.api.nvim_buf_get_lines(0, row - 1, row, false)[1] or ""
@@ -59,7 +87,11 @@ function M.press(keys, row, col)
 
   captured = nil
   local sequence = enter_key .. keys .. '<Cmd>lua require("spec.helpers.insert_mode").__capture()<CR><Esc>'
-  vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(sequence, true, false, true), "x", false)
+  -- pcall only so the global option is restored on the way out; the error is rethrown
+  -- immediately after, since a burst that blew up is a spec failure worth seeing.
+  local ok, err = pcall(vim.api.nvim_feedkeys, vim.api.nvim_replace_termcodes(sequence, true, false, true), "x", false)
+  vim.o.backspace = saved_backspace
+  assert(ok, err)
 
   return captured
     or {

--- a/spec/markdown-plus/interop_recipes_spec.lua
+++ b/spec/markdown-plus/interop_recipes_spec.lua
@@ -93,13 +93,53 @@ describe("markdown-plus interop recipes", function()
   end)
 
   describe("snippet <Tab> recipe", function()
+    -- Stands in for the snippet plugin's *global* `<Tab>` mapping. The recipe below is
+    -- buffer-local, so it shadows this one outright: returning `"<Tab>"` from a non-remappable
+    -- buffer-local expr mapping never reaches a global mapping. That is exactly why the recipe
+    -- has to consult the snippet engine itself rather than "falling through" to it.
+    local global_tab_calls = 0
+
     before_each(function()
+      global_tab_calls = 0
       vim.keymap.set("i", "<Tab>", function()
+        global_tab_calls = global_tab_calls + 1
+        return "<Tab>"
+      end, { expr = true })
+
+      vim.keymap.set("i", "<Tab>", function()
+        if vim.snippet.active({ direction = 1 }) then
+          return "<Cmd>lua vim.snippet.jump(1)<CR>"
+        end
         if require("markdown-plus").in_list_context("indent") then
           return "<Plug>(MarkdownPlusListIndent)"
         end
         return "<Tab>"
       end, { expr = true, buffer = true })
+    end)
+
+    after_each(function()
+      pcall(vim.keymap.del, "i", "<Tab>")
+      if vim.snippet.active() then
+        vim.snippet.stop()
+      end
+    end)
+
+    it("jumps to the next tabstop while a snippet is active", function()
+      vim.bo[buf].expandtab = false
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+      -- The snippet must be expanded *inside* the key-processing burst: a session started
+      -- beforehand does not survive entering insert mode from the spec.
+      insert_mode.__reset()
+      local sequence = 'i<Cmd>lua vim.snippet.expand("one $1 two $2 end")<CR><Tab>'
+        .. '<Cmd>lua require("spec.helpers.insert_mode").__capture()<CR><Esc>'
+      vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(sequence, true, false, true), "x", false)
+      local result = insert_mode.__captured()
+
+      -- Cursor moved from the `$1` tabstop (col 4) to `$2` (col 9) and no tab was inserted.
+      assert.are.same({ "one  two  end" }, result.lines)
+      assert.are.same({ 1, 9 }, result.cursor)
     end)
 
     it("indents the list item in list context", function()
@@ -114,6 +154,15 @@ describe("markdown-plus interop recipes", function()
       vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "plain" })
       local result = insert_mode.press("<Tab>", 1, 5)
       assert.are.same({ "plain\t" }, result.lines)
+    end)
+
+    -- Documents the constraint the recipe is built around: the displaced global mapping is
+    -- unreachable from the buffer-local one, whichever branch the recipe takes.
+    it("never reaches the shadowed global <Tab> mapping", function()
+      vim.bo[buf].expandtab = false
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "plain" })
+      insert_mode.press("<Tab>", 1, 5)
+      assert.are.equal(0, global_tab_calls)
     end)
   end)
 end)

--- a/spec/markdown-plus/keymap_fallback_spec.lua
+++ b/spec/markdown-plus/keymap_fallback_spec.lua
@@ -278,6 +278,90 @@ describe("markdown-plus keymap_fallback", function()
       -- `3x` must still delete three characters.
       assert.are.equal("def", vim.api.nvim_buf_get_lines(0, 0, 1, false)[1])
     end)
+
+    -- Some of our defaults sit on keys that mean nothing on their own — table navigation's
+    -- `<A-l>` is inert in insert mode, so degrading to the literal lhs would swallow the
+    -- keypress. `opts.fallback_key` names the key that degradation should feed instead, so
+    -- every terminal path (no target, bounce, target error) ends in real behavior.
+    describe("opts.fallback_key", function()
+      before_each(function()
+        vim.api.nvim_buf_set_lines(0, 0, -1, false, { "abcdef" })
+        vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      end)
+
+      it("feeds the substitute key when no target resolves", function()
+        fallback.run("n", "<F5>", { fallback_key = "x" })
+        flush()
+
+        assert.are.equal("bcdef", vim.api.nvim_buf_get_lines(0, 0, 1, false)[1])
+      end)
+
+      it("applies opts.count to the substitute key", function()
+        fallback.run("n", "<F5>", { count = 3, fallback_key = "x" })
+        flush()
+
+        assert.are.equal("def", vim.api.nvim_buf_get_lines(0, 0, 1, false)[1])
+      end)
+
+      it("feeds the substitute key when the target routes back into markdown-plus", function()
+        -- copilot/blink shape: the target hands our own `<Plug>` back. Without the option the
+        -- chain terminates in the inert raw lhs; with it, the substitute key runs.
+        vim.keymap.set("n", "<F5>", function()
+          return "<Plug>(MarkdownPlusListBackspace)"
+        end, { expr = true, replace_keycodes = true })
+
+        fallback.run("n", "<F5>", { fallback_key = "x" })
+        flush()
+
+        assert.are.equal("bcdef", vim.api.nvim_buf_get_lines(0, 0, 1, false)[1])
+      end)
+
+      it("feeds the substitute key when the resolved target errors", function()
+        local original_notify = vim.notify
+        local messages = {}
+        vim.notify = function(msg, level)
+          table.insert(messages, { msg = msg, level = level })
+        end
+
+        vim.keymap.set("n", "<F5>", function()
+          error("target exploded")
+        end)
+
+        fallback.run("n", "<F5>", { fallback_key = "x" })
+        flush()
+        vim.notify = original_notify
+
+        assert.are.equal(1, #messages)
+        assert.are.equal("bcdef", vim.api.nvim_buf_get_lines(0, 0, 1, false)[1])
+      end)
+
+      it("feeds the substitute key when the target re-enters run for the same key", function()
+        local calls = 0
+        vim.keymap.set("n", "<F5>", function()
+          calls = calls + 1
+          fallback.run("n", "<F5>", { fallback_key = "x" })
+        end)
+
+        fallback.run("n", "<F5>", { fallback_key = "x" })
+        flush()
+
+        assert.are.equal(1, calls)
+        assert.are.equal("bcdef", vim.api.nvim_buf_get_lines(0, 0, 1, false)[1])
+      end)
+
+      it("still runs a resolved target instead of the substitute key", function()
+        local calls = 0
+        vim.keymap.set("n", "<F5>", function()
+          calls = calls + 1
+        end)
+
+        fallback.run("n", "<F5>", { fallback_key = "x" })
+        flush()
+
+        assert.are.equal(1, calls)
+        assert.are.equal("abcdef", vim.api.nvim_buf_get_lines(0, 0, 1, false)[1])
+      end)
+    end)
   end)
 
   -- Regression: a *remappable* foreign mapping whose keys start with its own lhs (the

--- a/spec/markdown-plus/keymap_fallback_spec.lua
+++ b/spec/markdown-plus/keymap_fallback_spec.lua
@@ -279,6 +279,25 @@ describe("markdown-plus keymap_fallback", function()
       assert.are.equal("def", vim.api.nvim_buf_get_lines(0, 0, 1, false)[1])
     end)
 
+    -- The in-flight guard's bounce branch is a degradation path like any other: the previous
+    -- fallback left the buffer untouched, so the count the user typed was never spent and the
+    -- raw key we terminate with still owns it.
+    it("keeps opts.count on the guard-bounce path", function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { "abcdef" })
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      -- Capture-shape target: it swallows the key and does nothing, leaving the changedtick
+      -- unchanged, which is exactly what makes the next run() inside the burst a bounce.
+      vim.keymap.set("n", "<F5>", function()
+        return ""
+      end, { expr = true })
+
+      fallback.run("n", "<F5>", { count = 3, fallback_key = "x" })
+      fallback.run("n", "<F5>", { count = 3, fallback_key = "x" })
+      flush()
+
+      assert.are.equal("def", vim.api.nvim_buf_get_lines(0, 0, 1, false)[1])
+    end)
+
     -- Some of our defaults sit on keys that mean nothing on their own — table navigation's
     -- `<A-l>` is inert in insert mode, so degrading to the literal lhs would swallow the
     -- keypress. `opts.fallback_key` names the key that degradation should feed instead, so

--- a/spec/markdown-plus/list_context_spec.lua
+++ b/spec/markdown-plus/list_context_spec.lua
@@ -117,6 +117,84 @@ describe("markdown-plus list context API", function()
     assert.are.equal(vim.log.levels.ERROR, messages[1].level)
   end)
 
+  -- Every list handler is wrapped in `skip_in_codeblock`, so a `- item` inside a fence is
+  -- *not* a context the handler acts in. The predicate must agree, or a recipe keyed on it
+  -- routes the key into a handler that immediately hands it back.
+  describe("inside a fenced code block", function()
+    local FENCED = {
+      "Intro",
+      "```markdown",
+      "- item",
+      "  wrapped text",
+      "```",
+    }
+
+    ---Run `fn` with `treesitter.is_in_fenced_code_block` stubbed to `value`.
+    ---`true`/`false` exercise the treesitter path in `utils.is_in_code_block`; `nil` makes it
+    ---fall through to the regex scan, which is the path Neovim takes without a markdown parser.
+    ---@param value boolean|nil Stubbed treesitter verdict
+    ---@param fn fun() Body to run under the stub
+    ---@return nil
+    local function with_treesitter(value, fn)
+      local ts = require("markdown-plus.treesitter")
+      local original = ts.is_in_fenced_code_block
+      ts.is_in_fenced_code_block = function()
+        return value
+      end
+      local ok, err = pcall(fn)
+      ts.is_in_fenced_code_block = original
+      assert(ok, err)
+    end
+
+    it("reports no context for any kind on the treesitter path", function()
+      with_treesitter(true, function()
+        fixture(FENCED, 3, 2)
+        assert.is_false(list.in_list_context("backspace"))
+        assert.is_false(list.in_list_context("indent"))
+        assert.is_false(list.in_list_context("enter"))
+      end)
+    end)
+
+    it("reports no context for any kind on the regex fallback path", function()
+      with_treesitter(nil, function()
+        fixture(FENCED, 3, 2)
+        assert.is_false(list.in_list_context("backspace"))
+        assert.is_false(list.in_list_context("indent"))
+        assert.is_false(list.in_list_context("enter"))
+      end)
+    end)
+
+    -- `enter` reaches back to a parent list item, so a continuation line inside the fence would
+    -- otherwise report context from a marker line that is itself fenced.
+    it("reports no enter context on a continuation line inside the fence", function()
+      with_treesitter(nil, function()
+        fixture(FENCED, 4, 4)
+        assert.is_false(list.in_list_context("enter"))
+      end)
+      with_treesitter(true, function()
+        fixture(FENCED, 4, 4)
+        assert.is_false(list.in_list_context("enter"))
+      end)
+    end)
+
+    it("still reports context on a list line outside the fence", function()
+      local lines = { "```", "code", "```", "- item" }
+      with_treesitter(nil, function()
+        fixture(lines, 4, 2)
+        assert.is_true(list.in_list_context("backspace"))
+        assert.is_true(list.in_list_context("indent"))
+        assert.is_true(list.in_list_context("enter"))
+      end)
+    end)
+
+    it("reports no context in a real fenced buffer with no stubbing", function()
+      fixture(FENCED, 3, 2)
+      assert.is_false(list.in_list_context("backspace"))
+      assert.is_false(list.in_list_context("indent"))
+      assert.is_false(list.in_list_context("enter"))
+    end)
+  end)
+
   it("does not modify the buffer", function()
     fixture({ "- item" }, 1, 6)
     local tick = vim.api.nvim_buf_get_changedtick(0)

--- a/spec/markdown-plus/table_nav_fallback_spec.lua
+++ b/spec/markdown-plus/table_nav_fallback_spec.lua
@@ -1,0 +1,146 @@
+---Insert-mode table navigation (`<A-h/j/k/l>`) keymap-fallback behavior.
+---
+---The navigation handlers own their keys only while the cursor is inside a table. Outside one,
+---the key belongs to whoever else mapped it (window movers, terminal plugins, snippet engines),
+---so the handler must yield through `keymap_fallback` instead of raw-feeding the arrow key.
+
+local insert_mode = require("spec.helpers.insert_mode")
+
+describe("table insert-mode navigation fallback", function()
+  local keymaps = require("markdown-plus.table.keymaps")
+  local buf
+
+  ---Buffer-local defaults installed by `setup_buffer_keymaps`, paired with the key
+  ---their fallback degrades to when nothing foreign is mapped.
+  local NAV_KEYS = {
+    { key = "<A-h>", native = "left" },
+    { key = "<A-l>", native = "right" },
+    { key = "<A-k>", native = "up" },
+    { key = "<A-j>", native = "down" },
+  }
+
+  ---Counts of foreign-mapping invocations, keyed by lhs
+  ---@type table<string, integer>
+  local foreign_calls
+
+  ---Install a foreign (non-markdown-plus) global insert-mode mapping for `lhs`
+  ---@param lhs string
+  ---@return nil
+  local function map_foreign(lhs)
+    vim.keymap.set("i", lhs, function()
+      foreign_calls[lhs] = (foreign_calls[lhs] or 0) + 1
+    end)
+  end
+
+  ---Number of times the foreign mapping for `lhs` fired
+  ---@param lhs string
+  ---@return integer
+  local function calls(lhs)
+    return foreign_calls[lhs] or 0
+  end
+
+  before_each(function()
+    vim.cmd("enew")
+    vim.bo.filetype = "markdown"
+    buf = vim.api.nvim_get_current_buf()
+
+    keymaps.register_plug_mappings()
+    keymaps.setup_buffer_keymaps({
+      enabled = true,
+      auto_format = true,
+      default_alignment = "left",
+      confirm_destructive = true,
+      keymaps = {
+        enabled = true,
+        prefix = "<localleader>t",
+        insert_mode_navigation = true,
+      },
+    })
+
+    foreign_calls = {}
+    for _, nav in ipairs(NAV_KEYS) do
+      map_foreign(nav.key)
+    end
+  end)
+
+  after_each(function()
+    for _, nav in ipairs(NAV_KEYS) do
+      pcall(vim.keymap.del, "i", nav.key)
+    end
+    vim.cmd("bdelete!")
+  end)
+
+  describe("outside a table", function()
+    it("runs the foreign mapping for every navigation key", function()
+      for _, nav in ipairs(NAV_KEYS) do
+        vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "Regular text", "second line" })
+        insert_mode.press(nav.key, 1, 4)
+        assert.are.equal(1, calls(nav.key), nav.key .. " should defer to the foreign mapping")
+      end
+    end)
+
+    it("leaves the buffer untouched when the foreign mapping runs", function()
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "Regular text" })
+      local result = insert_mode.press("<A-l>", 1, 4)
+      assert.are.same({ "Regular text" }, result.lines)
+    end)
+  end)
+
+  describe("inside a table", function()
+    before_each(function()
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, {
+        "| A | B |",
+        "| --- | --- |",
+        "| 1 | 2 |",
+      })
+    end)
+
+    -- Cell columns for the fixture below: column 0 starts at byte 2, column 1 at byte 6.
+    it("navigates to the next cell without running the foreign mapping", function()
+      local result = insert_mode.press("<A-l>", 1, 2)
+      assert.are.equal(0, calls("<A-l>"))
+      assert.are.same({ 1, 6 }, result.cursor)
+    end)
+
+    it("navigates to the previous cell without running the foreign mapping", function()
+      local result = insert_mode.press("<A-h>", 1, 6)
+      assert.are.equal(0, calls("<A-h>"))
+      assert.are.same({ 1, 2 }, result.cursor)
+    end)
+
+    it("navigates to the cell below without running the foreign mapping", function()
+      local result = insert_mode.press("<A-j>", 1, 2)
+      assert.are.equal(0, calls("<A-j>"))
+      assert.are.same({ 3, 2 }, result.cursor)
+    end)
+
+    it("navigates to the cell above without running the foreign mapping", function()
+      local result = insert_mode.press("<A-k>", 3, 2)
+      assert.are.equal(0, calls("<A-k>"))
+      assert.are.same({ 1, 2 }, result.cursor)
+    end)
+
+    it("leaves the table text unchanged", function()
+      local result = insert_mode.press("<A-l>", 1, 2)
+      assert.are.same({ "| A | B |", "| --- | --- |", "| 1 | 2 |" }, result.lines)
+    end)
+  end)
+
+  describe("without a foreign mapping", function()
+    it("degrades to native cursor movement outside a table", function()
+      pcall(vim.keymap.del, "i", "<A-l>")
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "Regular text" })
+      local result = insert_mode.press("<A-l>", 1, 4)
+      assert.are.same({ "Regular text" }, result.lines)
+      assert.are.equal(5, result.cursor[2])
+    end)
+
+    it("degrades to native cursor movement for <A-h> outside a table", function()
+      pcall(vim.keymap.del, "i", "<A-h>")
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "Regular text" })
+      local result = insert_mode.press("<A-h>", 1, 4)
+      assert.are.same({ "Regular text" }, result.lines)
+      assert.are.equal(3, result.cursor[2])
+    end)
+  end)
+end)


### PR DESCRIPTION
## Summary

Layer 5 of the #376 stack: table insert-mode navigation (`<A-h/j/k/l>`) was the last raw-feed fallback path — outside a table it fed the arrow key with no remapping, bypassing user/plugin insert-mode mappings (window movers, terminal mappings). Now it defers through `keymap_fallback` like every other shared key.

## Changes

- **`table/keymaps.lua`**: failed table movement now calls `keymap_fallback.run("i", lhs, { fallback_key = arrow_key })` — the user's own `<A-h/j/k/l>` mapping wins; with none, native arrow movement is preserved
- **`keymap_fallback.lua`**: new `FallbackOpts.fallback_key` — a substitute key fed on every terminal degradation path (no target, guard bounce, `routes_back_to_us`, erroring target, empty rhs). Fixes the capturing-plugin bounce path, which previously ended in an inert raw `<A-l>` instead of arrow movement. `skip_in_codeblock` param renamed to `lhs` to avoid colliding with the new option's meaning
- **New `spec/markdown-plus/table_nav_fallback_spec.lua`** (9 specs) + 6 `fallback_key` specs: foreign mapping fires outside tables for all four keys, cell movement asserted with exact cursor positions inside tables, arrow degradation, count interplay, bounce termination
- **Wiki docs** (`4.Usage`, `5.Keymaps`, `6.Customizing-Keymaps`): interop + recipes + `in_list_context` reference, recipe snippets byte-identical to README (spec-locked); README/vimdoc updated for the wider surface and the `insert_mode_navigation = false` opt-out

## Test plan

- [x] `make check` green
- [x] 1574 passing / 0 failed (net +15 over layer 4)
- [x] Recipe snippets byte-verified across README / vimdoc / wiki
