### PR TITLE
docs(wiki): add Lua API, Treesitter, and Plug mappings wiki pages

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,19 +6,30 @@
 **Purpose:** Modern, feature-rich Markdown editing for Neovim
 
 ### Core Features
-- **List management:** Auto-continue, indent/outdent, renumbering, checkbox support
-- **Text formatting:** Bold, italic, strikethrough, inline code, clear formatting
-- **Headers & TOC:** Navigate, promote/demote, generate/update GitHub-compatible TOC
-- **Link management:** Insert, edit, convert inline/reference, auto-link URLs
+Eleven user-facing feature modules, each toggleable via `features.*`:
+- **list** — auto-continue, indent/outdent, renumbering, checkboxes, list-type toggling
+- **format** — bold, italic, strikethrough, inline code, highlight, escape, clear formatting
+- **headers** — navigate, promote/demote, ATX/setext toggle, generate/update GitHub-compatible TOC
+- **links** — insert, edit, convert inline/reference, auto-link URLs, smart paste
+- **table** — create, format, navigate, row/column ops, cell editor, CSV conversion
+- **footnotes** — insert, edit, delete, navigate, footnotes window
+- **code_block** — insert/wrap, navigate (`]b`/`[b`), change language
+- **callouts** — GFM admonitions, cycle types, custom types
+- **quote** — toggle blockquote markers
+- **images** — insert/edit image syntax
+- **thematic_break** — insert and cycle horizontal-rule styles
 
 ### Architecture
-- `lua/markdown-plus/` - Core modules (81 Lua files across 14 directories):
+- `lua/markdown-plus/` - Core modules (83 Lua files: 6 at root + 77 across 14 directories):
   - Feature modules: list/, format/, headers/, links/, table/, footnotes/, callouts/, quote/, images/, code_block/, thematic_break/
   - Shared: utils/ (buffer, text, selection, element, html), treesitter/, config/
-  - Root: init.lua, types.lua, utils.lua, keymap_helper.lua, health.lua
+  - Root: init.lua, types.lua, utils.lua, keymap_helper.lua, keymap_fallback.lua, health.lua
 - `plugin/markdown-plus.lua` - Entry point with lazy initialization guard
-- `spec/` - 45 Busted test suites
+- `spec/` - 49 Busted test suites, plus `spec/helpers/` and `spec/minimal_init.lua`
+- `test/e2e/` - Separate end-to-end keymap harness (real keypresses, isolated Neovim)
+- `scripts/` - `test` (coverage enforcement), `run-e2e.sh` (isolated e2e runner)
 - `doc/` - Vimdoc help files
+- `docs/wiki/` - Published wiki source (synced by wiki-sync.yml)
 - `rockspecs/` - LuaRocks package specifications
 
 ### Quality Tooling
@@ -26,7 +37,7 @@
 - **Linting:** .luacheckrc
 - **Formatting:** .stylua.toml
 - **Type checking:** .luarc.json (Lua 5.1 runtime)
-- **Testing:** Busted + Plenary (45 spec files, ~85% coverage)
+- **Testing:** Busted + Plenary (49 spec files, ~85% coverage)
 
 ---
 
@@ -56,6 +67,8 @@
 3. **Keymaps**
    - Expose ALL functionality through `<Plug>` mappings
    - Use `keymap_helper.lua` for defaults; it checks existing buffer-local mappings with `maparg()` before setting them
+   - `<Plug>` mappings are global and registered once per mode; user-facing defaults are buffer-local and tracked so teardown removes only our own
+   - Keys other plugins commonly own (`<CR>`, `<BS>`, `<Tab>`, `<S-Tab>`, `<A-CR>`, `o`/`O`, `<A-h/j/k/l>`) must hand the press back via `keymap_fallback.run()` when outside markdown-plus's own context — never reimplement native behavior, and never feed a key that routes back into our own `<Plug>`
    - Never create global normal-mode maps that conflict with common user mappings
    - Keep keymaps buffer-local and properly scoped
 
@@ -87,15 +100,20 @@ make test              # Run all tests
 make test-coverage     # Run tests with coverage threshold checks (85% overall, 80% critical)
 make test-file         # Run tests for a specific file (set FILE=path/to/spec.lua)
 make test-watch        # Run tests in watch mode
+make test-e2e          # Real keypresses through real keymaps in an isolated Neovim
 
 # Code Quality
-make lint              # Run luacheck
-make format            # Format code with stylua
+make lint              # luacheck on lua/ spec/ test/
+make format            # stylua on lua/ spec/ plugin/ test/
 make format-check      # Check formatting without modifying files
 
 # Combined
-make check             # Run lint + format-check + test
+make check             # lint + format-check + test (does NOT include test-e2e)
 ```
+
+Coverage enforcement lives in `scripts/test`, gated by `MARKDOWN_PLUS_ENFORCE_COVERAGE=1`.
+Critical files held to 80%: `headers/init.lua`, `headers/toc.lua`, `list/init.lua`, `links/http_fetch.lua`.
+CI is a reused workflow (`folke/github/.github/workflows/ci.yml`), so most checks are not defined in this repo.
 
 ### Best Practices Checklist
 
@@ -199,13 +217,21 @@ make check             # Run lint + format-check + test
 - `lua/markdown-plus/types.lua` - Type definitions (extend here first)
 - `lua/markdown-plus/config/validate.lua` - Config validation
 - `lua/markdown-plus/utils.lua` - Shared utilities
+- `lua/markdown-plus/keymap_helper.lua` - `<Plug>` + default keymap registration
+- `lua/markdown-plus/keymap_fallback.lua` - Hands keys back to other plugins
 - `plugin/markdown-plus.lua` - Initialization entry point
 - `spec/markdown-plus/*` - Test files
 
+### Gotchas
+- `docs/*` is gitignored except `docs/wiki/` and `docs/manual-testing/` — new files elsewhere under `docs/` are silently untracked
+- `lint` covers `lua/ spec/ test/`; `format`/`format-check` also cover `plugin/`
+- `spec/` (Busted) and `test/e2e/` (real keypresses) are different harnesses; `make check` runs only the former
+- Reset module state in `before_each`/`after_each` — plenary never reaches an event-loop turn between `it` blocks, so `vim.schedule`-released state leaks between tests
+- Requires are mixed by design: shared infra (`utils`, `treesitter`) at module top, feature/sibling modules required inside functions to break cycles
+- Use `vim.notify("markdown-plus: ...")` for user-facing errors; the only `error(`-shaped calls in `lua/` are `health.error()` (vim.health API)
+
 ### Testing Coverage
-✅ Config merging & validation  
-✅ Utility helpers  
-✅ List management  
-✅ Headers & TOC  
-✅ Text formatting  
-✅ Link management
+49 spec files, ~85% overall. Covered areas: config merging & validation, utils, treesitter,
+health, keymap fallback & plugin interop, and all 11 feature modules — list (10 specs),
+table (9), footnotes (7), headers (6), format (3), images (2), links, smart paste,
+callouts, quote, code_block, thematic_break.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 **Stack**: Lua 5.1 / Neovim 0.11+ / Zero dependencies
 **Architecture**: Feature-based modular plugin — 11 user-facing feature modules plus shared config/utils/treesitter infrastructure under `lua/markdown-plus/`
 **Entry points**: `plugin/markdown-plus.lua` (load guard) → `lua/markdown-plus/init.lua` (setup + orchestration)
-**Test command**: `make test` (Busted + plenary.nvim, 45 spec files)
+**Test command**: `make test` (Busted + plenary.nvim, 49 spec files)
 **Build command**: `make check` (lint + format-check + test)
 
 ## Commands
@@ -14,21 +14,29 @@
 make test              # Run all tests (plenary.nvim harness)
 make test-file FILE=spec/markdown-plus/list_spec.lua
 make test-coverage     # Coverage thresholds: 85% overall, 80% critical files
-make lint              # luacheck
-make format            # stylua (120 col, 2-space indent, double quotes)
+make test-e2e          # Real keypresses through real keymaps in an isolated Neovim
+make lint              # luacheck on lua/ spec/ test/
+make format            # stylua on lua/ spec/ plugin/ test/ (120 col, 2-space, double quotes)
 make format-check      # Check only
-make check             # Full CI: lint + format-check + test
+make check             # lint + format-check + test — does NOT include test-e2e
 ```
+
+Coverage enforcement lives in `scripts/test`, gated by `MARKDOWN_PLUS_ENFORCE_COVERAGE=1`.
+Critical files held to 80%: `headers/init.lua`, `headers/toc.lua`, `list/init.lua`, `links/http_fetch.lua`.
 
 ## Key Directories
 
-- `lua/markdown-plus/` — Core plugin code (81 Lua files across 14 module directories)
+- `lua/markdown-plus/` — Core plugin code (83 Lua files: 6 at root + 77 across 14 module dirs)
 - `lua/markdown-plus/types.lua` — LuaCATS type definitions (update FIRST for new types)
 - `lua/markdown-plus/config/validate.lua` — Schema-based config validation
-- `lua/markdown-plus/utils.lua` — Shared utilities (cursor, line, buffer ops)
+- `lua/markdown-plus/utils.lua` — Facade over `utils/` (buffer, text, selection, element, html)
 - `lua/markdown-plus/keymap_helper.lua` — Centralized `<Plug>` + default keymap registration
-- `spec/markdown-plus/` — 45 Busted test suites
+- `lua/markdown-plus/keymap_fallback.lua` — Hands keys back to other plugins outside our context
+- `spec/markdown-plus/` — 49 Busted test suites (plus `spec/helpers/`, `spec/minimal_init.lua`)
+- `test/e2e/` — Separate e2e harness (real keypresses, isolated Neovim) — not Busted
+- `scripts/` — `test` (coverage enforcement), `run-e2e.sh` (isolated e2e runner)
 - `doc/markdown-plus.txt` — Vimdoc help file
+- `docs/wiki/` — Published wiki source (synced by `wiki-sync.yml`)
 - `plugin/markdown-plus.lua` — Load guard (no logic here)
 
 ## Feature Module Pattern
@@ -38,6 +46,8 @@ Features are conditionally loaded based on `config.features.*` flags in `init.lu
 Features are mostly isolated; all depend on `utils.lua` and `keymap_helper.lua`.
 Note: `utils/element.lua` has a soft cross-reference into `treesitter` and `code_block.parser`.
 Table is the main special case: `init.lua` passes `config.table` to `table.setup()` and wires table keymaps directly without a `table.enable()` call.
+
+Keys other plugins commonly own — `<CR>`, `<BS>`, `<Tab>`, `<S-Tab>`, `<A-CR>`, `o`/`O`, `<A-h/j/k/l>` — are only acted on inside markdown-plus's own context. Everywhere else `keymap_fallback.run()` resolves buffer-local → global → raw key and hands the press back. Never feed a key that routes back into our own `<Plug>`; that bounces.
 
 ## Conventions
 
@@ -64,9 +74,20 @@ require("markdown-plus").setup(opts)
 
 ## Testing
 
-- Framework: Busted via plenary.nvim (`spec/minimal_init.lua` bootstraps)
+- Framework: Busted via plenary.nvim (`spec/minimal_init.lua` bootstraps; finds plenary via `PLENARY_DIR` or common plugin-manager paths)
 - Pattern: `describe()`/`it()` blocks, buffer fixtures in `before_each`
-- 45 test files covering: config, utils, list (4 files: main + group_scanner/normal_handler/parser), format (3 files: main + escape/repeat), headers (6 files: main + manipulation/navigation + toc actions/render/state), links, smart_paste, table (7 files: main + cell_breaks/creator/cell_ops/column_ops/row_ops/row_mapper), footnotes (7 files: main + insertion/navigation/window/line_parser/query/scanner), callouts, health, treesitter, images (2 files: main + insertion), code_block, thematic_break, quote
+- Helpers in `spec/helpers/`: `mocks.lua` (stub `vim.notify` / `vim.ui.select` / `vim.fn.input`), `insert_mode.lua`, `async.lua`
+- Reset module state explicitly in `before_each`/`after_each` — plenary never reaches an event-loop turn between `it` blocks, so `vim.schedule`-released state leaks between tests
+- 49 spec files. Densest areas: list (10), table (9), footnotes (7), headers (6), format (3), images (2); plus `keymap_fallback_spec.lua` and `interop_recipes_spec.lua`
+- `test/e2e/` is a separate harness (`make test-e2e`) driving real keys through real buffer-local keymaps; not run by `make check` or CI
+
+## Gotchas
+
+- `docs/*` is gitignored except `docs/wiki/` and `docs/manual-testing/` — new files elsewhere under `docs/` are silently untracked
+- `lint` covers `lua/ spec/ test/`; `format`/`format-check` also cover `plugin/`
+- Requires are mixed by design: shared infra (`utils`, `treesitter`) at module top, feature/sibling modules required inside functions to break cycles — follow the surrounding file
+- The only `error(`-shaped calls in `lua/` are `health.error()` (vim.health API); runtime code uses `vim.notify("markdown-plus: ...")`
+- CI is a reused workflow (`folke/github/.github/workflows/ci.yml`), so most checks are not defined in this repo
 
 ## Don't
 

--- a/docs/wiki/1.Installation.md
+++ b/docs/wiki/1.Installation.md
@@ -8,8 +8,9 @@
 ### Optional: Treesitter parsers
 
 The plugin works fully without Treesitter. When the Markdown parsers are
-available, text formatting becomes context-aware — bold/italic toggles skip
-content inside code spans and fenced code blocks instead of mangling it.
+available, list handling and text formatting become context-aware — the list
+keys defer inside fenced code blocks, and bold/italic toggles act on the whole
+formatted region rather than just the word under the cursor.
 
 **Neovim already ships these parsers**, so on a stock 0.11+ install there is
 nothing to do. Confirm with:

--- a/docs/wiki/1.Installation.md
+++ b/docs/wiki/1.Installation.md
@@ -5,6 +5,24 @@
 - Neovim 0.11+ (uses modern Lua APIs)
 - No external dependencies
 
+### Optional: Treesitter parsers
+
+The plugin works fully without Treesitter. When the Markdown parsers are
+available, text formatting becomes context-aware — bold/italic toggles skip
+content inside code spans and fenced code blocks instead of mangling it.
+
+**Neovim already ships these parsers**, so on a stock 0.11+ install there is
+nothing to do. Confirm with:
+
+```vim
+:checkhealth markdown-plus
+```
+
+If they are somehow missing, install them with a parser manager such as
+nvim-treesitter (`:TSInstall markdown markdown_inline`). See
+[Treesitter Integration](https://github.com/YousefHadder/markdown-plus.nvim/wiki/11.Treesitter)
+for what changes with and without them.
+
 ## Installation Methods
 
 > [!NOTE]

--- a/docs/wiki/10.Lua-API.md
+++ b/docs/wiki/10.Lua-API.md
@@ -1,0 +1,270 @@
+# Lua API
+
+markdown-plus exposes a Lua API for plugin authors and for anyone scripting
+their own mappings, commands or autocommands.
+
+Everything here is also in the help file — `:help markdown-plus-api`.
+
+## Entry Points
+
+```lua
+local mp = require("markdown-plus")
+```
+
+| Function | Description |
+|----------|-------------|
+| `mp.setup(opts)` | Validate and merge config, load enabled features, register `<Plug>` mappings and autocommands |
+| `mp.teardown()` | Undo everything `setup()` did and restore the default config |
+| `mp.config` | The merged, validated config table (read-only in practice) |
+| `mp.in_list_context(kind)` | Whether the cursor is in list context — see [Customizing Keymaps](https://github.com/YousefHadder/markdown-plus.nvim/wiki/6.Customizing-Keymaps) |
+| `mp.enable_features_for_buffer()` | Enable features for the current buffer manually |
+| `mp.setup_autocmds()` | Re-register the `FileType` autocommands |
+
+`setup()` is the only function most users ever call.
+
+### `teardown()`
+
+Fully unloads the plugin from the current session:
+
+```lua
+require("markdown-plus").teardown()
+```
+
+It disables per-buffer features across loaded buffers, clears the augroup,
+removes the buffer-local default keymaps it installed, resets the `<Plug>`
+registration cache and the keymap-fallback state, drops the module handles, and
+restores `mp.config` to the shipped defaults.
+
+This makes `setup()` safely re-runnable, which is what the test suite relies on.
+It is also handy while tuning your config:
+
+```lua
+vim.keymap.set("n", "<leader>mr", function()
+  require("markdown-plus").teardown()
+  package.loaded["markdown-plus"] = nil
+  require("markdown-plus").setup({ --[[ new options ]] })
+end, { desc = "Reload markdown-plus" })
+```
+
+## Reaching the Feature Modules
+
+Each feature is exposed as a field on the root module:
+
+```lua
+require("markdown-plus").headers.generate_toc()
+require("markdown-plus").footnotes.list()
+```
+
+> [!IMPORTANT]
+> These handles are `nil` until `setup()` has run, and they are only assigned
+> when the matching `features.*` flag is enabled. If you disable a feature, its
+> handle stays `nil`.
+
+```lua
+local mp = require("markdown-plus")
+if mp.headers then
+  mp.headers.generate_toc()
+end
+```
+
+`require()` the module directly if you want it regardless of the feature flags:
+
+```lua
+require("markdown-plus.headers").generate_toc()
+```
+
+| Handle | Module path |
+|--------|-------------|
+| `mp.list` | `markdown-plus.list` |
+| `mp.format` | `markdown-plus.format` |
+| `mp.thematic_break` | `markdown-plus.thematic_break` |
+| `mp.headers` | `markdown-plus.headers` |
+| `mp.links` | `markdown-plus.links` |
+| `mp.images` | `markdown-plus.images` |
+| `mp.quotes` | `markdown-plus.quote` |
+| `mp.callouts` | `markdown-plus.callouts` |
+| `mp.code_block` | `markdown-plus.code_block` |
+| `mp.table` | `markdown-plus.table` |
+| `mp.footnotes` | `markdown-plus.footnotes` |
+
+> [!NOTE]
+> The quotes handle is plural (`mp.quotes`) but the module path is singular
+> (`markdown-plus.quote`). Easy to trip over.
+
+## Function Reference
+
+### List
+
+| Function | Description |
+|----------|-------------|
+| `in_list_context(kind)` | `true` if the cursor is in list context for `'enter'`, `'backspace'` or `'indent'` |
+| `handle_enter()` | Insert-mode `<CR>` handler |
+| `continue_list_content()` | Continue content without starting a new bullet |
+| `handle_tab()` / `handle_shift_tab()` | Indent / outdent the item |
+| `handle_backspace()` | Insert-mode `<BS>` handler |
+| `handle_normal_o()` / `handle_normal_O()` | Normal-mode `o` / `O` handlers |
+| `renumber_ordered_lists()` | Renumber every ordered list in the buffer |
+| `debug_list_groups()` | Print the parsed list groups — useful for bug reports |
+
+The handlers return `true` when they acted and `false` when they declined, which
+is what makes them safe to compose with other plugins.
+
+### Format
+
+| Function | Description |
+|----------|-------------|
+| `toggle_format(format_type)` | Toggle formatting over the visual selection |
+| `toggle_format_word(format_type)` | Toggle formatting on the word under the cursor |
+| `strip_all_formatting(text)` | Return `text` with all markup removed |
+| `toggle_escape_selection()` | Escape / unescape Markdown punctuation in the selection |
+| `convert_to_code_block()` | Convert the visual selection into a fenced block |
+| `clear_formatting()` / `clear_formatting_word()` | Clear formatting on selection / word |
+| `get_lines_in_range(start_row, end_row)` | Fetch a line range |
+
+### Headers & TOC
+
+| Function | Description |
+|----------|-------------|
+| `promote_header()` / `demote_header()` | Add / remove a `#` |
+| `set_header_level(level)` | Set the line to a specific level (1–6) |
+| `toggle_atx_setext()` | Switch an H1/H2 between ATX and setext style |
+| `next_header()` / `prev_header()` | Jump between headers |
+| `generate_toc()` / `update_toc()` | Create / refresh the table of contents |
+| `follow_link()` | Follow the TOC link under the cursor — returns `boolean` |
+| `open_toc_window(window_type)` | Interactive TOC: `'vertical'` (default), `'horizontal'` or `'tab'` |
+| `parse_header(line, next_line)` | Parse an ATX or setext heading |
+
+### Code Block
+
+| Function | Description |
+|----------|-------------|
+| `insert_with_language()` | Insert a fenced block, prompting for the language |
+| `wrap_selection()` | Wrap the visual selection in a fence |
+| `change_language()` | Change the language of the block under the cursor |
+| `toggle_fence_style()` | Switch between backtick and tilde fences |
+| `find_all_blocks()` | Every fenced block in the buffer |
+| `find_block_at_cursor()` | The block containing the cursor, or `nil` |
+
+`find_block_at_cursor()` is the one to reach for when you need to make your own
+mapping defer inside code blocks.
+
+### Thematic Break
+
+| Function | Description |
+|----------|-------------|
+| `insert()` | Insert a break below the cursor, adding blank lines as needed |
+| `cycle_style()` | Rotate `---` → `***` → `___` → `---` |
+
+### Links
+
+| Function | Description |
+|----------|-------------|
+| `insert_link()` | Prompt for text and URL, insert an inline link |
+| `selection_to_link()` | Turn the visual selection into the link text |
+| `edit_link()` | Edit the link under the cursor |
+| `auto_link_url()` | Wrap a bare URL in `<>` |
+| `convert_to_reference()` / `convert_to_inline()` | Convert between link styles |
+| `find_reference_url(ref)` | Resolve a reference label to its URL |
+
+Smart paste lives in a submodule rather than on the `links` handle:
+
+```lua
+require("markdown-plus.links.smart_paste").smart_paste()
+```
+
+It is a no-op unless `links.smart_paste.enabled` is `true` in your config.
+
+### Images
+
+| Function | Description |
+|----------|-------------|
+| `insert_image()` | Prompt for alt text and path, insert an image |
+| `selection_to_image()` | Turn the visual selection into the alt text |
+| `edit_image()` | Edit the image under the cursor |
+| `get_image_at_cursor()` | Return the image under the cursor, or `nil` |
+| `toggle_image_link()` | Switch between `![alt](src)` and `[alt](src)` |
+
+### Quotes & Callouts
+
+| Function | Description |
+|----------|-------------|
+| `quote.toggle_quote()` | Toggle blockquote on the line or selection |
+| `callouts.insert_callout(type)` | Insert a callout of a given type |
+| `callouts.insert_callout_prompt()` | Insert a callout, prompting for the type |
+| `callouts.wrap_selection_in_callout()` | Wrap the selection in a callout |
+| `callouts.toggle_callout_type()` | Cycle the type of the callout under the cursor |
+| `callouts.convert_to_callout()` / `convert_to_blockquote()` | Convert between the two |
+| `callouts.get_callout_at_cursor()` | The callout under the cursor, or `nil` |
+| `callouts.is_valid_callout_type(type)` | Validate a callout type string |
+
+### Tables
+
+The largest module. Everything below operates on the table under the cursor;
+most are no-ops outside one.
+
+| Function | Description |
+|----------|-------------|
+| `is_in_table()` | `true` if the cursor is inside a table |
+| `create_table()` | Create a new table interactively |
+| `format_table()` / `normalize_table()` | Realign columns / normalize structure |
+| `move_left()` / `move_right()` / `move_up()` / `move_down()` | Move between cells |
+| `edit_cell()` / `clear_cell()` | Edit / empty the current cell |
+| `wrap_cell()` / `unwrap_cell()` | Toggle soft wrapping in a cell |
+| `insert_break()` | Insert a line break inside a cell |
+| `insert_row_above()` / `insert_row_below()` | Insert a row |
+| `delete_row()` | Delete the current row |
+| `move_row_up()` / `move_row_down()` | Reorder rows |
+| `insert_column_left()` / `insert_column_right()` | Insert a column |
+| `delete_column()` | Delete the current column |
+| `move_column_left()` / `move_column_right()` | Reorder columns |
+| `toggle_cell_alignment()` | Cycle the column's alignment marker |
+| `sort_ascending()` / `sort_descending()` | Sort rows by the current column |
+| `transpose_table()` | Swap rows and columns |
+| `csv_to_table()` / `table_to_csv()` | Convert between CSV and Markdown tables |
+
+### Footnotes
+
+| Function | Description |
+|----------|-------------|
+| `insert()` | Insert a reference and, if needed, its definition |
+| `edit()` | Jump to the definition and enter insert mode |
+| `delete()` | Delete every reference plus the definition |
+| `goto_definition()` / `goto_reference()` | Jump between the two |
+| `next_footnote()` / `prev_footnote()` | Walk references in document order |
+| `list()` | Picker showing every footnote and its health |
+| `get_all_footnotes()` | Every footnote with its references and definition |
+| `get_next_id()` | The next unused numeric ID |
+| `get_footnote_at_cursor()` | The footnote under the cursor, or `nil` |
+
+`get_all_footnotes()` is what you want for a lint-style check — each entry
+carries its definition and reference list, so orphans and missing definitions
+are easy to spot.
+
+### Utils
+
+| Function | Description |
+|----------|-------------|
+| `get_lines_in_range(start_row, end_row)` | Fetch a line range |
+| `get_code_block_lines(lines)` | Map of which lines fall inside fenced blocks |
+| `build_markdown_link(text, url, title)` | Build `[text](url "title")` |
+| `build_markdown_image(alt, url, title)` | Build `![alt](url "title")` |
+
+## Commands
+
+Three buffer-local commands are available in Markdown buffers when the
+`headers_toc` feature is enabled:
+
+| Command | Equivalent |
+|---------|-----------|
+| `:Toc` | `headers.open_toc_window("vertical")` |
+| `:Toch` | `headers.open_toc_window("horizontal")` |
+| `:Toct` | `headers.open_toc_window("tab")` |
+
+They are only created if a command of that name does not already exist on the
+buffer, so they will not clobber a command from another plugin.
+
+## See Also
+
+- [Customizing Keymaps](https://github.com/YousefHadder/markdown-plus.nvim/wiki/6.Customizing-Keymaps) — `in_list_context` recipes and plugin interop
+- [Plug Mappings](https://github.com/YousefHadder/markdown-plus.nvim/wiki/12.Plug-Mappings) — the full `<Plug>` reference
+- `:help markdown-plus-api` — the same reference inside Neovim

--- a/docs/wiki/10.Lua-API.md
+++ b/docs/wiki/10.Lua-API.md
@@ -24,7 +24,7 @@ local mp = require("markdown-plus")
 
 ### `teardown()`
 
-Fully unloads the plugin from the current session:
+Resets plugin-managed state so `setup()` can be re-run cleanly:
 
 ```lua
 require("markdown-plus").teardown()
@@ -34,6 +34,12 @@ It disables per-buffer features across loaded buffers, clears the augroup,
 removes the buffer-local default keymaps it installed, resets the `<Plug>`
 registration cache and the keymap-fallback state, drops the module handles, and
 restores `mp.config` to the shipped defaults.
+
+> [!IMPORTANT]
+> This is not a full unload. The global `<Plug>` mappings created by an earlier
+> `setup()` are **not** deleted — only the cache that tracks them is cleared, so the
+> next `setup()` re-registers them. Invoking a `<Plug>` mapping in between still runs
+> the handler it captured.
 
 This makes `setup()` safely re-runnable, which is what the test suite relies on.
 It is also handy while tuning your config:
@@ -106,8 +112,10 @@ require("markdown-plus.headers").generate_toc()
 | `renumber_ordered_lists()` | Renumber every ordered list in the buffer |
 | `debug_list_groups()` | Print the parsed list groups — useful for bug reports |
 
-The handlers return `true` when they acted and `false` when they declined, which
-is what makes them safe to compose with other plugins.
+The handlers are not predicates and do not report whether they acted. When the
+cursor is not in list context they emulate the native behavior for that key
+themselves and return nothing. If you need to branch before calling one, use
+`in_list_context(kind)`.
 
 ### Format
 
@@ -205,7 +213,7 @@ most are no-ops outside one.
 | Function | Description |
 |----------|-------------|
 | `is_in_table()` | `true` if the cursor is inside a table |
-| `create_table()` | Create a new table interactively |
+| `create_table(rows, cols)` | Create a `rows` × `cols` table — both arguments are required |
 | `format_table()` / `normalize_table()` | Realign columns / normalize structure |
 | `move_left()` / `move_right()` / `move_up()` / `move_down()` | Move between cells |
 | `edit_cell()` / `clear_cell()` | Edit / empty the current cell |

--- a/docs/wiki/11.Treesitter.md
+++ b/docs/wiki/11.Treesitter.md
@@ -1,0 +1,154 @@
+# Treesitter
+
+markdown-plus uses Treesitter to understand document structure when it is
+available, and falls back to regex parsing when it is not. The plugin works
+either way — Treesitter just makes it more accurate.
+
+## Requirements
+
+- Neovim 0.11+ (for `vim.treesitter.get_node`)
+- The `markdown` and `markdown_inline` parsers
+
+**You almost certainly already have these.** Neovim ships the Markdown parsers
+in its own runtime — `:help treesitter` lists Markdown under "Nvim includes
+these parsers", and both `markdown` and `markdown_inline` are bundled. On a
+stock Neovim 0.11+ install, there is nothing to do.
+
+Check with:
+
+```vim
+:checkhealth markdown-plus
+```
+
+If the parsers really are missing (an unusual build, or a stripped-down
+distribution), install them with a parser manager such as
+[nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter):
+
+```vim
+:TSInstall markdown markdown_inline
+```
+
+Note that `:TSInstall` is provided by nvim-treesitter, not by Neovim — it won't
+exist unless you have that plugin. markdown-plus does not require it.
+
+Both parsers matter. `markdown` handles block structure (lists, code blocks,
+tables, blockquotes) and `markdown_inline` handles inline structure (bold,
+italic, strikethrough, code spans, links). markdown-plus only asks for the
+`markdown` parser directly — `markdown_inline` is pulled in as an injected
+language, so if it is missing, inline format detection quietly drops to regex.
+
+> [!NOTE]
+> `:checkhealth markdown-plus` only verifies the `markdown` parser, so a missing
+> `markdown_inline` will not be reported. See [Verifying It Works](#verifying-it-works)
+> for how to confirm the injected parser directly.
+
+## What Treesitter Is Used For
+
+| Area | What it buys you |
+|------|-----------------|
+| List detection | Reliable parsing of markers, ordered/unordered, task items and nesting |
+| Code block detection | markdown-plus knows exactly where fences begin and end, so it never acts inside one |
+| Format region detection | Bold, italic, strikethrough and inline code are recognized as *regions*, not just strings |
+
+Code block detection is the one you feel most. Every shared key (`<CR>`,
+`<Tab>`, `<S-Tab>`, `<BS>`, `o`, `O`) defers unconditionally inside a fence, so a
+`- item` written inside a ```` ```markdown ```` block is left alone.
+
+## Fallback Behavior
+
+If Treesitter is missing, the parser is not installed, or a specific element
+fails to parse, markdown-plus falls back to regex parsing for that operation.
+There is no configuration to set and nothing breaks — you just lose some
+precision in ambiguous documents.
+
+Parsers are cached per buffer against `changedtick`, so repeated operations
+between edits do not re-parse.
+
+## Smart Formatting
+
+Treesitter is what makes the formatting toggles feel smart rather than literal.
+
+### Toggling Works on the Whole Region
+
+Put the cursor anywhere inside a formatted region and the toggle applies to all
+of it — you do not have to select it or sit on a particular word.
+
+```markdown
+This is **some bold text** here
+              ↑ cursor anywhere in here
+
+Press <localleader>mb →
+
+This is some bold text here
+```
+
+Without Treesitter this only reliably works on a single word.
+
+### Nesting Instead of Breaking
+
+Applying a *different* format to already-formatted text nests it rather than
+mangling the markers:
+
+```markdown
+This is **bold** text
+           ↑ cursor here
+
+Press <localleader>mi →
+
+This is ***bold and italic*** text
+```
+
+markdown-plus works out whether you are nesting a new format or toggling the
+existing one.
+
+### Visual Selections Inside a Region
+
+If your visual selection is fully contained inside a formatted region, toggling
+that format removes it from the whole container rather than splitting it into
+fragments:
+
+```markdown
+This is **some bold text** here
+            └─ selected ─┘
+
+Press <localleader>mb →
+
+This is some bold text here
+```
+
+## Highlight and Underline Are Different
+
+`==highlight==` and `++underline++` are **not** part of the standard
+`markdown_inline` grammar. They are always detected with regex, even when
+Treesitter is installed and working.
+
+In practice this means the region-level smartness above applies to bold, italic,
+strikethrough and inline code, but `<localleader>m=` and `<localleader>mu`
+behave more literally. This is a grammar limitation, not a bug.
+
+## Verifying It Works
+
+```vim
+:checkhealth markdown-plus
+```
+
+If something looks wrong:
+
+1. Confirm the parser loads — `:lua =vim.treesitter.get_parser(0, "markdown") ~= nil`
+2. Confirm the buffer filetype — `:set filetype?` should report `markdown`
+3. Confirm Neovim is 0.11 or newer — `:version`
+
+You can also inspect the tree directly:
+
+```vim
+:InspectTree
+```
+
+Put the cursor inside some `**bold**` text and check that the node under it is
+`strong_emphasis`. If it is not, `markdown_inline` is missing or not injected.
+
+## See Also
+
+- [Troubleshooting](https://github.com/YousefHadder/markdown-plus.nvim/wiki/8.Troubleshooting)
+- [Usage Examples](https://github.com/YousefHadder/markdown-plus.nvim/wiki/4.Usage) — the formatting section
+- `:help markdown-plus-treesitter`

--- a/docs/wiki/11.Treesitter.md
+++ b/docs/wiki/11.Treesitter.md
@@ -47,12 +47,17 @@ language, so if it is missing, inline format detection quietly drops to regex.
 | Area | What it buys you |
 |------|-----------------|
 | List detection | Reliable parsing of markers, ordered/unordered, task items and nesting |
-| Code block detection | markdown-plus knows exactly where fences begin and end, so it never acts inside one |
+| Code block detection | markdown-plus knows exactly where fences begin and end, so the list keys defer inside one |
 | Format region detection | Bold, italic, strikethrough and inline code are recognized as *regions*, not just strings |
 
-Code block detection is the one you feel most. Every shared key (`<CR>`,
-`<Tab>`, `<S-Tab>`, `<BS>`, `o`, `O`) defers unconditionally inside a fence, so a
+Code block detection is the one you feel most. Every shared list key (`<CR>`,
+`<Tab>`, `<S-Tab>`, `<BS>`, `o`, `O`) defers inside a fence, so a
 `- item` written inside a ```` ```markdown ```` block is left alone.
+
+> [!IMPORTANT]
+> That deferral belongs to the **list handlers**. The formatting toggles have no
+> fenced-code guard — `<localleader>mb` inside a fence will still bold the text.
+> The code block actions operate inside fences deliberately.
 
 ## Fallback Behavior
 
@@ -95,8 +100,11 @@ This is **bold** text
 
 Press <localleader>mi →
 
-This is ***bold and italic*** text
+This is ***bold*** text
 ```
+
+The word is now both bold and italic — markdown-plus wrapped the existing
+`**bold**` region rather than breaking its markers.
 
 markdown-plus works out whether you are nesting a new format or toggling the
 existing one.

--- a/docs/wiki/12.Plug-Mappings.md
+++ b/docs/wiki/12.Plug-Mappings.md
@@ -1,8 +1,10 @@
 # Plug Mappings
 
-Every markdown-plus action is exposed as a `<Plug>` mapping. There are **105** of them, listed below with the modes they support and the default key they are bound to (if any).
+Every markdown-plus action is exposed as a `<Plug>` mapping. There are **110** of them, listed below with the modes they support and the default key they are bound to (if any).
 
-`<Plug>` mappings are global and always registered once `setup()` has run, even when `keymaps.enabled = false`. The *default keys* are buffer-local and only installed in Markdown buffers.
+Most `<Plug>` mappings are global and registered once `setup()` has run, even when `keymaps.enabled = false`. Their *default keys* are buffer-local and only installed in Markdown buffers.
+
+The five [TOC Window](#toc-window) mappings are the exception. They are registered the first time a TOC window is opened, and their defaults are forced into that window's buffer — so they are installed even when `keymaps.enabled = false`.
 
 ```lua
 -- Rebind anything you like
@@ -20,6 +22,7 @@ See [Customizing Keymaps](https://github.com/YousefHadder/markdown-plus.nvim/wik
 - [Text Formatting](#text-formatting) (8)
 - [Code Blocks](#code-blocks) (6)
 - [Headers & TOC](#headers--toc) (15)
+- [TOC Window](#toc-window) (5)
 - [Thematic Breaks](#thematic-breaks) (2)
 - [Links](#links) (7)
 - [Images](#images) (4)
@@ -96,6 +99,21 @@ See [Customizing Keymaps](https://github.com/YousefHadder/markdown-plus.nvim/wik
 | `<Plug>(MarkdownPlusPromoteHeader)` | `n` | `<localleader>h+` | Promote header (increase level) |
 | `<Plug>(MarkdownPlusToggleAtxSetext)` | `n` | `<localleader>ms` | Toggle heading between ATX and setext style |
 | `<Plug>(MarkdownPlusUpdateTOC)` | `n` | `<localleader>hu` | Update table of contents |
+
+## TOC Window
+
+These act on the navigable TOC window opened by `<localleader>hT`. Unlike every other
+mapping on this page, they are registered lazily — the first time a TOC window opens —
+and their defaults are buffer-local to that window and forced, so they work even when
+`keymaps.enabled = false`.
+
+| `<Plug>` mapping | Modes | Default key | Description |
+|------------------|-------|-------------|-------------|
+| `<Plug>(MarkdownPlusTocClose)` | `n` | `q` | Close TOC |
+| `<Plug>(MarkdownPlusTocCollapse)` | `n` | `h` | Collapse header |
+| `<Plug>(MarkdownPlusTocExpand)` | `n` | `l` | Expand header |
+| `<Plug>(MarkdownPlusTocHelp)` | `n` | `?` | Show help |
+| `<Plug>(MarkdownPlusTocJump)` | `n` | `<CR>` | Jump to header |
 
 ## Thematic Breaks
 

--- a/docs/wiki/12.Plug-Mappings.md
+++ b/docs/wiki/12.Plug-Mappings.md
@@ -1,0 +1,198 @@
+# Plug Mappings
+
+Every markdown-plus action is exposed as a `<Plug>` mapping. There are **105** of them, listed below with the modes they support and the default key they are bound to (if any).
+
+`<Plug>` mappings are global and always registered once `setup()` has run, even when `keymaps.enabled = false`. The *default keys* are buffer-local and only installed in Markdown buffers.
+
+```lua
+-- Rebind anything you like
+vim.keymap.set("n", "<leader>b", "<Plug>(MarkdownPlusBold)")
+```
+
+> [!NOTE]
+> Mappings with no default key are opt-in — bind them yourself if you want them.
+
+See [Customizing Keymaps](https://github.com/YousefHadder/markdown-plus.nvim/wiki/6.Customizing-Keymaps) for how defaults interact with your existing mappings.
+
+## Contents
+
+- [List Management](#list-management) (20)
+- [Text Formatting](#text-formatting) (8)
+- [Code Blocks](#code-blocks) (6)
+- [Headers & TOC](#headers--toc) (15)
+- [Thematic Breaks](#thematic-breaks) (2)
+- [Links](#links) (7)
+- [Images](#images) (4)
+- [Quotes](#quotes) (1)
+- [Callouts](#callouts) (4)
+- [Tables](#tables) (30)
+- [Footnotes](#footnotes) (8)
+
+## List Management
+
+| `<Plug>` mapping | Modes | Default key | Description |
+|------------------|-------|-------------|-------------|
+| `<Plug>(MarkdownPlusDebugLists)` | `n` | `<localleader>md` | Debug list groups |
+| `<Plug>(MarkdownPlusListBackspace)` | `i` | `<BS>` | Smart backspace (remove empty list) |
+| `<Plug>(MarkdownPlusListEnter)` | `i` | `<CR>` | Auto-continue list or split content |
+| `<Plug>(MarkdownPlusListIndent)` | `i` | `<Tab>` | Indent list item |
+| `<Plug>(MarkdownPlusListOutdent)` | `i` | `<S-Tab>` | Outdent list item |
+| `<Plug>(MarkdownPlusListShiftEnter)` | `i` | `<A-CR>` | Continue list content on next line |
+| `<Plug>(MarkdownPlusNewListItemAbove)` | `n` | `O` | New list item above |
+| `<Plug>(MarkdownPlusNewListItemBelow)` | `n` | `o` | New list item below |
+| `<Plug>(MarkdownPlusRenumberLists)` | `n` | `<localleader>mr` | Renumber ordered lists |
+| `<Plug>(MarkdownPlusToggleCheckbox)` | `n, i, v, x` | `<localleader>mx`, `<C-t>` | Toggle checkbox |
+| `<Plug>(MarkdownPlusToggleListClear)` | `n, v, x` | `<localleader>ltc` | Clear list markers (plain text) |
+| `<Plug>(MarkdownPlusToggleListLetterLower)` | `n, v, x` | `<localleader>ltl` | Toggle lowercase letter list |
+| `<Plug>(MarkdownPlusToggleListLetterLowerParen)` | `n, v, x` | `<localleader>ltp` | Toggle parenthesized lowercase letter list |
+| `<Plug>(MarkdownPlusToggleListLetterUpper)` | `n, v, x` | `<localleader>ltL` | Toggle uppercase letter list |
+| `<Plug>(MarkdownPlusToggleListLetterUpperParen)` | `n, v, x` | `<localleader>ltP` | Toggle parenthesized uppercase letter list |
+| `<Plug>(MarkdownPlusToggleListOrdered)` | `n, v, x` | `<localleader>ltn` | Toggle ordered list |
+| `<Plug>(MarkdownPlusToggleListOrderedParen)` | `n, v, x` | `<localleader>ltN` | Toggle parenthesized ordered list |
+| `<Plug>(MarkdownPlusToggleListPick)` | `n, v, x` | — | Toggle list (pick type: u/t/n/N/l/L/p/P, c=clear) |
+| `<Plug>(MarkdownPlusToggleListTask)` | `n, v, x` | `<localleader>ltt` | Toggle task list |
+| `<Plug>(MarkdownPlusToggleListUnordered)` | `n, v, x` | `<localleader>ltu` | Toggle unordered list |
+
+## Text Formatting
+
+| `<Plug>` mapping | Modes | Default key | Description |
+|------------------|-------|-------------|-------------|
+| `<Plug>(MarkdownPlusBold)` | `n, v, x` | `<localleader>mb` | Toggle bold formatting |
+| `<Plug>(MarkdownPlusClearFormatting)` | `n, v, x` | `<localleader>mF` | Clear all formatting |
+| `<Plug>(MarkdownPlusCode)` | `n, v, x` | `<localleader>m`` | Toggle inline code formatting |
+| `<Plug>(MarkdownPlusEscapeSelection)` | `v, x` | `<localleader>me` | Escape/unescape markdown punctuation in selection |
+| `<Plug>(MarkdownPlusHighlight)` | `n, v, x` | `<localleader>m=` | Toggle highlight formatting |
+| `<Plug>(MarkdownPlusItalic)` | `n, v, x` | `<localleader>mi` | Toggle italic formatting |
+| `<Plug>(MarkdownPlusStrikethrough)` | `n, v, x` | `<localleader>mS` | Toggle strikethrough formatting |
+| `<Plug>(MarkdownPlusUnderline)` | `n, v, x` | `<localleader>mu` | Toggle underline formatting |
+
+## Code Blocks
+
+| `<Plug>` mapping | Modes | Default key | Description |
+|------------------|-------|-------------|-------------|
+| `<Plug>(MarkdownPlusCodeBlock)` | `v, x` | `<localleader>mw` | Convert selection to code block |
+| `<Plug>(MarkdownPlusCodeBlockChangeLanguage)` | `n` | `<localleader>mC` | Change language of fenced code block |
+| `<Plug>(MarkdownPlusCodeBlockInsert)` | `n, v, x` | `<localleader>mc` | Insert/wrap fenced code block with language |
+| `<Plug>(MarkdownPlusCodeBlockNext)` | `n` | `]b` | Jump to next fenced code block |
+| `<Plug>(MarkdownPlusCodeBlockPrev)` | `n` | `[b` | Jump to previous fenced code block |
+| `<Plug>(MarkdownPlusCodeBlockToggleFence)` | `n` | — | Toggle code block fence style |
+
+## Headers & TOC
+
+| `<Plug>` mapping | Modes | Default key | Description |
+|------------------|-------|-------------|-------------|
+| `<Plug>(MarkdownPlusDemoteHeader)` | `n` | `<localleader>h-` | Demote header (decrease level) |
+| `<Plug>(MarkdownPlusFollowLink)` | `n` | `gd` | Follow TOC link to header |
+| `<Plug>(MarkdownPlusGenerateTOC)` | `n` | `<localleader>ht` | Generate table of contents |
+| `<Plug>(MarkdownPlusHeader1)` | `n` | `<localleader>h1` | Set/convert to H1 |
+| `<Plug>(MarkdownPlusHeader2)` | `n` | `<localleader>h2` | Set/convert to H2 |
+| `<Plug>(MarkdownPlusHeader3)` | `n` | `<localleader>h3` | Set/convert to H3 |
+| `<Plug>(MarkdownPlusHeader4)` | `n` | `<localleader>h4` | Set/convert to H4 |
+| `<Plug>(MarkdownPlusHeader5)` | `n` | `<localleader>h5` | Set/convert to H5 |
+| `<Plug>(MarkdownPlusHeader6)` | `n` | `<localleader>h6` | Set/convert to H6 |
+| `<Plug>(MarkdownPlusNextHeader)` | `n` | `]]` † | Jump to next header |
+| `<Plug>(MarkdownPlusOpenTocWindow)` | `n` | `<localleader>hT` | Open navigable TOC window |
+| `<Plug>(MarkdownPlusPrevHeader)` | `n` | `[[` † | Jump to previous header |
+| `<Plug>(MarkdownPlusPromoteHeader)` | `n` | `<localleader>h+` | Promote header (increase level) |
+| `<Plug>(MarkdownPlusToggleAtxSetext)` | `n` | `<localleader>ms` | Toggle heading between ATX and setext style |
+| `<Plug>(MarkdownPlusUpdateTOC)` | `n` | `<localleader>hu` | Update table of contents |
+
+## Thematic Breaks
+
+| `<Plug>` mapping | Modes | Default key | Description |
+|------------------|-------|-------------|-------------|
+| `<Plug>(MarkdownPlusCycleThematicBreak)` | `n` | `<localleader>mH` | Cycle thematic break style |
+| `<Plug>(MarkdownPlusInsertThematicBreak)` | `n` | `<localleader>mh` | Insert thematic break below cursor |
+
+## Links
+
+| `<Plug>` mapping | Modes | Default key | Description |
+|------------------|-------|-------------|-------------|
+| `<Plug>(MarkdownPlusAutoLinkURL)` | `n` | `<localleader>ma` | Convert URL to markdown link |
+| `<Plug>(MarkdownPlusConvertToInline)` | `n` | `<localleader>mI` | Convert to inline link |
+| `<Plug>(MarkdownPlusConvertToReference)` | `n` | `<localleader>mR` | Convert to reference-style link |
+| `<Plug>(MarkdownPlusEditLink)` | `n` | `<localleader>me` | Edit link under cursor |
+| `<Plug>(MarkdownPlusInsertLink)` | `n` | `<localleader>ml` | Insert markdown link |
+| `<Plug>(MarkdownPlusSelectionToLink)` | `v, x, s` | `<localleader>ml` | Convert selection to link |
+| `<Plug>(MarkdownPlusSmartPaste)` | `n` | `<localleader>mp` | Smart paste URL from clipboard as markdown link |
+
+## Images
+
+| `<Plug>` mapping | Modes | Default key | Description |
+|------------------|-------|-------------|-------------|
+| `<Plug>(MarkdownPlusEditImage)` | `n` | `<localleader>mE` | Edit image under cursor |
+| `<Plug>(MarkdownPlusInsertImage)` | `n` | `<localleader>mL` | Insert markdown image |
+| `<Plug>(MarkdownPlusSelectionToImage)` | `v, x, s` | `<localleader>mL` | Convert selection to image |
+| `<Plug>(MarkdownPlusToggleImageLink)` | `n` | `<localleader>mA` | Toggle between link and image |
+
+## Quotes
+
+| `<Plug>` mapping | Modes | Default key | Description |
+|------------------|-------|-------------|-------------|
+| `<Plug>(MarkdownPlusToggleQuote)` | `n, v, x` | `<localleader>mq` | Toggle blockquote |
+
+## Callouts
+
+| `<Plug>` mapping | Modes | Default key | Description |
+|------------------|-------|-------------|-------------|
+| `<Plug>(MarkdownPlusConvertToBlockquote)` | `n` | `<localleader>mQb` | Convert callout to blockquote |
+| `<Plug>(MarkdownPlusConvertToCallout)` | `n` | `<localleader>mQc` | Convert blockquote to callout |
+| `<Plug>(MarkdownPlusInsertCallout)` | `n, v, x` | `<localleader>mQi` | Insert/wrap callout |
+| `<Plug>(MarkdownPlusToggleCalloutType)` | `n` | `<localleader>mQt` | Toggle callout type |
+
+## Tables
+
+| `<Plug>` mapping | Modes | Default key | Description |
+|------------------|-------|-------------|-------------|
+| `<Plug>(MarkdownPlusTableClearCell)` | `n` | `<localleader>tx` | Clear cell content |
+| `<Plug>(MarkdownPlusTableCreate)` | `n` | `<localleader>tc` | Create new table |
+| `<Plug>(MarkdownPlusTableDeleteColumn)` | `n` | `<localleader>tdc` | Delete column |
+| `<Plug>(MarkdownPlusTableDeleteRow)` | `n` | `<localleader>tdr` | Delete row |
+| `<Plug>(MarkdownPlusTableDuplicateColumn)` | `n` | `<localleader>tyc` | Duplicate column |
+| `<Plug>(MarkdownPlusTableDuplicateRow)` | `n` | `<localleader>tyr` | Duplicate row |
+| `<Plug>(MarkdownPlusTableEditCell)` | `n` | `<localleader>te` | Edit cell content in a floating popup |
+| `<Plug>(MarkdownPlusTableFormat)` | `n` | `<localleader>tf` | Format table |
+| `<Plug>(MarkdownPlusTableFromCSV)` | `n` | `<localleader>tvi` | Convert CSV to table |
+| `<Plug>(MarkdownPlusTableInsertBreak)` | `n` | `<localleader>tb` | Insert <br> line break at cursor inside cell |
+| `<Plug>(MarkdownPlusTableInsertColumnLeft)` | `n` | `<localleader>tiC` | Insert column left |
+| `<Plug>(MarkdownPlusTableInsertColumnRight)` | `n` | `<localleader>tic` | Insert column right |
+| `<Plug>(MarkdownPlusTableInsertRowAbove)` | `n` | `<localleader>tiR` | Insert row above |
+| `<Plug>(MarkdownPlusTableInsertRowBelow)` | `n` | `<localleader>tir` | Insert row below |
+| `<Plug>(MarkdownPlusTableMoveColumnLeft)` | `n` | `<localleader>tmh` | Move column left |
+| `<Plug>(MarkdownPlusTableMoveColumnRight)` | `n` | `<localleader>tml` | Move column right |
+| `<Plug>(MarkdownPlusTableMoveRowDown)` | `n` | `<localleader>tmj` | Move row down |
+| `<Plug>(MarkdownPlusTableMoveRowUp)` | `n` | `<localleader>tmk` | Move row up |
+| `<Plug>(MarkdownPlusTableNavDown)` | `i` | `<A-j>` | Navigate to cell below or move cursor down |
+| `<Plug>(MarkdownPlusTableNavLeft)` | `i` | `<A-h>` | Navigate to cell left or move cursor left |
+| `<Plug>(MarkdownPlusTableNavRight)` | `i` | `<A-l>` | Navigate to cell right or move cursor right |
+| `<Plug>(MarkdownPlusTableNavUp)` | `i` | `<A-k>` | Navigate to cell above or move cursor up |
+| `<Plug>(MarkdownPlusTableNormalize)` | `n` | `<localleader>tn` | Normalize table |
+| `<Plug>(MarkdownPlusTableSortAscending)` | `n` | `<localleader>tsa` | Sort table by column (ascending) |
+| `<Plug>(MarkdownPlusTableSortDescending)` | `n` | `<localleader>tsd` | Sort table by column (descending) |
+| `<Plug>(MarkdownPlusTableToCSV)` | `n` | `<localleader>tvx` | Convert table to CSV |
+| `<Plug>(MarkdownPlusTableToggleCellAlignment)` | `n` | `<localleader>ta` | Toggle cell alignment (left/center/right) |
+| `<Plug>(MarkdownPlusTableTranspose)` | `n` | `<localleader>tt` | Transpose table (swap rows/columns) |
+| `<Plug>(MarkdownPlusTableUnwrapCell)` | `n` | `<localleader>tW` | Unwrap cell (strip every <br> variant) |
+| `<Plug>(MarkdownPlusTableWrapCell)` | `n` | `<localleader>tw` | Wrap cell content at word boundaries using <br> |
+
+## Footnotes
+
+| `<Plug>` mapping | Modes | Default key | Description |
+|------------------|-------|-------------|-------------|
+| `<Plug>(MarkdownPlusFootnoteDelete)` | `n` | `<localleader>mfd` | Delete footnote |
+| `<Plug>(MarkdownPlusFootnoteEdit)` | `n` | `<localleader>mfe` | Edit footnote |
+| `<Plug>(MarkdownPlusFootnoteGotoDefinition)` | `n` | `<localleader>mfg` | Go to footnote definition |
+| `<Plug>(MarkdownPlusFootnoteGotoReference)` | `n` | `<localleader>mfr` | Go to footnote reference |
+| `<Plug>(MarkdownPlusFootnoteInsert)` | `n` | `<localleader>mfi` | Insert footnote |
+| `<Plug>(MarkdownPlusFootnoteList)` | `n` | `<localleader>mfl` | List footnotes |
+| `<Plug>(MarkdownPlusFootnoteNext)` | `n` | `<localleader>mfn` | Next footnote |
+| `<Plug>(MarkdownPlusFootnotePrev)` | `n` | `<localleader>mfp` | Previous footnote |
+
+† On recent Neovim versions this key is already mapped by the built-in markdown ftplugin (`$VIMRUNTIME/ftplugin/markdown.lua` maps `]]` and `[[` to section motions). markdown-plus never shadows an existing mapping, so it preserves that one and its own default is not installed. Bind the `<Plug>` mapping yourself if you want markdown-plus to own the key.
+
+## See Also
+
+- [Keymaps Reference](https://github.com/YousefHadder/markdown-plus.nvim/wiki/5.Keymaps) — the defaults, grouped by task
+- [Customizing Keymaps](https://github.com/YousefHadder/markdown-plus.nvim/wiki/6.Customizing-Keymaps) — disabling, remapping and plugin interop
+- [Lua API](https://github.com/YousefHadder/markdown-plus.nvim/wiki/10.Lua-API) — call the same actions from Lua
+- `:help markdown-plus-plug-mappings`

--- a/docs/wiki/4.Usage.md
+++ b/docs/wiki/4.Usage.md
@@ -262,43 +262,6 @@ text → ++text++
 ++text++ → text (toggle off)
 ```
 
-### Convert to Code Block
-
-```markdown
-Select any text in visual line mode and convert it to a code block:
-1. Enter visual line mode with `V`
-2. Select the rows you want to convert
-3. Press `<localleader>mw`
-4. Enter the language for the code block (e.g., `lua`, `python`)
-
-Example:
-This is some text
-and more text
-
-→
-
-    ```txt
-    This is some text
-    and more text
-    ```
-```
-
-### Fenced Code Block Workflows
-
-```markdown
-Insert a fenced block with language picker:
-- Press <localleader>mc in normal mode
-- Choose language (e.g. lua, python, bash)
-
-Wrap visual selection:
-- Select lines in visual mode
-- Press <localleader>mc
-
-Navigate and update existing blocks:
-- ]b / [b to jump next/previous code block
-- <localleader>mC to change language on current block
-```
-
 ### Clear All Formatting
 
 ```markdown
@@ -329,6 +292,112 @@ Select any text in visual mode and format it:
 
 Example: Select "multiple words here" → **multiple words here**
 ```
+
+### Dot-repeat
+
+```markdown
+Normal-mode formatting toggles support Neovim's dot-repeat.
+
+Format one word, then repeat on others without re-typing the mapping:
+1. Put the cursor on a word and press <localleader>mb   → **word**
+2. Move to another word and press .                     → **another**
+3. Keep moving and pressing . for each word you want bold
+
+Works for mb, mi, mS, m`, m=, mu and mF.
+```
+
+## Code Block Examples
+
+### Insert a Fenced Block
+
+````markdown
+Press <localleader>mc in normal mode and pick a language from the list:
+
+|                          ← cursor here
+
+→
+
+```lua
+                           ← cursor lands inside, ready to type
+```
+````
+
+The picker is populated from `code_block.languages`. Add your own:
+
+```lua
+require("markdown-plus").setup({
+  code_block = {
+    languages = { "lua", "python", "rust", "sql", "dockerfile" },
+  },
+})
+```
+
+### Wrap a Selection
+
+````markdown
+Select lines in visual mode, then press <localleader>mc and choose a language:
+
+print("hello")
+print("world")
+
+→
+
+```python
+print("hello")
+print("world")
+```
+````
+
+`<localleader>mw` does the same from visual line mode — it is the original
+binding from the formatting module, kept for compatibility.
+
+### Navigate Between Blocks
+
+```markdown
+]b  jump to the next fenced code block
+[b  jump to the previous fenced code block
+
+Both work from anywhere in the document, including from inside a block.
+```
+
+### Change the Language of an Existing Block
+
+````markdown
+Put the cursor anywhere inside a block and press <localleader>mC:
+
+```js          ← was js
+console.log(1)
+```
+
+→ pick "typescript" →
+
+```typescript  ← now typescript
+console.log(1)
+```
+````
+
+### Toggle Fence Style
+
+Switch a block between backtick and tilde fences. This has no default key —
+bind the `<Plug>` mapping yourself:
+
+```lua
+vim.keymap.set("n", "<localleader>mT", "<Plug>(MarkdownPlusCodeBlockToggleFence)")
+```
+
+````markdown
+```lua          →    ~~~lua
+print(1)             print(1)
+```                  ~~~
+````
+
+Tilde fences are useful when the block itself contains backtick fences. Set
+`code_block.fence_style = "tilde"` to make new blocks use tildes by default.
+
+> [!NOTE]
+> markdown-plus never acts inside a fenced code block. List continuation,
+> formatting toggles and the shared keys (`<CR>`, `<Tab>`, `<BS>`) all defer to
+> your other plugins or to native Neovim behavior there.
 
 ## Headers & TOC Examples
 
@@ -477,6 +546,56 @@ After pressing 'l' on "Getting Started":
 - `<Enter>` - Jump to header in source buffer
 - `q` - Close TOC window
 - `?` - Show help popup
+
+## Thematic Break Examples
+
+### Insert a Thematic Break
+
+```markdown
+Press <localleader>mh in normal mode. The break is inserted *below* the cursor
+line, and blank lines are added automatically so it parses correctly:
+
+Some paragraph text.        ← cursor here
+Next paragraph.
+
+→
+
+Some paragraph text.
+
+---                         ← cursor lands here
+
+Next paragraph.
+```
+
+markdown-plus only adds the blank lines that are actually missing — if the line
+above or below is already blank, it is left alone.
+
+### Cycle the Style
+
+```markdown
+Press <localleader>mH on an existing break to rotate through the three
+CommonMark styles:
+
+---   →   ***   →   ___   →   ---
+
+Indentation is preserved, so a break nested inside a list item stays nested.
+```
+
+If the cursor is not on a thematic break, you get a
+`Current line is not a thematic break` warning rather than a silent no-op.
+
+### Choose the Default Style
+
+`thematic_break.style` controls what `<localleader>mh` inserts. Cycling is
+unaffected — it always walks the full rotation.
+
+```lua
+require("markdown-plus").setup({
+  thematic_break = {
+    style = "***",  -- "---" (default), "***" or "___"
+  },
+})
+```
 
 ## Links & References Examples
 
@@ -1383,4 +1502,126 @@ Cannot delete header row or separator row. Operations protect table integrity.
 **Smart Cursor Positioning:**
 After all operations, cursor is automatically positioned in the most
 logical cell (usually first cell of new/modified row/column).
+```
+
+## Footnotes Examples
+
+All footnote mappings live under the `<localleader>mf` prefix.
+
+| Key | Action |
+|-----|--------|
+| `<localleader>mfi` | Insert footnote |
+| `<localleader>mfe` | Edit footnote |
+| `<localleader>mfd` | Delete footnote |
+| `<localleader>mfg` | Go to definition |
+| `<localleader>mfr` | Go to reference |
+| `<localleader>mfn` | Next footnote |
+| `<localleader>mfp` | Previous footnote |
+| `<localleader>mfl` | List all footnotes |
+
+### Insert a Footnote
+
+```markdown
+Press <localleader>mfi in normal mode:
+1. You are prompted "Footnote ID: ", pre-filled with the next free number
+2. Accept it or type your own (letters, digits, - and _ are allowed)
+
+Neovim is a text editor.     ← cursor at end of "editor"
+
+→
+
+Neovim is a text editor[^1].
+
+## Footnotes
+
+[^1]:                        ← cursor lands here in insert mode
+```
+
+The `## Footnotes` section is created at the end of the document the first time
+you need it, and reused afterwards. Rename it with
+`footnotes.section_header`:
+
+```lua
+require("markdown-plus").setup({
+  footnotes = { section_header = "References" },
+})
+```
+
+If you reuse an ID that already has a definition, markdown-plus inserts just the
+reference and tells you which line the existing definition is on — it will not
+create a duplicate.
+
+### Edit a Footnote
+
+```markdown
+Press <localleader>mfe from *either* the reference or the definition.
+
+Either of these positions works:
+
+Neovim is a text editor[^1].     ← cursor on the reference
+[^1]: A hyperextensible editor.  ← or cursor on the definition
+
+→ jumps to the end of the definition line and enters insert mode
+```
+
+### Jump Between Reference and Definition
+
+```markdown
+<localleader>mfg   from a reference → jump to its definition
+<localleader>mfr   from a definition → jump to its reference
+
+Both push to the jump list, so <C-o> brings you back.
+
+If a footnote has several references, <localleader>mfr shows a picker:
+  Line 12: Neovim is a text editor[^1].
+  Line 48: As mentioned earlier[^1], ...
+```
+
+### Navigate Through Footnotes
+
+```markdown
+<localleader>mfn   next reference
+<localleader>mfp   previous reference
+
+These walk *references* in document order, not definitions, and wrap around at
+the ends (you get a notification when they do).
+```
+
+### List All Footnotes
+
+```markdown
+Press <localleader>mfl to open a picker of every footnote:
+
+Footnotes (3):
+  [^1] A hyperextensible text editor (2 refs)
+⚠ [^2] Defined but never cited (0 refs)
+✗ [^note] (no definition) (1 ref)
+
+  (space)    healthy — defined and referenced
+  ⚠          orphan — defined but never referenced
+  ✗          missing — referenced but never defined
+
+Selecting an entry jumps to its definition (or its first reference when the
+definition is missing) and centers the line.
+```
+
+This is the quickest way to audit a long document before publishing.
+
+### Delete a Footnote
+
+```markdown
+Press <localleader>mfd from a reference or the definition. It removes *every*
+reference plus the definition, and asks first:
+
+Delete footnote [^1]? (2 references, 1 definition)
+  1. Yes
+  2. No
+```
+
+Set `footnotes.confirm_delete = false` to skip the prompt:
+
+```lua
+require("markdown-plus").setup({
+  footnotes = { confirm_delete = false },
+})
 ```

--- a/docs/wiki/4.Usage.md
+++ b/docs/wiki/4.Usage.md
@@ -395,9 +395,10 @@ Tilde fences are useful when the block itself contains backtick fences. Set
 `code_block.fence_style = "tilde"` to make new blocks use tildes by default.
 
 > [!NOTE]
-> markdown-plus never acts inside a fenced code block. List continuation,
-> formatting toggles and the shared keys (`<CR>`, `<Tab>`, `<BS>`) all defer to
-> your other plugins or to native Neovim behavior there.
+> The shared list keys (`<CR>`, `<Tab>`, `<S-Tab>`, `<BS>`, `o`, `O`) defer inside a
+> fenced code block, handing control back to your other plugins or to native Neovim
+> behavior. Formatting toggles are *not* guarded this way — they still act inside a
+> fence — and the code block actions are meant to.
 
 ## Headers & TOC Examples
 

--- a/docs/wiki/5.Keymaps.md
+++ b/docs/wiki/5.Keymaps.md
@@ -101,6 +101,21 @@ ordered types are renumbered automatically.
 | `<localleader>hT` | Toggle TOC window |
 | `gd` | Follow TOC link |
 
+> [!NOTE]
+> On recent Neovim versions `]]` and `[[` are already mapped by the built-in
+> markdown ftplugin, which jumps between sections using Treesitter. markdown-plus
+> declares the same defaults but never shadows an existing mapping, so in a normal
+> setup you are using Neovim's implementation, not the plugin's. Header navigation
+> works either way. If you specifically want markdown-plus's version, map it
+> yourself:
+>
+> ```lua
+> vim.keymap.set("n", "]]", "<Plug>(MarkdownPlusNextHeader)", { buffer = true })
+> vim.keymap.set("n", "[[", "<Plug>(MarkdownPlusPrevHeader)", { buffer = true })
+> ```
+>
+> `:verbose nmap ]]` will tell you which one is currently active.
+
 ## Thematic breaks
 
 | Keymap | Description |

--- a/docs/wiki/6.Customizing-Keymaps.md
+++ b/docs/wiki/6.Customizing-Keymaps.md
@@ -174,7 +174,7 @@ See `:help markdown-plus-interop` for the full reference.
 The full list lives in two places:
 
 - **[`<Plug>` Mappings Reference](https://github.com/YousefHadder/markdown-plus.nvim/wiki/12.Plug-Mappings)**
-  — all 105 mappings in one table, grouped by module, with modes and default keys
+  — all 110 mappings in one table, grouped by module, with modes and default keys
 - Vimdoc, which ships with the plugin and always matches your installed version:
   - `:help markdown-plus-keymaps`
   - `:help markdown-plus-plug-mappings`

--- a/docs/wiki/6.Customizing-Keymaps.md
+++ b/docs/wiki/6.Customizing-Keymaps.md
@@ -171,7 +171,21 @@ See `:help markdown-plus-interop` for the full reference.
 
 ## Discover available `<Plug>` mappings
 
-Use vimdoc for the complete up-to-date list:
+The full list lives in two places:
 
-- `:help markdown-plus-keymaps`
-- `:help markdown-plus-plug-mappings`
+- **[`<Plug>` Mappings Reference](https://github.com/YousefHadder/markdown-plus.nvim/wiki/12.Plug-Mappings)**
+  — all 105 mappings in one table, grouped by module, with modes and default keys
+- Vimdoc, which ships with the plugin and always matches your installed version:
+  - `:help markdown-plus-keymaps`
+  - `:help markdown-plus-plug-mappings`
+
+To inspect what is actually mapped in the buffer you're in right now:
+
+```vim
+:map <buffer>
+:verbose nmap <localleader>mb
+```
+
+`:verbose` reports which file set the mapping — useful when a default didn't
+take because another plugin or Neovim's built-in markdown ftplugin already
+owned the key.

--- a/docs/wiki/7.Contributing.md
+++ b/docs/wiki/7.Contributing.md
@@ -59,11 +59,12 @@ make demo  # requires 'vhs'
 ```
 
 > [!NOTE]
-> `make check` is the local aggregate, not a mirror of CI. CI reuses
-> `folke/github/.github/workflows/ci.yml`, which runs a Stylua check, a scan for
-> leftover debug calls, and `./scripts/test` — it does not invoke `make lint` or
-> `make format-check`. Passing `make check` locally is the right bar, but the debug-call
-> scan only exists in CI.
+> `make check` is the local aggregate, not a mirror of CI. The reused
+> `folke/github/.github/workflows/ci.yml` runs a Stylua check, a scan for leftover
+> debug calls, and `./scripts/test` — it never calls `make lint` or `make format-check`.
+> A separate `security-scan.yml` job does run `luacheck lua/`, but with `|| true`, so a
+> lint failure cannot fail CI. Running `make check` locally is the only thing that
+> actually enforces luacheck, and it covers `spec/` and `test/` as well as `lua/`.
 
 `make help` lists every target.
 

--- a/docs/wiki/7.Contributing.md
+++ b/docs/wiki/7.Contributing.md
@@ -51,12 +51,19 @@ make format  # requires 'stylua'
 # Check formatting without modifying
 make format-check
 
-# Everything CI runs: lint + format-check + test
+# Standard local aggregate: lint + format-check + test
 make check
 
 # Regenerate the demo GIFs
 make demo  # requires 'vhs'
 ```
+
+> [!NOTE]
+> `make check` is the local aggregate, not a mirror of CI. CI reuses
+> `folke/github/.github/workflows/ci.yml`, which runs a Stylua check, a scan for
+> leftover debug calls, and `./scripts/test` — it does not invoke `make lint` or
+> `make format-check`. Passing `make check` locally is the right bar, but the debug-call
+> scan only exists in CI.
 
 `make help` lists every target.
 
@@ -70,14 +77,18 @@ Lua functions directly. Fast, and where the bulk of coverage lives.
 **`make test-e2e` — end-to-end keymap tests.** Drives real keypresses through the
 real buffer-local mappings and asserts exact buffer contents. Because it goes
 through actual keymap registration and dispatch, it catches breakage the busted
-specs structurally cannot see — a mapping that was never installed, or one that
-lost a collision with another plugin, still passes its unit test.
+specs structurally cannot see — a mapping that was never installed, or one whose
+dispatch chain silently broke, still passes its unit test.
 
 The e2e runner (`scripts/run-e2e.sh`) starts Neovim with `--clean`, fresh
 temporary `XDG_*` directories, and `-u test/e2e/init.lua` as the only config, so
 your personal setup can't influence the result. The isolated init aborts the run
 if a user config appears on the `runtimepath`, so an isolation regression fails
 loudly rather than quietly tainting results.
+
+That isolation is also the suite's limit: it loads no plugin but the one under
+test, so it cannot observe collisions with other plugins. Collision behavior
+lives in the busted specs and in manual testing.
 
 ```bash
 scripts/run-e2e.sh              # run all cases
@@ -180,9 +191,12 @@ docs(wiki): document the Lua API
 `feat` triggers a minor bump, `fix` a patch bump. A `!` after the type, or a
 `BREAKING CHANGE:` footer, triggers a major bump.
 
-**Pull request titles must follow the same convention** — CI validates them
-(`.github/workflows/pr.yml`). Since PRs are squash-merged, the PR title becomes
-the commit message that release-please reads.
+**Pull request titles follow the same convention, plus one extra rule: the scope is
+required.** CI validates the title (`.github/workflows/pr.yml`), and the reused
+workflow sets `requireScope: true`, so a bare `docs: add wiki pages` is rejected —
+write `docs(wiki): add wiki pages`. The subject must also start with a lowercase
+letter. Since PRs are squash-merged, the PR title becomes the commit message that
+release-please reads.
 
 Don't edit `CHANGELOG.md` by hand; it is generated.
 

--- a/docs/wiki/7.Contributing.md
+++ b/docs/wiki/7.Contributing.md
@@ -27,7 +27,7 @@ git clone https://github.com/nvim-lua/plenary.nvim \
 ### Run Tests
 
 ```bash
-# Run all tests
+# Run all tests (49 spec files)
 make test
 
 # Run specific test file
@@ -35,6 +35,12 @@ make test-file FILE=spec/markdown-plus/config_spec.lua
 
 # Watch for changes and run tests
 make test-watch  # requires 'entr' command
+
+# Run tests with coverage thresholds enforced
+make test-coverage  # 85% overall, 80% on critical files
+
+# Run the end-to-end keymap suite
+make test-e2e
 
 # Run linter
 make lint  # requires 'luacheck'
@@ -44,7 +50,41 @@ make format  # requires 'stylua'
 
 # Check formatting without modifying
 make format-check
+
+# Everything CI runs: lint + format-check + test
+make check
+
+# Regenerate the demo GIFs
+make demo  # requires 'vhs'
 ```
+
+`make help` lists every target.
+
+### Two Test Suites
+
+The project has two independent harnesses, and they catch different things.
+
+**`make test` — busted specs.** Unit and integration tests that call the plugin's
+Lua functions directly. Fast, and where the bulk of coverage lives.
+
+**`make test-e2e` — end-to-end keymap tests.** Drives real keypresses through the
+real buffer-local mappings and asserts exact buffer contents. Because it goes
+through actual keymap registration and dispatch, it catches breakage the busted
+specs structurally cannot see — a mapping that was never installed, or one that
+lost a collision with another plugin, still passes its unit test.
+
+The e2e runner (`scripts/run-e2e.sh`) starts Neovim with `--clean`, fresh
+temporary `XDG_*` directories, and `-u test/e2e/init.lua` as the only config, so
+your personal setup can't influence the result. The isolated init aborts the run
+if a user config appears on the `runtimepath`, so an isolation regression fails
+loudly rather than quietly tainting results.
+
+```bash
+scripts/run-e2e.sh              # run all cases
+scripts/run-e2e.sh --keep-tmp   # keep temp dirs for debugging (path is printed)
+```
+
+Exit codes: `0` all passed, `1` at least one case failed, `2` isolation failure.
 
 ### Code Quality Tools
 
@@ -67,23 +107,112 @@ cargo install stylua
 
 ## Test Structure
 
+Specs are organized per feature. Larger features are split across several files
+rather than one monolith, so `list_spec.lua` covers the public surface while
+`list_parser_spec.lua`, `list_group_scanner_spec.lua`, and friends cover the
+internals.
+
 ```
 spec/
-├── markdown-plus/
-│   ├── config_spec.lua       # Configuration tests
-│   ├── utils_spec.lua        # Utility function tests
-│   ├── list_spec.lua         # List management tests
-│   ├── headers_spec.lua      # Headers & TOC tests
-│   ├── links_spec.lua        # Link management tests
-│   └── quote_spec.lua        # Quote management tests
-└── minimal_init.lua          # Test environment setup
+├── minimal_init.lua           # Test environment bootstrap
+├── helpers/                   # Shared test utilities
+│   ├── init.lua
+│   ├── async.lua              # Async/scheduled-callback helpers
+│   ├── insert_mode.lua        # Simulates insert-mode keypresses
+│   └── mocks.lua
+└── markdown-plus/             # 49 spec files
+    ├── config_spec.lua        # Configuration & validation
+    ├── utils_spec.lua         # Shared utilities
+    ├── health_spec.lua        # :checkhealth
+    ├── treesitter_spec.lua    # Treesitter integration
+    ├── keymap_fallback_spec.lua   # Keymap collision handling
+    ├── interop_recipes_spec.lua   # Third-party plugin interop
+    ├── list_*_spec.lua        # Lists (10 files)
+    ├── format_*_spec.lua      # Text formatting (3 files)
+    ├── headers_*_spec.lua     # Headers & TOC (6 files)
+    ├── footnotes_*_spec.lua   # Footnotes (7 files)
+    ├── table_*_spec.lua       # Tables (9 files)
+    ├── images_*_spec.lua      # Images (2 files)
+    └── ...                    # links, quote, callouts, code_block,
+                               # thematic_break, smart_paste
 ```
+
+The end-to-end suite lives separately:
+
+```
+test/e2e/
+├── init.lua        # Isolated Neovim config used by the runner
+├── runner.lua      # Harness: feeds keys, asserts buffer state
+└── cases.lua       # The test cases themselves
+scripts/
+├── run-e2e.sh      # Entry point for `make test-e2e`
+└── test            # Coverage-enforcing wrapper for `make test-coverage`
+```
+
+Note that `make lint` covers `lua/ spec/ test/` and `make format` covers
+`lua/ spec/ plugin/ test/` — test code is held to the same standard as the
+plugin itself.
+
+## Commit Messages
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/).
+This is not a style preference: releases are automated with
+[release-please](https://github.com/googleapis/release-please), which derives the
+next version number and generates `CHANGELOG.md` by parsing commit messages. A
+malformed message means a missed changelog entry or a wrong version bump.
+
+Allowed types (`.commitlintrc.json`):
+
+```
+feat  fix  docs  style  refactor  perf  test  chore  revert  ci  build
+```
+
+Format:
+
+```
+<type>(<optional scope>): <description>
+
+feat(footnotes): add jump-to-definition mapping
+fix(table): keep alignment row intact when deleting a column
+docs(wiki): document the Lua API
+```
+
+`feat` triggers a minor bump, `fix` a patch bump. A `!` after the type, or a
+`BREAKING CHANGE:` footer, triggers a major bump.
+
+**Pull request titles must follow the same convention** — CI validates them
+(`.github/workflows/pr.yml`). Since PRs are squash-merged, the PR title becomes
+the commit message that release-please reads.
+
+Don't edit `CHANGELOG.md` by hand; it is generated.
 
 ## Development Workflow
 
 1. Create a feature branch: `git checkout -b feature/your-feature`
-2. Add tests for new features
-3. Ensure all tests pass: `make test`
-4. Run linter: `make lint`
-5. Format code: `make format`
-6. Submit a pull request
+2. Add tests for new features — see [Test Structure](#test-structure) for where they belong
+3. If you added or changed a keymap, add an e2e case in `test/e2e/cases.lua`
+4. Update the docs: `README.md`, `doc/markdown-plus.txt`, and `docs/wiki/`
+5. Run the full check: `make check`
+6. Run the keymap suite: `make test-e2e`
+7. Commit using Conventional Commits
+8. Open a pull request with a Conventional Commits title
+
+### Adding a Configuration Option
+
+A new config key touches six places. Missing one usually shows up as a confusing
+validation error rather than an obvious failure:
+
+1. `lua/markdown-plus/types.lua` — the LuaCATS type definition
+2. `lua/markdown-plus/init.lua` — the default value
+3. `lua/markdown-plus/config/validate.lua` — the schema (it rejects unknown fields,
+   so an option missing here is unusable even if everything else is wired up)
+4. `README.md`
+5. `doc/markdown-plus.txt`
+6. `spec/markdown-plus/config_spec.lua`
+
+### Documentation
+
+The wiki is generated from `docs/wiki/` in this repository — edit those files, not
+the wiki directly. A push to `main` syncs them via
+`.github/workflows/wiki-sync.yml`, and the sync uses `rsync --delete`, so changes
+made in the wiki UI are overwritten on the next push.

--- a/docs/wiki/8.Troubleshooting.md
+++ b/docs/wiki/8.Troubleshooting.md
@@ -36,7 +36,7 @@ If you encounter any issues, run the health check first - it will often identify
    ```vim
    :set filetype?
    ```
-   By default, the plugin only loads for `markdown` filetype. See [Configuration](3.Configuration) to enable for other filetypes.
+   By default, the plugin only loads for `markdown` filetype. See [Configuration](https://github.com/YousefHadder/markdown-plus.nvim/wiki/3.Configuration) to enable for other filetypes.
 
 1. Run the health check:
    ```vim

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -27,7 +27,7 @@ A complete reference of all default keybindings for Normal, Insert, and Visual m
 How to disable defaults and map `<Plug>` actions your own way.
 
 ### [🔌 `<Plug>` Mappings Reference](https://github.com/YousefHadder/markdown-plus.nvim/wiki/12.Plug-Mappings)
-Every one of the 105 `<Plug>` mappings, grouped by module, with modes and default keys.
+Every one of the 110 `<Plug>` mappings, grouped by module, with modes and default keys.
 
 ### [🧩 Lua API](https://github.com/YousefHadder/markdown-plus.nvim/wiki/10.Lua-API)
 Call plugin functions directly from Lua — for custom keymaps, autocmds, and scripting.

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -26,11 +26,24 @@ A complete reference of all default keybindings for Normal, Insert, and Visual m
 ### [🔧 Customizing keymaps](https://github.com/YousefHadder/markdown-plus.nvim/wiki/6.Customizing-Keymaps)
 How to disable defaults and map `<Plug>` actions your own way.
 
+### [🔌 `<Plug>` Mappings Reference](https://github.com/YousefHadder/markdown-plus.nvim/wiki/12.Plug-Mappings)
+Every one of the 105 `<Plug>` mappings, grouped by module, with modes and default keys.
+
+### [🧩 Lua API](https://github.com/YousefHadder/markdown-plus.nvim/wiki/10.Lua-API)
+Call plugin functions directly from Lua — for custom keymaps, autocmds, and scripting.
+
+### [🌳 Treesitter Integration](https://github.com/YousefHadder/markdown-plus.nvim/wiki/11.Treesitter)
+What Treesitter enables, how to install the parsers, and what happens without them.
+
 ### [🤝 Contributing](https://github.com/YousefHadder/markdown-plus.nvim/wiki/7.Contributing)
 Guidelines for contributing code, reporting bugs, and suggesting features.
 
 ### [🔧 Troubleshooting](https://github.com/YousefHadder/markdown-plus.nvim/wiki/8.Troubleshooting)
 Solutions to common issues and health-check guidance.
+
+> [!TIP]
+> The same reference material ships with the plugin. Run `:help markdown-plus`
+> inside Neovim, or `:checkhealth markdown-plus` to verify your setup.
 
 ## Why markdown-plus.nvim?
 


### PR DESCRIPTION
Fills the gaps I found auditing `docs/wiki/` against what the plugin actually does. Three areas had no coverage at all, and a few existing pages were describing an older version of the project.

## New pages

- **10.Lua-API** — the 11 module handles, per-module function reference, and the `teardown()` reload recipe. Notes the two easy traps: handles are `nil` until `setup()` runs with the matching `features.*` flag, and the quotes handle is plural (`mp.quotes`) while the module path is singular (`markdown-plus.quote`).
- **11.Treesitter** — what Treesitter buys you, what falls back to regex, and the three smart-formatting behaviors. Includes the non-obvious bit that `==highlight==` and `++underline++` aren't in the `markdown_inline` grammar, so they're always regex-matched.
- **12.Plug-Mappings** — all 105 `<Plug>` mappings with modes and default keys. Generated from a headless-nvim dump of the real mappings rather than transcribed by hand.

## Updated pages

- **4.Usage** — added Code Block, Thematic Break, and Footnotes sections, plus a dot-repeat example. Code block content was previously buried under Text Formatting; moved it into its own section.
- **7.Contributing** — said 6 spec files, actual is 49. Added `make check`, `make test-coverage`, `make test-e2e`, `make demo`, documented the `test/e2e/` harness, and added the Conventional Commits requirement (release-please derives versions and the changelog from commit messages, so this isn't optional).
- **1.Installation**, **5.Keymaps**, **6.Customizing-Keymaps**, **Home** — Treesitter note, the `]]`/`[[` clarification below, a link to the new `<Plug>` reference, and the new pages in the index.
- **8.Troubleshooting** — one relative link switched to an absolute URL to match every other page.

## On `]]` and `[[`

Worth flagging since it's surprising. The source declares these as `NextHeader`/`PrevHeader` defaults, but on recent Neovim the built-in markdown ftplugin already maps them, and markdown-plus never shadows an existing mapping — so its own defaults are never installed.

Navigation still works because the built-in is Treesitter-based, so I documented the nuance instead of treating it as a bug. `5.Keymaps` now explains it and shows how to bind the `<Plug>` versions if you want markdown-plus's implementation. The reference page marks both with a footnote.

## Verification

Docs-only, so no runtime tests apply, but I checked the claims mechanically rather than trusting the drafts:

- All 94 documented API functions confirmed to exist by introspecting the loaded modules
- 105 `<Plug>` rows match the headless dump
- All 13 wiki files pass a fence-balance check
- All 12 internal wiki links resolve to real pages
- The `<Plug>` remap recipe in `5.Keymaps` was run headlessly to confirm the cursor actually moves

That pass caught three things that would otherwise have shipped as confidently-worded but wrong docs: telling users to `:TSInstall` parsers Neovim already bundles (and via a command that only exists with nvim-treesitter, which this plugin doesn't depend on), documenting `links.smart_paste()` when it lives at `markdown-plus.links.smart_paste`, and a false keymap collision that was just Neovim normalizing `<C-t>` to `<C-T>` on readback.

Also refreshes `CLAUDE.md` and `.github/copilot-instructions.md`, which had drifted on spec counts and were missing the e2e harness.

Reminder for whoever merges: `docs/wiki/` syncs to the wiki on push to `main` via `rsync --delete`, so this replaces the published pages.