### PR TITLE
fix(list): parse empty checkbox items at end of line (#387)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ demo
 .github/agents
 .claude
 .tests/
+
+# e2e test run logs (generated)
+test/e2e/logs/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-coverage test-file test-watch lint format format-check check demo help
+.PHONY: test test-e2e test-coverage test-file test-watch lint format format-check check demo help
 
 # Default target
 help:
@@ -12,6 +12,7 @@ help:
 	@echo "  make format        - Format all Lua files with stylua"
 	@echo "  make format-check  - Check formatting without modifying files"
 	@echo "  make check         - Run lint + format-check + test (CI checks)"
+	@echo "  make test-e2e      - Run end-to-end keymap tests in an isolated Neovim"
 	@echo "  make demo          - Generate all demo GIFs (requires vhs)"
 	@echo "  make help          - Show this help message"
 	@echo ""
@@ -68,7 +69,7 @@ lint:
 		(echo "Error: 'luacheck' not found"; \
 		 echo "Install with: luarocks install luacheck"; exit 1)
 	@echo "Running luacheck..."
-	@luacheck lua/ spec/ --globals vim
+	@luacheck lua/ spec/ test/ --globals vim
 
 # Format Lua code with stylua
 format:
@@ -77,7 +78,7 @@ format:
 		 echo "Install with: cargo install stylua"; \
 		 echo "Or on macOS: brew install stylua"; exit 1)
 	@echo "Formatting Lua files with stylua..."
-	@stylua lua/ spec/ plugin/
+	@stylua lua/ spec/ plugin/ test/
 
 # Check formatting without modifying files
 format-check:
@@ -86,9 +87,14 @@ format-check:
 		 echo "Install with: cargo install stylua"; \
 		 echo "Or on macOS: brew install stylua"; exit 1)
 	@echo "Checking Lua formatting..."
-	@stylua --check lua/ spec/ plugin/
+	@stylua --check lua/ spec/ plugin/ test/
 
 # Run all CI checks (lint + format-check + test)
+# End-to-end keymap tests: real keypresses through the real mappings, in a Neovim that
+# loads only this plugin (no personal config, temp XDG dirs). See scripts/run-e2e.sh.
+test-e2e:
+	@bash scripts/run-e2e.sh
+
 check: lint format-check test
 	@echo "✓ All checks passed!"
 

--- a/lua/markdown-plus/list/parser.lua
+++ b/lua/markdown-plus/list/parser.lua
@@ -167,6 +167,23 @@ function M.parse_list_line(line, row, opts)
   -- Try treesitter first (if row provided)
   local ts_result = row and parse_list_line_ts(row) or nil
   if ts_result then
+    -- Treesitter only emits a task-list-marker node for checkbox items that carry content, so
+    -- an empty task ("- [ ]", with or without a trailing space) comes back as a plain list
+    -- marker. That result must not hide the checkbox the regex path does recognize (#387).
+    --
+    -- Returning here deliberately bypasses the `skip_empty` rejection below: that check asks
+    -- "is this a bare marker at EOL?", and against the *treesitter* result "- [ ]" looks like
+    -- one (its full_marker is just "-", leaving " [ ]" as trailing content — so it would not
+    -- even be rejected, it would be returned as a checkbox-less item). An empty checkbox is a
+    -- complete, unambiguous list item, so it stays visible to `skip_empty` callers exactly as
+    -- the trailing-space form "- [ ] " already is. The regex path is authoritative for it.
+    if not ts_result.checkbox then
+      local regex_result = parse_list_line_regex(line, opts)
+      if regex_result and regex_result.checkbox then
+        return regex_result
+      end
+    end
+
     -- When skipping empty patterns, reject markers at EOL with no trailing content
     if skip_empty and is_empty_marker(line, ts_result) then
       return nil

--- a/lua/markdown-plus/list/patterns.lua
+++ b/lua/markdown-plus/list/patterns.lua
@@ -41,6 +41,13 @@ M.TS_CHECKBOX_TYPES = {
 ---@field ordered_paren_checkbox string Pattern for parenthesized ordered checkbox lists (1) [ ])
 ---@field letter_lower_paren_checkbox string Pattern for parenthesized lowercase letter checkbox lists (a) [ ])
 ---@field letter_upper_paren_checkbox string Pattern for parenthesized uppercase letter checkbox lists (A) [ ])
+---@field checkbox_empty string Pattern for unordered checkbox items with nothing after `]` (- [ ])
+---@field ordered_checkbox_empty string Pattern for ordered checkbox items with nothing after `]` (1. [ ])
+---@field letter_lower_checkbox_empty string Pattern for lowercase letter checkbox items at EOL (a. [ ])
+---@field letter_upper_checkbox_empty string Pattern for uppercase letter checkbox items at EOL (A. [ ])
+---@field ordered_paren_checkbox_empty string Pattern for parenthesized ordered checkbox items at EOL (1) [ ])
+---@field letter_lower_paren_checkbox_empty string Pattern for parenthesized lowercase letter checkboxes at EOL (a) [ ])
+---@field letter_upper_paren_checkbox_empty string Pattern for parenthesized uppercase letter checkboxes at EOL (A) [ ])
 ---@field unordered_empty string Pattern for empty unordered lists at EOL (-, +, *)
 ---@field ordered_empty string Pattern for empty ordered lists at EOL (1., 2., etc.)
 ---@field letter_lower_empty string Pattern for empty lowercase letter lists at EOL (a., b., c.)
@@ -65,6 +72,23 @@ M.patterns = {
   ordered_paren_checkbox = "^(%s*)(%d+)%)%s+%[(.?)%]%s+",
   letter_lower_paren_checkbox = "^(%s*)([a-z])%)%s+%[(.?)%]%s+",
   letter_upper_paren_checkbox = "^(%s*)([A-Z])%)%s+%[(.?)%]%s+",
+  -- Empty checkbox patterns: closing bracket is the last thing on the line.
+  -- The with-content variants above require whitespace after `]`, so an untouched empty task
+  -- (the normal state once trailing whitespace is trimmed) would otherwise parse as a plain
+  -- list item whose content is "[ ]" (issue #387). Anchored with `$` so a checkbox prefix
+  -- followed by real content never matches here.
+  -- The state capture is `.?`, matching the with-content variants above: any single character
+  -- counts as a checkbox state, which keeps custom states ("-", "~", …) working. The knock-on
+  -- effect is that a CommonMark shortcut reference link alone on the line ("- [a]") reads as
+  -- checkbox state "a" — deliberate, not an oversight: "- [a] text" already parses that way,
+  -- so treating the EOL form differently would be the inconsistency.
+  checkbox_empty = "^(%s*)([%-%+%*])%s+%[(.?)%]$",
+  ordered_checkbox_empty = "^(%s*)(%d+)%.%s+%[(.?)%]$",
+  letter_lower_checkbox_empty = "^(%s*)([a-z])%.%s+%[(.?)%]$",
+  letter_upper_checkbox_empty = "^(%s*)([A-Z])%.%s+%[(.?)%]$",
+  ordered_paren_checkbox_empty = "^(%s*)(%d+)%)%s+%[(.?)%]$",
+  letter_lower_paren_checkbox_empty = "^(%s*)([a-z])%)%s+%[(.?)%]$",
+  letter_upper_paren_checkbox_empty = "^(%s*)([A-Z])%)%s+%[(.?)%]$",
   -- Empty item patterns (marker at end of line, no trailing space required)
   -- These handle the case where trim_trailing_whitespace removes the space
   unordered_empty = "^(%s*)([%-%+%*])$",
@@ -91,6 +115,33 @@ M.PATTERN_CONFIG = {
   },
   {
     pattern = "letter_upper_paren_checkbox",
+    type = "letter_upper_paren",
+    delimiter = DELIMITER_PAREN,
+    has_checkbox = true,
+  },
+  -- Empty checkbox variants (nothing after `]`). They must precede the plain marker patterns
+  -- below, which would otherwise swallow "- [ ]" as an unordered item with content "[ ]".
+  -- Unlike the bare empty-marker patterns at the end of this list these are NOT flagged
+  -- `is_empty`, so callers passing `skip_empty_patterns` (group scanning) still see these lines
+  -- as list items — exactly as they already see the trailing-space form "- [ ] ".
+  { pattern = "ordered_checkbox_empty", type = "ordered", delimiter = DELIMITER_DOT, has_checkbox = true },
+  { pattern = "letter_lower_checkbox_empty", type = "letter_lower", delimiter = DELIMITER_DOT, has_checkbox = true },
+  { pattern = "letter_upper_checkbox_empty", type = "letter_upper", delimiter = DELIMITER_DOT, has_checkbox = true },
+  { pattern = "checkbox_empty", type = "unordered", delimiter = "", has_checkbox = true },
+  {
+    pattern = "ordered_paren_checkbox_empty",
+    type = "ordered_paren",
+    delimiter = DELIMITER_PAREN,
+    has_checkbox = true,
+  },
+  {
+    pattern = "letter_lower_paren_checkbox_empty",
+    type = "letter_lower_paren",
+    delimiter = DELIMITER_PAREN,
+    has_checkbox = true,
+  },
+  {
+    pattern = "letter_upper_paren_checkbox_empty",
     type = "letter_upper_paren",
     delimiter = DELIMITER_PAREN,
     has_checkbox = true,

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# End-to-end keymap tests for markdown-plus.
+#
+# Drives real keypresses through the plugin's real buffer-local keymaps in a Neovim that
+# knows nothing about the developer's setup, and asserts exact buffer contents. Unlike the
+# busted suite (`make test`) this exercises keymap registration and dispatch, so it catches
+# breakage that unit-level specs cannot see.
+#
+# Isolation, in order of importance:
+#   - `-u test/e2e/init.lua`  : the only config loaded; never ~/.config/nvim
+#   - fresh XDG_* temp dirs   : no shada/state/cache from the real Neovim can leak in
+#   - `--clean`               : skips user runtime directories entirely
+# test/e2e/init.lua additionally aborts the run if a personal config appears on the
+# runtimepath, so an isolation regression fails loudly instead of quietly tainting results.
+#
+# Usage:
+#   scripts/run-e2e.sh              # run all cases, clean up temp dirs
+#   scripts/run-e2e.sh --keep-tmp   # keep temp dirs for debugging (path is printed)
+#
+# Exit codes: 0 = all cases passed, 1 = at least one failed, 2 = isolation failure.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+KEEP_TMP=0
+[ "${1:-}" = "--keep-tmp" ] && KEEP_TMP=1
+
+command -v nvim >/dev/null 2>&1 || { echo "Error: 'nvim' not found in PATH"; exit 1; }
+
+# Every piece of Neovim state points somewhere disposable.
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/markdown-plus-e2e.XXXXXX")"
+export XDG_CONFIG_HOME="$TMP_ROOT/config"
+export XDG_DATA_HOME="$TMP_ROOT/data"
+export XDG_STATE_HOME="$TMP_ROOT/state"
+export XDG_CACHE_HOME="$TMP_ROOT/cache"
+mkdir -p "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_STATE_HOME" "$XDG_CACHE_HOME"
+
+# The isolated init resolves the plugin from here rather than from the cwd, so the runner
+# works no matter where it is invoked from.
+export MARKDOWN_PLUS_ROOT="$REPO_ROOT"
+
+LOG_DIR="$REPO_ROOT/test/e2e/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/run.log"
+
+cleanup() {
+  if [ "$KEEP_TMP" -eq 1 ]; then
+    echo "Temp dirs kept at: $TMP_ROOT"
+  else
+    rm -rf "$TMP_ROOT"
+  fi
+}
+trap cleanup EXIT
+
+nvim --clean --headless -u "$REPO_ROOT/test/e2e/init.lua" \
+  -l "$REPO_ROOT/test/e2e/runner.lua" 2>&1 | tee "$LOG_FILE"
+
+STATUS=${PIPESTATUS[0]}
+
+echo
+case "$STATUS" in
+  0) echo "All end-to-end cases passed. Log: $LOG_FILE" ;;
+  2) echo "Isolation failure: a personal config reached the runtimepath. Log: $LOG_FILE" ;;
+  *) echo "End-to-end failures above. Full log: $LOG_FILE" ;;
+esac
+
+exit "$STATUS"

--- a/spec/markdown-plus/list_parser_spec.lua
+++ b/spec/markdown-plus/list_parser_spec.lua
@@ -131,6 +131,99 @@ describe("markdown-plus list parser", function()
     end)
   end)
 
+  describe("empty checkbox at end of line (#387)", function()
+    ---Marker families × checkbox states with nothing after the closing bracket.
+    ---@type { line: string, type: string, marker: string, checkbox: string }[]
+    local EMPTY_CHECKBOX_CASES = {
+      { line = "- [ ]", type = "unordered", marker = "-", checkbox = " " },
+      { line = "* [ ]", type = "unordered", marker = "*", checkbox = " " },
+      { line = "+ [ ]", type = "unordered", marker = "+", checkbox = " " },
+      { line = "- [x]", type = "unordered", marker = "-", checkbox = "x" },
+      { line = "- [X]", type = "unordered", marker = "-", checkbox = "X" },
+      { line = "- [-]", type = "unordered", marker = "-", checkbox = "-" },
+      { line = "- [~]", type = "unordered", marker = "-", checkbox = "~" },
+      { line = "1. [ ]", type = "ordered", marker = "1.", checkbox = " " },
+      { line = "2. [x]", type = "ordered", marker = "2.", checkbox = "x" },
+      { line = "1) [ ]", type = "ordered_paren", marker = "1)", checkbox = " " },
+      { line = "3) [X]", type = "ordered_paren", marker = "3)", checkbox = "X" },
+      { line = "a. [ ]", type = "letter_lower", marker = "a.", checkbox = " " },
+      { line = "A. [x]", type = "letter_upper", marker = "A.", checkbox = "x" },
+      { line = "b) [ ]", type = "letter_lower_paren", marker = "b)", checkbox = " " },
+      { line = "B) [x]", type = "letter_upper_paren", marker = "B)", checkbox = "x" },
+    }
+
+    for _, case in ipairs(EMPTY_CHECKBOX_CASES) do
+      it(("parses %q as a checkbox item via the treesitter-assisted path"):format(case.line), function()
+        local info = set_and_parse(case.line)
+        assert.is_not_nil(info)
+        assert.are.equal(case.type, info.type)
+        assert.are.equal(case.marker, info.marker)
+        assert.are.equal(case.checkbox, info.checkbox)
+        assert.are.equal(case.marker .. " [" .. case.checkbox .. "]", info.full_marker)
+      end)
+
+      it(("parses %q as a checkbox item via the regex fallback"):format(case.line), function()
+        local info = parser.parse_list_line(case.line)
+        assert.is_not_nil(info)
+        assert.are.equal(case.type, info.type)
+        assert.are.equal(case.marker, info.marker)
+        assert.are.equal(case.checkbox, info.checkbox)
+      end)
+    end
+
+    it("parses an indented empty checkbox", function()
+      local info = set_and_parse("  - [ ]")
+      assert.is_not_nil(info)
+      assert.are.equal("unordered", info.type)
+      assert.are.equal("  ", info.indent)
+      assert.are.equal(" ", info.checkbox)
+    end)
+
+    it("treats an empty checkbox line as an empty list item", function()
+      local info = set_and_parse("- [ ]")
+      assert.is_not_nil(info)
+      assert.is_true(parser.is_empty_list_item("- [ ]", info))
+    end)
+
+    it("still parses checkbox items with trailing content unchanged", function()
+      local info = set_and_parse("- [ ] task")
+      assert.is_not_nil(info)
+      assert.are.equal("unordered", info.type)
+      assert.are.equal(" ", info.checkbox)
+      assert.is_false(parser.is_empty_list_item("- [ ] task", info))
+    end)
+
+    it("still parses the trailing-space empty checkbox form", function()
+      local info = set_and_parse("- [ ] ")
+      assert.is_not_nil(info)
+      assert.are.equal(" ", info.checkbox)
+    end)
+
+    it("does not treat an unterminated bracket as a checkbox", function()
+      local info = set_and_parse("- [not a checkbox")
+      assert.is_not_nil(info)
+      assert.are.equal("unordered", info.type)
+      assert.is_nil(info.checkbox)
+    end)
+
+    it("does not treat a bracket followed by glued content as a checkbox", function()
+      local info = set_and_parse("- [ ]x")
+      assert.is_not_nil(info)
+      assert.are.equal("unordered", info.type)
+      assert.is_nil(info.checkbox)
+    end)
+
+    it("keeps recognizing empty checkboxes when skip_empty_patterns is set", function()
+      local info = parser.parse_list_line("- [ ]", nil, { skip_empty_patterns = true })
+      assert.is_not_nil(info)
+      assert.are.equal(" ", info.checkbox)
+    end)
+
+    it("still skips a bare empty marker when skip_empty_patterns is set", function()
+      assert.is_nil(parser.parse_list_line("-", nil, { skip_empty_patterns = true }))
+    end)
+  end)
+
   describe("is_empty_list_item", function()
     it("returns true for a marker with no content", function()
       local info = set_and_parse("- ")

--- a/spec/markdown-plus/list_patterns_spec.lua
+++ b/spec/markdown-plus/list_patterns_spec.lua
@@ -61,6 +61,23 @@ describe("markdown-plus list patterns", function()
       ordered_paren_empty = "1)",
       letter_lower_paren_empty = "a)",
       letter_upper_paren_empty = "A)",
+      checkbox_empty = "- [ ]",
+      ordered_checkbox_empty = "1. [x]",
+      letter_lower_checkbox_empty = "a. [ ]",
+      letter_upper_checkbox_empty = "A. [X]",
+      ordered_paren_checkbox_empty = "1) [ ]",
+      letter_lower_paren_checkbox_empty = "a) [x]",
+      letter_upper_paren_checkbox_empty = "A) [ ]",
+    }
+
+    ---Inputs that must NOT match the given pattern (anchoring guards, #387)
+    local negative_cases = {
+      { pattern = "checkbox_empty", input = "- [ ] task" },
+      { pattern = "checkbox_empty", input = "- [ ]x" },
+      { pattern = "checkbox_empty", input = "- [not a checkbox" },
+      { pattern = "ordered_checkbox_empty", input = "1. [ ] task" },
+      { pattern = "ordered_paren_checkbox_empty", input = "1) [x] task" },
+      { pattern = "letter_lower_checkbox_empty", input = "a. [ ] task" },
     }
 
     it("defines all expected pattern keys", function()
@@ -74,6 +91,18 @@ describe("markdown-plus list patterns", function()
         local m = input:match(patterns.patterns[key])
         assert.is_not_nil(m, "pattern did not match: " .. key .. " input=" .. input)
       end
+    end)
+
+    it("empty-checkbox patterns stay anchored to end of line", function()
+      for _, case in ipairs(negative_cases) do
+        local m = case.input:match(patterns.patterns[case.pattern])
+        assert.is_nil(m, "pattern matched unexpectedly: " .. case.pattern .. " input=" .. case.input)
+      end
+    end)
+
+    it("empty-checkbox patterns capture the checkbox state", function()
+      local _, _, state = ("- [x]"):match(patterns.patterns.checkbox_empty)
+      assert.are.equal("x", state)
     end)
 
     it("indents are captured by patterns", function()
@@ -91,6 +120,20 @@ describe("markdown-plus list patterns", function()
       assert.is_true(idx.ordered_checkbox < idx.ordered)
       assert.is_true(idx.checkbox < idx.unordered)
       assert.is_true(idx.letter_lower_checkbox < idx.letter_lower)
+    end)
+
+    it("places empty-checkbox variants before the plain marker patterns", function()
+      local idx = {}
+      for i, config in ipairs(patterns.PATTERN_CONFIG) do
+        idx[config.pattern] = i
+      end
+      assert.is_true(idx.checkbox_empty < idx.unordered)
+      assert.is_true(idx.ordered_checkbox_empty < idx.ordered)
+      assert.is_true(idx.ordered_paren_checkbox_empty < idx.ordered_paren)
+      assert.is_true(idx.letter_lower_checkbox_empty < idx.letter_lower)
+      assert.is_true(idx.letter_upper_checkbox_empty < idx.letter_upper)
+      assert.is_true(idx.letter_lower_paren_checkbox_empty < idx.letter_lower_paren)
+      assert.is_true(idx.letter_upper_paren_checkbox_empty < idx.letter_upper_paren)
     end)
 
     it("places empty patterns last and flags them is_empty", function()

--- a/spec/markdown-plus/list_spec.lua
+++ b/spec/markdown-plus/list_spec.lua
@@ -33,6 +33,16 @@ describe("markdown-plus list management", function()
   end)
 
   after_each(function()
+    -- Handlers that yield to `keymap_fallback` (and `skip_in_codeblock` inside a code block)
+    -- queue their keys via `nvim_feedkeys` instead of editing the buffer. A spec that calls
+    -- such a handler directly never drives a key-processing burst, so those keys sit in the
+    -- typeahead and would be flushed by the first burst a *later* spec performs — landing in
+    -- the wrong buffer. Cancel any pending `startinsert` and drain the typeahead here, once,
+    -- rather than per-describe.
+    vim.cmd("stopinsert")
+    vim.api.nvim_feedkeys("", "x", false)
+    vim.cmd("stopinsert")
+
     if vim.api.nvim_buf_is_valid(buf) then
       vim.api.nvim_buf_delete(buf, { force = true })
     end
@@ -1328,6 +1338,91 @@ describe("markdown-plus list management", function()
       end)
     end)
 
+    -- Regression: an empty task whose closing bracket ends the line parsed as a plain list
+    -- item with content "[ ]", so toggling *added* a second checkbox and silently corrupted
+    -- the line ("- [ ]" -> "- [ ] [ ]"). See issue #387. Assertions compare the whole line:
+    -- a "contains [x]" check would have passed on the corrupted output.
+    describe("empty checkbox at EOL (#387 regression)", function()
+      ---Toggle line 1 of a single-line buffer and return the resulting line
+      ---@param line string
+      ---@return string
+      local function toggle_line(line)
+        vim.api.nvim_buf_set_lines(buf, 0, -1, false, { line })
+        list.toggle_checkbox_on_line(1)
+        return vim.api.nvim_buf_get_lines(buf, 0, 1, false)[1]
+      end
+
+      ---@type { input: string, expected: string }[]
+      local CASES = {
+        { input = "- [ ]", expected = "- [x] " },
+        { input = "- [x]", expected = "- [ ] " },
+        { input = "- [X]", expected = "- [ ] " },
+        { input = "* [ ]", expected = "* [x] " },
+        { input = "+ [x]", expected = "+ [ ] " },
+        { input = "1. [ ]", expected = "1. [x] " },
+        { input = "2. [x]", expected = "2. [ ] " },
+        { input = "1) [ ]", expected = "1) [x] " },
+        { input = "a. [ ]", expected = "a. [x] " },
+        { input = "A. [x]", expected = "A. [ ] " },
+        { input = "b) [ ]", expected = "b) [x] " },
+        -- Custom/extended states are anything but x/X, so they toggle to checked
+        { input = "- [-]", expected = "- [x] " },
+        { input = "- [~]", expected = "- [x] " },
+        { input = "  - [ ]", expected = "  - [x] " },
+        { input = "\t- [x]", expected = "\t- [ ] " },
+      }
+
+      for _, case in ipairs(CASES) do
+        it(("toggles %q in place without duplicating the bracket"):format(case.input), function()
+          assert.are.equal(case.expected, toggle_line(case.input))
+        end)
+      end
+
+      it("round-trips back to unchecked", function()
+        vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "- [ ]" })
+        list.toggle_checkbox_on_line(1)
+        list.toggle_checkbox_on_line(1)
+        -- The marker→content pad is re-emitted, so the line keeps a single trailing space;
+        -- the checkbox itself round-trips and is never duplicated.
+        assert.are.same({ "- [ ] " }, vim.api.nvim_buf_get_lines(buf, 0, -1, false))
+      end)
+
+      it("toggles via toggle_checkbox_line (normal mode entry point)", function()
+        vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "- [ ]" })
+        vim.api.nvim_win_set_cursor(0, { 1, 0 })
+        list.toggle_checkbox_line()
+        assert.are.same({ "- [x] " }, vim.api.nvim_buf_get_lines(buf, 0, -1, false))
+      end)
+
+      it("toggles via toggle_checkbox_insert (insert mode entry point)", function()
+        vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "- [ ]" })
+        vim.api.nvim_win_set_cursor(0, { 1, 4 })
+        list.toggle_checkbox_insert()
+        assert.are.same({ "- [x] " }, vim.api.nvim_buf_get_lines(buf, 0, -1, false))
+      end)
+
+      it("toggles a range mixing empty and content checkboxes", function()
+        vim.api.nvim_buf_set_lines(buf, 0, -1, false, {
+          "- [ ]",
+          "- [ ] has content",
+          "- [x]",
+          "1. [ ]",
+        })
+        vim.cmd("normal! ggVGG")
+        list.toggle_checkbox_range()
+        assert.are.same({
+          "- [x] ",
+          "- [x] has content",
+          "- [ ] ",
+          "1. [x] ",
+        }, vim.api.nvim_buf_get_lines(buf, 0, -1, false))
+      end)
+
+      it("leaves an unterminated bracket alone (adds a checkbox, does not invent a state)", function()
+        assert.are.equal("- [ ] [not a checkbox", toggle_line("- [not a checkbox"))
+      end)
+    end)
+
     describe("toggle_checkbox_range", function()
       it("adds checkboxes to multiple list items", function()
         vim.api.nvim_buf_set_lines(buf, 0, -1, false, {
@@ -1923,12 +2018,6 @@ describe("markdown-plus list management", function()
 
   describe("skip_in_codeblock wrapper", function()
     local handlers = require("markdown-plus.list.handlers")
-
-    after_each(function()
-      -- Inside a code block the wrapper queues its fallback keys via `nvim_feedkeys`.
-      -- Drain the typeahead so those keys cannot leak into a later spec.
-      vim.api.nvim_feedkeys("", "x", false)
-    end)
 
     it("does not call handler when inside code block", function()
       vim.api.nvim_buf_set_lines(buf, 0, -1, false, {
@@ -2746,6 +2835,63 @@ describe("markdown-plus list management", function()
       assert.are.equal("1. a", result[1])
       assert.are.equal("1. b", result[2])
       assert.are.equal("1. c", result[3])
+    end)
+  end)
+
+  -- Regression: an empty task item with the marker at end of line (trailing whitespace
+  -- trimmed) used to parse as a plain `-` item with content "[ ]", so <CR> created a new
+  -- `- ` item instead of breaking out of the list. See issue #387.
+  describe("<CR> on an empty checkbox item (#387)", function()
+    local handlers = require("markdown-plus.list.handlers")
+
+    before_each(function()
+      insert_mode.map_default(
+        "i",
+        "<CR>",
+        "<Plug>(MarkdownPlusListEnter)",
+        handlers.skip_in_codeblock(list.handle_enter, "<CR>", "i"),
+        buf
+      )
+    end)
+
+    after_each(function()
+      insert_mode.unmap_default("i", "<CR>", "<Plug>(MarkdownPlusListEnter)", buf)
+    end)
+
+    it("breaks out of the list on an unchecked empty task at EOL", function()
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "- [ ]" })
+      local result = insert_mode.press("<CR>", 1, 5)
+      assert.are.same({ "" }, result.lines)
+    end)
+
+    it("breaks out of the list on a checked empty task at EOL", function()
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "- [x]" })
+      local result = insert_mode.press("<CR>", 1, 5)
+      assert.are.same({ "" }, result.lines)
+    end)
+
+    it("breaks out of the list on an empty ordered task at EOL", function()
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "1. [ ]" })
+      local result = insert_mode.press("<CR>", 1, 6)
+      assert.are.same({ "" }, result.lines)
+    end)
+
+    it("keeps the indentation when breaking out of a nested empty task", function()
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "- parent", "  - [ ]" })
+      local result = insert_mode.press("<CR>", 2, 7)
+      assert.are.same({ "- parent", "  " }, result.lines)
+    end)
+
+    it("continues the list with a fresh unchecked checkbox when the task has content", function()
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "- [x] task" })
+      local result = insert_mode.press("<CR>", 1, 10)
+      assert.are.same({ "- [x] task", "- [ ] " }, result.lines)
+    end)
+
+    it("still breaks out of a plain empty list item", function()
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "- " })
+      local result = insert_mode.press("<CR>", 1, 2)
+      assert.are.same({ "" }, result.lines)
     end)
   end)
 end)

--- a/test/e2e/cases.lua
+++ b/test/e2e/cases.lua
@@ -1,0 +1,228 @@
+-- End-to-end scenarios for the #387 empty-checkbox fix, mirroring TESTING.md.
+--
+-- Each case is driven through the real buffer-local keymaps with real keypresses, so a pass
+-- means the whole chain works: filetype detection, keymap registration, handler dispatch and
+-- the parser fix underneath. Expected values are exact whole lines — the bug this guards
+-- against produced a *duplicated bracket*, which a substring check would have missed.
+--
+---@class markdown-plus.e2e.Case
+---@field name string Human-readable scenario name
+---@field priority string "P0" | "P1" | "P2"
+---@field lines string[] Buffer contents before the keys are pressed
+---@field cursor? number[] {row, col} 1-indexed row, 0-indexed col. Defaults to {1, 0}
+---@field keys string Key sequence, in Neovim notation, fed through real mappings
+---@field expected string[] Exact buffer contents afterwards
+
+-- localleader is "," in test/e2e/init.lua, so the checkbox toggle default is ",mx".
+local TOGGLE = ",mx"
+
+return {
+  -- ---------------------------------------------------------------- P0: corruption path
+  {
+    name = "toggle empty unchecked task (main wrote '- [ ] [ ]')",
+    priority = "P0",
+    lines = { "- [ ]" },
+    keys = TOGGLE,
+    expected = { "- [x] " },
+  },
+  {
+    name = "toggle empty checked task",
+    priority = "P0",
+    lines = { "- [x]" },
+    keys = TOGGLE,
+    expected = { "- [ ] " },
+  },
+  {
+    name = "toggle empty checked task, capital X",
+    priority = "P0",
+    lines = { "- [X]" },
+    keys = TOGGLE,
+    expected = { "- [ ] " },
+  },
+  {
+    name = "toggle round-trip does not accumulate content",
+    priority = "P0",
+    lines = { "- [ ]" },
+    keys = TOGGLE .. TOGGLE,
+    expected = { "- [ ] " },
+  },
+  {
+    name = "toggle from insert mode via <C-t>",
+    priority = "P0",
+    lines = { "- [ ]" },
+    cursor = { 1, 3 },
+    keys = "i<C-t><Esc>",
+    expected = { "- [x] " },
+  },
+  {
+    name = "toggle a visual range mixing empty and content tasks",
+    priority = "P0",
+    lines = { "- [ ]", "- [ ] real task", "- [x]", "- [x] done task" },
+    keys = "ggVG" .. TOGGLE,
+    expected = { "- [x] ", "- [x] real task", "- [ ] ", "- [ ] done task" },
+  },
+
+  -- ---------------------------------------------------------------- P0: Enter behavior
+  {
+    name = "Enter on an empty task breaks out of the list",
+    priority = "P0",
+    lines = { "- [ ]" },
+    keys = "A<CR><Esc>",
+    expected = { "" },
+  },
+  -- The continued item carries a trailing space: the list prefix builder always emits the
+  -- marker-to-content pad. Pre-existing behavior, and the reason an untouched empty task
+  -- becomes "- [ ]" once trailing whitespace is trimmed on save — the cycle behind #387.
+  {
+    name = "Enter on a task with content continues the list",
+    priority = "P0",
+    lines = { "- [ ] real task" },
+    keys = "A<CR><Esc>",
+    expected = { "- [ ] real task", "- [ ] " },
+  },
+  {
+    name = "Enter on a checked task continues with a fresh unchecked box",
+    priority = "P0",
+    lines = { "- [x] done task" },
+    keys = "A<CR><Esc>",
+    expected = { "- [x] done task", "- [ ] " },
+  },
+
+  -- ---------------------------------------------------------------- P0: must not over-match
+  -- The anchored patterns require the bracket to end the line, so "- [ ]x" stays a plain
+  -- list item whose content happens to start with "[ ]". Continuing it therefore yields a
+  -- bare marker, not a checkbox — this is the assertion that catches an over-broad pattern.
+  {
+    name = "'- [ ]x' is not an empty task (continues as a plain item)",
+    priority = "P0",
+    lines = { "- [ ]x" },
+    keys = "A<CR><Esc>",
+    expected = { "- [ ]x", "- " },
+  },
+  {
+    name = "'- [not a checkbox' is not a checkbox (Enter continues as a plain item)",
+    priority = "P0",
+    lines = { "- [not a checkbox" },
+    keys = "A<CR><Esc>",
+    expected = { "- [not a checkbox", "- " },
+  },
+  {
+    name = "trailing-space form '- [ ] ' behaves identically to '- [ ]'",
+    priority = "P0",
+    lines = { "- [ ] " },
+    keys = TOGGLE,
+    expected = { "- [x] " },
+  },
+
+  -- ---------------------------------------------------------------- P1: marker families
+  {
+    name = "toggle empty task, '*' marker",
+    priority = "P1",
+    lines = { "* [ ]" },
+    keys = TOGGLE,
+    expected = { "* [x] " },
+  },
+  {
+    name = "toggle empty task, '+' marker",
+    priority = "P1",
+    lines = { "+ [ ]" },
+    keys = TOGGLE,
+    expected = { "+ [x] " },
+  },
+  {
+    name = "toggle empty ordered task",
+    priority = "P1",
+    lines = { "1. [ ]" },
+    keys = TOGGLE,
+    expected = { "1. [x] " },
+  },
+  {
+    name = "toggle empty parenthesized ordered task",
+    priority = "P1",
+    lines = { "1) [ ]" },
+    keys = TOGGLE,
+    expected = { "1) [x] " },
+  },
+  {
+    name = "toggle empty lowercase lettered task",
+    priority = "P1",
+    lines = { "a. [ ]" },
+    keys = TOGGLE,
+    expected = { "a. [x] " },
+  },
+  {
+    name = "toggle empty uppercase lettered task",
+    priority = "P1",
+    lines = { "A. [x]" },
+    keys = TOGGLE,
+    expected = { "A. [ ] " },
+  },
+  {
+    name = "Enter breaks out of an empty ordered task",
+    priority = "P1",
+    lines = { "1. [ ]" },
+    keys = "A<CR><Esc>",
+    expected = { "" },
+  },
+
+  -- ---------------------------------------------------------------- P1: states + indent
+  {
+    name = "custom state '-' counts as unchecked",
+    priority = "P1",
+    lines = { "- [-]" },
+    keys = TOGGLE,
+    expected = { "- [x] " },
+  },
+  {
+    name = "custom state '~' counts as unchecked",
+    priority = "P1",
+    lines = { "- [~]" },
+    keys = TOGGLE,
+    expected = { "- [x] " },
+  },
+  {
+    name = "toggle a nested empty task keeps its indentation",
+    priority = "P1",
+    lines = { "- parent", "  - [ ]" },
+    cursor = { 2, 0 },
+    keys = TOGGLE,
+    expected = { "- parent", "  - [x] " },
+  },
+  {
+    name = "Enter on a nested empty task keeps the indentation",
+    priority = "P1",
+    lines = { "- parent", "  - [ ]" },
+    cursor = { 2, 0 },
+    keys = "A<CR><Esc>",
+    expected = { "- parent", "  " },
+  },
+
+  -- ---------------------------------------------------------------- P1: neighbouring features
+  {
+    name = "Tab indents an empty task without disturbing the box",
+    priority = "P1",
+    lines = { "- first", "- [ ]" },
+    cursor = { 2, 0 },
+    keys = "A<Tab><Esc>",
+    expected = { "- first", "  - [ ] " },
+  },
+  -- Renumbering is <localleader>mr. The point of this case is that an empty task counts as
+  -- a member of the list: the new patterns are deliberately not flagged as "empty", so
+  -- group scanning must not treat this line as a break in the list.
+  {
+    name = "an empty task stays a list member for renumbering",
+    priority = "P1",
+    lines = { "1. first", "1. [ ]", "1. third" },
+    keys = ",mr",
+    expected = { "1. first", "2. [ ] ", "3. third" },
+  },
+
+  -- ---------------------------------------------------------------- P2: documented reach
+  {
+    name = "'- [a]' reads as checkbox state 'a' (pre-existing, deliberate)",
+    priority = "P2",
+    lines = { "- [a]" },
+    keys = TOGGLE,
+    expected = { "- [x] " },
+  },
+}

--- a/test/e2e/init.lua
+++ b/test/e2e/init.lua
@@ -1,0 +1,47 @@
+-- Isolated Neovim config for end-to-end keymap tests.
+--
+-- This file is the ONLY config the e2e harness loads. It deliberately does not read
+-- ~/.config/nvim, does not use a plugin manager, and loads nothing but the plugin under
+-- test, so a result here is a property of the plugin rather than of whoever is running it.
+-- `scripts/run-e2e.sh` additionally points every XDG_* dir at a fresh temp directory, so
+-- shada, swap and state from the developer's real Neovim cannot leak in either.
+
+-- The plugin under test, resolved from the repo root the runner passes in.
+local root = os.getenv("MARKDOWN_PLUS_ROOT") or vim.fn.getcwd()
+vim.opt.runtimepath:prepend(root)
+
+-- No writing to disk: these tests only ever inspect buffer contents.
+vim.opt.swapfile = false
+vim.opt.backup = false
+vim.opt.writebackup = false
+vim.opt.shadafile = "NONE"
+
+-- Deterministic indentation. Several cases assert exact leading whitespace, so these must
+-- not be inherited from the environment.
+vim.opt.expandtab = true
+vim.opt.shiftwidth = 2
+vim.opt.tabstop = 2
+vim.opt.autoindent = true
+
+-- The checkbox toggle default is <localleader>mx, so localleader must be defined before
+-- the plugin registers its buffer-local defaults.
+vim.g.mapleader = "\\"
+vim.g.maplocalleader = ","
+
+-- Load the plugin's own entry point exactly as a user would.
+vim.cmd("runtime! plugin/**/*.lua")
+require("markdown-plus").setup({})
+
+-- Guard against the thing this file exists to prevent: if a personal config ever ends up on
+-- the runtimepath, every downstream assertion becomes untrustworthy, so fail loudly instead.
+local rtp = vim.o.runtimepath
+local home = vim.fn.expand("~")
+for entry in vim.gsplit(rtp, ",", { plain = true }) do
+  local is_user_config = entry:find(home .. "/.config/nvim", 1, true)
+    or entry:find(home .. "/.local/share/nvim/lazy", 1, true)
+    or entry:find(home .. "/.local/share/nvim/site", 1, true)
+  if is_user_config then
+    io.stderr:write("ISOLATION FAILURE: personal config on runtimepath: " .. entry .. "\n")
+    vim.cmd("cquit 2")
+  end
+end

--- a/test/e2e/runner.lua
+++ b/test/e2e/runner.lua
@@ -1,0 +1,100 @@
+-- Driver for the end-to-end keymap scenarios in test/e2e/cases.lua.
+--
+-- Run via scripts/run-e2e.sh, which supplies the isolated config and temp XDG dirs.
+-- Every case gets a brand-new scratch buffer backed by a real .md path so the FileType
+-- autocmd fires and the plugin installs its buffer-local keymaps, exactly as for a user.
+-- Keys are fed with the "x" flag, which processes the typeahead synchronously, so the run
+-- is deterministic: no sleeps, no polling, no dependence on machine speed.
+
+local root = os.getenv("MARKDOWN_PLUS_ROOT") or vim.fn.getcwd()
+local cases = dofile(root .. "/test/e2e/cases.lua")
+
+local GREEN, RED, DIM, RESET = "\27[32m", "\27[31m", "\27[2m", "\27[0m"
+local results = { passed = 0, failed = 0, failures = {} }
+
+---Render a list of lines so trailing whitespace is visible in the report.
+---The bug under test turns on exact trailing characters, so "- [x] " and "- [x]" must not
+---look identical in the output.
+---@param lines string[]
+---@return string
+local function show(lines)
+  local parts = {}
+  for i, line in ipairs(lines) do
+    parts[i] = string.format("%q", line)
+  end
+  return "{ " .. table.concat(parts, ", ") .. " }"
+end
+
+---Run one scenario in a fresh buffer and record the outcome.
+---@param case markdown-plus.e2e.Case
+---@param index number
+---@return nil
+local function run_case(case, index)
+  local path = string.format("%s/e2e-%03d.md", vim.fn.tempname(), index)
+  vim.fn.mkdir(vim.fn.fnamemodify(path, ":h"), "p")
+
+  vim.cmd("silent! edit " .. vim.fn.fnameescape(path))
+  vim.bo.filetype = "markdown"
+
+  -- Pin indentation *after* the filetype is set: Neovim's bundled markdown ftplugin sets
+  -- shiftwidth=4 on FileType, which would otherwise decide how far <Tab> indents and make
+  -- these assertions depend on the shipped runtime rather than on the plugin.
+  vim.bo.shiftwidth = 2
+  vim.bo.tabstop = 2
+  vim.bo.expandtab = true
+
+  vim.api.nvim_buf_set_lines(0, 0, -1, false, case.lines)
+  local cursor = case.cursor or { 1, 0 }
+  pcall(vim.api.nvim_win_set_cursor, 0, cursor)
+
+  local keys = vim.api.nvim_replace_termcodes(case.keys, true, false, true)
+  local ok, err = pcall(vim.api.nvim_feedkeys, keys, "mx", false)
+
+  -- Leave insert mode and drain anything a handler queued, so one case cannot bleed into
+  -- the next through the typeahead.
+  pcall(vim.api.nvim_feedkeys, vim.api.nvim_replace_termcodes("<Esc>", true, false, true), "nx", false)
+
+  local actual = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  local matched = ok and vim.deep_equal(actual, case.expected)
+
+  if matched then
+    results.passed = results.passed + 1
+    io.write(string.format("%s  PASS%s  [%s] %s\n", GREEN, RESET, case.priority, case.name))
+  else
+    results.failed = results.failed + 1
+    table.insert(results.failures, case.name)
+    io.write(string.format("%s  FAIL%s  [%s] %s\n", RED, RESET, case.priority, case.name))
+    io.write(string.format("        keys      %s\n", case.keys))
+    io.write(string.format("        expected  %s\n", show(case.expected)))
+    io.write(string.format("        actual    %s\n", show(actual)))
+    if not ok then
+      io.write(string.format("        error     %s\n", tostring(err)))
+    end
+  end
+
+  vim.cmd("silent! bwipeout!")
+end
+
+io.write("\nmarkdown-plus end-to-end keymap tests\n")
+io.write(string.rep("-", 72) .. "\n")
+io.write(string.format("%snvim       %s%s\n", DIM, tostring(vim.version()), RESET))
+io.write(string.format("%splugin     %s%s\n", DIM, os.getenv("MARKDOWN_PLUS_ROOT") or vim.fn.getcwd(), RESET))
+io.write(string.format("%sXDG_CONFIG %s%s\n", DIM, tostring(os.getenv("XDG_CONFIG_HOME")), RESET))
+io.write(string.rep("-", 72) .. "\n")
+
+for index, case in ipairs(cases) do
+  run_case(case, index)
+end
+
+io.write(string.rep("-", 72) .. "\n")
+io.write(string.format("passed %d   failed %d   total %d\n", results.passed, results.failed, #cases))
+
+if results.failed > 0 then
+  io.write("\nfailed cases:\n")
+  for _, name in ipairs(results.failures) do
+    io.write("  - " .. name .. "\n")
+  end
+  vim.cmd("cquit 1")
+end
+
+vim.cmd("quitall!")


### PR DESCRIPTION
Closes #387.

## Summary

A checkbox item with nothing after the bracket — `- [ ]` — was parsed as a plain list item whose content happened to be `[ ]`. The trigger is the common case rather than an edge case: trimming trailing whitespace on save turns every empty task into exactly this form.

Two independent causes had to be fixed together, which is why patterns alone would not have worked:

1. **Patterns.** Every checkbox pattern required whitespace after `]`, so the end-of-line form never matched. Anchored empty-checkbox patterns are now registered for each marker family (`-`/`*`/`+`, `1.`, `2)`, `a.`/`A.`, `b)`/`B)`) and every checkbox state.
2. **Treesitter masking.** tree-sitter-markdown only emits a `task_list_marker_*` node for a checkbox item that *carries content*, and a non-nil treesitter result won outright — so on the row-aware path the regex result was never consulted. `parse_list_line` now prefers the regex result when treesitter reports no checkbox and regex finds one.

## Impact beyond the reported behavior

The issue was filed as an Enter-key annoyance. It is also **silent line corruption** in the checkbox toggle. On `main` today:

```
- [ ]    --toggle-->  - [ ] [ ]
- [x]    --toggle-->  - [ ] [x]
1. [ ]   --toggle-->  1. [ ] [ ]
- [ ] task --toggle--> - [x] task   (unaffected)
```

Every toggle of an empty task writes garbage into the user's file, with no error shown. That path had **no** test coverage — all existing toggle specs use checkboxes with content — so this PR adds 20 regression specs that assert the entire resulting line, not a substring.

Two further latent bugs are fixed as a consequence:

- `- [ ] ` (trailing space) degraded to a plain item on the treesitter path whenever a row was passed.
- Custom states disagreed between paths: `- [-] task` gave `checkbox=nil` with a row and `checkbox="-"` without.

## Test plan

- [x] `make check` green; failure-grep across all spec files returns nothing
- [x] 1582 → **1649** passing (+67)
- [x] RED verified against `main` (`git archive baf5007` into a temp tree, specs replayed): 34 + 5 + 4 parser/pattern/Enter failures, then 19 of the 20 new toggle specs with the exact corruption strings above
- [x] Both parse paths asserted for 15 marker × state combinations (with a row = treesitter-assisted, without = regex)
- [x] Negatives unchanged: `- [ ] task`, `- [ ]x`, `- [not a checkbox`, bare `- `, indented and nested forms

## Notes

- No config surface added; the config checklist does not apply.
- Toggling a clean `- [ ]` yields `- [x] ` with a trailing space. That is pre-existing behavior (`- [ ] ` already produced it, as does the list-continuation prefix builder) and the round-trip is now asserted to be non-destructive at every step. Changing it would be a deliberate behavior change and belongs in its own issue.
