### PR TITLE
fix(table): land cursor at start of empty cells when navigating

### DIFF
--- a/doc/markdown-plus.txt
+++ b/doc/markdown-plus.txt
@@ -1645,7 +1645,8 @@ The plugin can be configured through the setup function:
       },
       table = {                  -- Table sub-configuration
         enabled = true,          -- Enable table features
-        auto_format = true,
+        auto_format = true,      -- Reserved; no effect today. Tables reformat
+                                 -- via the table commands, not as you type.
         default_alignment = 'left', -- 'left' | 'center' | 'right'
         confirm_destructive = true,  -- Confirm before transpose/sort operations
         width_mode = 'literal',  -- 'literal' (default; preserves today's behaviour)
@@ -1657,7 +1658,7 @@ The plugin can be configured through the setup function:
                                  -- command. nil = prompt every time.
         auto_wrap = false,       -- Opt-in: when true together with max_column_width,
                                  -- format_table auto-wraps cells whose widest segment
-                                 -- exceeds the cap. Independent of auto_format. Place
+                                 -- exceeds the cap. Place
                                  -- `<!-- markdown-plus: no-wrap -->` immediately above
                                  -- a table to opt it out individually.
         cell_editor = {          -- Floating cell-editor popup configuration

--- a/docs/wiki/1.Installation.md
+++ b/docs/wiki/1.Installation.md
@@ -79,7 +79,8 @@ for what changes with and without them.
       custom_types = {},  -- Add custom types like { "DANGER", "SUCCESS" }
     },
     table = {          -- Table sub-configuration
-      auto_format = true,
+      auto_format = true,          -- Reserved; no effect today. Tables
+                                   -- reformat via the table commands.
       default_alignment = "left",
       confirm_destructive = true,  -- Confirm before transpose/sort operations
       keymaps = {

--- a/docs/wiki/3.Configuration.md
+++ b/docs/wiki/3.Configuration.md
@@ -67,7 +67,8 @@ require("markdown-plus").setup({
 
   table = {
     enabled = true,
-    auto_format = true,
+    auto_format = true,         -- Reserved; no effect today. Tables reformat
+                                -- via the table commands, not as you type.
     default_alignment = "left",
     confirm_destructive = true,
     width_mode = "literal",     -- "literal" | "segment"  set "segment" so cells

--- a/lua/markdown-plus/health.lua
+++ b/lua/markdown-plus/health.lua
@@ -108,6 +108,19 @@ function M.check()
       end
     end
 
+    -- `table.auto_format` is accepted and validated but never read: tables are reformatted by the
+    -- table commands themselves, not as you type. Only warn when it is explicitly disabled, since
+    -- that is the case where the user asked for behavior they will not get.
+    if mp_ok and markdown_plus.config and markdown_plus.config.table then
+      if markdown_plus.config.table.auto_format == false then
+        health.warn("table.auto_format = false currently has no effect", {
+          "Tables are reformatted by the table commands themselves (insert/delete row or column,",
+          "cell edit, alignment toggle) rather than automatically as you type.",
+          "Setting this to false does not suppress that reformatting.",
+        })
+      end
+    end
+
     -- Check for plenary.nvim (optional, for tests)
     if can_require("plenary") then
       health.ok("plenary.nvim is installed (required for running tests)")

--- a/lua/markdown-plus/table/navigation.lua
+++ b/lua/markdown-plus/table/navigation.lua
@@ -11,19 +11,14 @@ local M = {}
 local SEPARATOR_ROW = 1
 
 ---Find the next unescaped pipe at or after `from`
+---
+---Delegates to the parser so cell boundaries are resolved by exactly the rule that produced
+---`table_info.cells`; a local copy would drift and land the cursor in a different cell.
 ---@param line string Table row
 ---@param from integer 1-indexed position to start searching from
 ---@return integer? col Column of the pipe (1-indexed), or nil when the row has none left
 local function next_unescaped_pipe(line, from)
-  for col = from, #line do
-    if line:sub(col, col) == "|" then
-      local prev = col > 1 and line:sub(col - 1, col - 1) or ""
-      if prev ~= "\\" then
-        return col
-      end
-    end
-  end
-  return nil
+  return require("markdown-plus.table.parser").next_unescaped_pipe(line, from)
 end
 
 ---Resolve the first typing position inside the cell opened by the pipe at `open_col`.

--- a/lua/markdown-plus/table/navigation.lua
+++ b/lua/markdown-plus/table/navigation.lua
@@ -10,47 +10,74 @@ local M = {}
 -- Separator row is always at index 1 (between header at 0 and data rows at 2+)
 local SEPARATOR_ROW = 1
 
+---Find the next unescaped pipe at or after `from`
+---@param line string Table row
+---@param from integer 1-indexed position to start searching from
+---@return integer? col Column of the pipe (1-indexed), or nil when the row has none left
+local function next_unescaped_pipe(line, from)
+  for col = from, #line do
+    if line:sub(col, col) == "|" then
+      local prev = col > 1 and line:sub(col - 1, col - 1) or ""
+      if prev ~= "\\" then
+        return col
+      end
+    end
+  end
+  return nil
+end
+
+---Resolve the first typing position inside the cell opened by the pipe at `open_col`.
+---
+---A non-empty cell lands on its first content character. An all-whitespace cell has no content to
+---land on, so it lands one padding space in — where content sits in a formatted table — instead of
+---running past the cell and stopping on the closing pipe. The search is bounded by the closing
+---pipe for exactly that reason.
+---
+---Column alignment is deliberately ignored: a centre- or right-aligned empty cell still lands at
+---the left-most typing position, because that is where the user expects to start typing.
+---@param line string Table row
+---@param open_col integer Column of the pipe opening the cell, or 0 for a row with no leading pipe
+---@return integer col Column position (1-indexed)
+local function cell_start_after(line, open_col)
+  -- An unterminated row (no closing pipe) runs to the end of the line.
+  local close_col = next_unescaped_pipe(line, open_col + 1) or (#line + 1)
+
+  for col = open_col + 1, close_col - 1 do
+    if not line:sub(col, col):match("%s") then
+      return col
+    end
+  end
+
+  -- Empty cell: one padding space in, clamped so a zero-width cell (`||`) stays inside itself.
+  return math.min(open_col + 2, close_col)
+end
+
 ---Find the start column of a cell in a row
 ---@param line string Table row
 ---@param cell_index integer Cell index (0-based)
 ---@return integer? col Column position (1-indexed) or nil
 local function find_cell_start_col(line, cell_index)
-  local col = 1
+  local leading_pipe = next_unescaped_pipe(line, 1)
+  local open_col
 
-  -- Skip leading pipe
-  if vim.trim(line):match("^|") then
-    col = col + 1
-    while col <= #line and line:sub(col, col):match("%s") do
-      col = col + 1
+  -- Locate the leading pipe's real column rather than assuming column 1, so indented tables
+  -- (inside a list item, say) resolve their first cell instead of landing on the pipe itself.
+  -- A row may also omit the leading pipe (`a | b`), in which case the first cell opens at the
+  -- start of the line.
+  if leading_pipe and vim.trim(line):match("^|") then
+    open_col = leading_pipe
+  else
+    open_col = 0
+  end
+
+  for _ = 1, cell_index do
+    open_col = next_unescaped_pipe(line, open_col + 1)
+    if not open_col then
+      return nil
     end
   end
 
-  if cell_index == 0 then
-    return col
-  end
-
-  -- Find the target cell
-  local current_cell = 0
-  while col <= #line do
-    local char = line:sub(col, col)
-    if char == "|" then
-      local prev = col > 1 and line:sub(col - 1, col - 1) or ""
-      if prev ~= "\\" then
-        current_cell = current_cell + 1
-        if current_cell == cell_index then
-          -- Skip pipe and whitespace
-          col = col + 1
-          while col <= #line and line:sub(col, col):match("%s") do
-            col = col + 1
-          end
-          return col
-        end
-      end
-    end
-    col = col + 1
-  end
-
-  return nil
+  return cell_start_after(line, open_col)
 end
 
 ---Move cursor to a specific cell in the table

--- a/lua/markdown-plus/table/parser.lua
+++ b/lua/markdown-plus/table/parser.lua
@@ -22,6 +22,38 @@ local M = {}
 ---@field alignments string[] Column alignments ('left', 'center', 'right')
 ---@field cells string[][] Parsed cell contents [row][col]
 
+---Report whether the pipe at `col` is a real cell boundary rather than an escaped literal.
+---
+---A backslash escapes the character after it, so a backslash run of odd length leaves the pipe
+---escaped, while an even-length run escapes itself and leaves the pipe as a boundary. This is the
+---rule `split_row_into_cells` applies while scanning; it lives here so every caller that needs to
+---locate boundaries agrees with the cells the parser actually produced.
+---@param line string Table row
+---@param col integer 1-indexed column of the pipe
+---@return boolean is_boundary
+function M.is_cell_boundary(line, col)
+  local backslashes = 0
+  local i = col - 1
+  while i >= 1 and line:sub(i, i) == "\\" do
+    backslashes = backslashes + 1
+    i = i - 1
+  end
+  return backslashes % 2 == 0
+end
+
+---Find the next unescaped pipe at or after `from`
+---@param line string Table row
+---@param from integer 1-indexed position to start searching from
+---@return integer? col Column of the pipe (1-indexed), or nil when the row has none left
+function M.next_unescaped_pipe(line, from)
+  for col = from, #line do
+    if line:sub(col, col) == "|" and M.is_cell_boundary(line, col) then
+      return col
+    end
+  end
+  return nil
+end
+
 ---Parse alignment from separator cell
 ---@param sep_cell string Separator cell (e.g., "---", ":---:", "---:")
 ---@return string alignment 'left', 'center', or 'right'
@@ -211,11 +243,8 @@ function M.get_cursor_position_in_table()
   local line = vim.api.nvim_get_current_line()
   local pipe_count = 0
   for i = 1, cursor_col - 1 do
-    if line:sub(i, i) == "|" then
-      local prev = i > 1 and line:sub(i - 1, i - 1) or ""
-      if prev ~= "\\" then
-        pipe_count = pipe_count + 1
-      end
+    if line:sub(i, i) == "|" and M.is_cell_boundary(line, i) then
+      pipe_count = pipe_count + 1
     end
   end
 

--- a/lua/markdown-plus/types.lua
+++ b/lua/markdown-plus/types.lua
@@ -34,7 +34,7 @@
 ---Table configuration
 ---@class markdown-plus.TableConfig
 ---@field enabled? boolean Enable table features (default: true)
----@field auto_format? boolean Automatically format tables on edit (default: true)
+---@field auto_format? boolean Reserved; currently has no effect. Tables are reformatted by the table commands themselves (insert/delete row or column, cell edit, alignment toggle), not automatically as you type. Setting this to false does not suppress that. (default: true)
 ---@field default_alignment? "left"|"center"|"right" Default column alignment (default: 'left')
 ---@field confirm_destructive? boolean Confirm before destructive operations like transpose/sort (default: true)
 ---@field width_mode? "literal"|"segment" Column-width calculation mode (default: 'literal'). 'segment' measures the widest <br>-split segment so cells containing breaks don't inflate column width.

--- a/lua/markdown-plus/types.lua
+++ b/lua/markdown-plus/types.lua
@@ -34,7 +34,7 @@
 ---Table configuration
 ---@class markdown-plus.TableConfig
 ---@field enabled? boolean Enable table features (default: true)
----@field auto_format? boolean Reserved; currently has no effect. Tables are reformatted by the table commands themselves (insert/delete row or column, cell edit, alignment toggle), not automatically as you type. Setting this to false does not suppress that. (default: true)
+---@field auto_format? boolean Reserved; currently has no effect (default: true)
 ---@field default_alignment? "left"|"center"|"right" Default column alignment (default: 'left')
 ---@field confirm_destructive? boolean Confirm before destructive operations like transpose/sort (default: true)
 ---@field width_mode? "literal"|"segment" Column-width calculation mode (default: 'literal'). 'segment' measures the widest <br>-split segment so cells containing breaks don't inflate column width.

--- a/spec/markdown-plus/health_spec.lua
+++ b/spec/markdown-plus/health_spec.lua
@@ -108,6 +108,58 @@ describe("health check", function()
       assert.is_true(found_deprecation_warning, "Expected warning for deprecated vim.g.markdown_plus configuration")
     end)
 
+    it("warns when table.auto_format is explicitly disabled", function()
+      local saved_warn = vim.health.warn
+      local warning_messages = {}
+
+      vim.health.warn = function(msg, _)
+        table.insert(warning_messages, msg)
+      end
+
+      markdown_plus.setup({ table = { auto_format = false } })
+
+      local success = pcall(function()
+        health_module.check()
+      end)
+
+      vim.health.warn = saved_warn
+
+      assert.is_true(success, "Health check should run with auto_format disabled")
+
+      local found = false
+      for _, msg in ipairs(warning_messages) do
+        if msg:match("auto_format") then
+          found = true
+          break
+        end
+      end
+
+      assert.is_true(found, "Expected warning that table.auto_format has no effect")
+    end)
+
+    it("does not warn about table.auto_format when left at its default", function()
+      local saved_warn = vim.health.warn
+      local warning_messages = {}
+
+      vim.health.warn = function(msg, _)
+        table.insert(warning_messages, msg)
+      end
+
+      markdown_plus.setup({})
+
+      local success = pcall(function()
+        health_module.check()
+      end)
+
+      vim.health.warn = saved_warn
+
+      assert.is_true(success, "Health check should run with default config")
+
+      for _, msg in ipairs(warning_messages) do
+        assert.is_nil(msg:match("auto_format"), "Did not expect an auto_format warning by default")
+      end
+    end)
+
     it("warns when plugin is not loaded", function()
       local health_calls = {}
       local orig_ok, orig_warn, orig_error, orig_info, orig_start =

--- a/spec/markdown-plus/table_spec.lua
+++ b/spec/markdown-plus/table_spec.lua
@@ -882,6 +882,133 @@ describe("table.insert_mode_navigation", function()
       assert.is_true(navigation.move_up())
     end)
   end)
+
+  ---Navigation must land on the first *typing* position of the target cell.
+  ---
+  ---The rest of this file asserts only relative movement (`after_col > before_col`), which is why
+  ---an empty cell landing on the closing pipe went unnoticed. These assert exact columns.
+  describe("cursor landing position", function()
+    ---Set up a buffer and return the column the cursor lands on after `move`
+    ---@param lines string[] Buffer contents
+    ---@param start_pos integer[] {row, col} to start from
+    ---@param move string Navigation function name
+    ---@return integer col 1-indexed column after the move
+    local function land(lines, start_pos, move)
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, lines)
+      vim.fn.cursor(start_pos[1], start_pos[2])
+      assert.is_true(navigation[move]())
+      return vim.fn.col(".")
+    end
+
+    -- Cell interiors are cols 2-11, 13-22, 24-33; content starts at 3, 14, 25.
+    local EMPTY_TABLE = {
+      "| Header 1 | Header 2 | Header 3 |",
+      "| -------- | -------- | -------- |",
+      "|          |          |          |",
+      "|          |          |          |",
+    }
+
+    it("lands at the start of an empty cell when moving down", function()
+      assert.equals(3, land(EMPTY_TABLE, { 1, 3 }, "move_down"))
+    end)
+
+    it("lands at the start of an empty cell when moving up", function()
+      assert.equals(3, land(EMPTY_TABLE, { 4, 3 }, "move_up"))
+    end)
+
+    it("lands at the start of an empty cell when moving right", function()
+      assert.equals(14, land(EMPTY_TABLE, { 3, 3 }, "move_right"))
+    end)
+
+    it("lands at the start of an empty cell when moving left", function()
+      assert.equals(14, land(EMPTY_TABLE, { 3, 25 }, "move_left"))
+    end)
+
+    it("lands at the start of an empty cell between two filled cells", function()
+      local lines = {
+        "| H1 | H2   | H3 |",
+        "| -- | ---- | -- |",
+        "| a  |      | c  |",
+      }
+      -- Middle cell opens at pipe col 6, so the first typing position is col 8.
+      assert.equals(8, land(lines, { 3, 3 }, "move_right"))
+    end)
+
+    it("still lands on the first content character of a non-empty cell", function()
+      local lines = {
+        "| Header 1 | Header 2 |",
+        "| -------- | -------- |",
+        "| aaa      | bbb      |",
+      }
+      assert.equals(3, land(lines, { 1, 3 }, "move_down"))
+      assert.equals(14, land(lines, { 3, 3 }, "move_right"))
+    end)
+
+    it("lands inside the first cell of an indented table", function()
+      local lines = {
+        "  | H1 | H2 |",
+        "  | -- | -- |",
+        "  |    | b  |",
+      }
+      -- The leading pipe is at col 3, so the first typing position is col 5.
+      assert.equals(5, land(lines, { 1, 5 }, "move_down"))
+    end)
+
+    it("lands inside a zero-width cell without skipping past it", function()
+      local lines = {
+        "| H1 | H2 |",
+        "| -- | -- |",
+        "||b|",
+      }
+      assert.equals(2, land(lines, { 1, 3 }, "move_down"))
+    end)
+
+    it("lands inside a single-space cell", function()
+      local lines = {
+        "| H1 | H2 |",
+        "| -- | -- |",
+        "| | b |",
+      }
+      assert.equals(3, land(lines, { 1, 3 }, "move_down"))
+    end)
+
+    it("handles a row with no trailing pipe", function()
+      local lines = {
+        "| H1 | H2 |",
+        "| -- | -- |",
+        "| a | b",
+      }
+      assert.equals(7, land(lines, { 3, 3 }, "move_right"))
+    end)
+
+    it("does not treat an escaped pipe as a cell boundary", function()
+      local lines = {
+        "| Header 1 | H2 |",
+        "| -------- | -- |",
+        "| a \\| b   | c  |",
+      }
+      assert.equals(3, land(lines, { 1, 3 }, "move_down"))
+    end)
+
+    it("lands at the start of an empty cell after a column operation", function()
+      local helpers = require("markdown-plus.table.helpers")
+      local lines = {
+        "| H1 | H2 |",
+        "| -- | -- |",
+        "|    |    |",
+      }
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, lines)
+      vim.fn.cursor(3, 3)
+
+      local table_info = parser.get_table_at_cursor()
+      assert.is_not_nil(table_info)
+
+      assert.is_true(helpers.format_reparse_and_move(table_info, 2, 1))
+      -- Formatting normalizes every column to width 3 (the separator minimum), producing
+      -- "|     |     |", so the second cell opens at col 7 and typing starts at col 9.
+      assert.equals(9, vim.fn.col("."))
+    end)
+  end)
 end)
 
 -- Phase 2 Tests

--- a/spec/markdown-plus/table_spec.lua
+++ b/spec/markdown-plus/table_spec.lua
@@ -84,6 +84,37 @@ describe("table.parser", function()
       assert.is_not_nil(pos)
       assert.equals(2, pos.row) -- 0=header, 1=separator, 2=first data row
     end)
+
+    -- `split_row_into_cells` clears the escape flag on the second backslash, so the pipe that
+    -- follows an even-length run is a real boundary. The pipe counter here has to agree, or
+    -- navigation derives a different cell index than the parser did.
+    it("counts a pipe after an even backslash run as a cell boundary", function()
+      local lines = {
+        "| H1 | H2 | H3 |",
+        "| -- | -- | -- |",
+        "| a\\\\| b | c |", -- buffer text: | a\\| b | c |
+      }
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, lines)
+      vim.fn.cursor(3, 8) -- on "b", which is the second cell
+
+      local pos = parser.get_cursor_position_in_table()
+      assert.is_not_nil(pos)
+      assert.equals(1, pos.col)
+    end)
+
+    it("counts a pipe after an odd backslash run as escaped", function()
+      local lines = {
+        "| H1 | H2 |",
+        "| -- | -- |",
+        "| a\\| b | c |", -- buffer text: | a\| b | c |
+      }
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, lines)
+      vim.fn.cursor(3, 7) -- on "b", still inside the first cell
+
+      local pos = parser.get_cursor_position_in_table()
+      assert.is_not_nil(pos)
+      assert.equals(0, pos.col)
+    end)
   end)
 end)
 
@@ -988,6 +1019,18 @@ describe("table.insert_mode_navigation", function()
         "| a \\| b   | c  |",
       }
       assert.equals(3, land(lines, { 1, 3 }, "move_down"))
+    end)
+
+    -- An even-length backslash run escapes itself, leaving the pipe as a real boundary. Landing
+    -- must agree with `parser.split_row_into_cells`, which reads this row as three cells.
+    it("treats a pipe after an even backslash run as a cell boundary", function()
+      local lines = {
+        "| Header 1 | H2 | H3 |",
+        "| -------- | -- | -- |",
+        "| a\\\\| b | c |", -- buffer text: | a\\| b | c |
+      }
+      -- Cells open at cols 1, 6, 10; the second cell's content ("b") starts at col 8.
+      assert.equals(8, land(lines, { 1, 14 }, "move_down"))
     end)
 
     it("lands at the start of an empty cell after a column operation", function()

--- a/test/e2e/cases.lua
+++ b/test/e2e/cases.lua
@@ -217,6 +217,44 @@ return {
     expected = { "1. first", "2. [ ] ", "3. third" },
   },
 
+  -- ---------------------------------------------------------------- P1: table cell navigation
+  -- Insert-mode table navigation is <A-h/j/k/l>. Landing position matters because the next
+  -- thing the user does is type: an empty cell must put the cursor where content goes, not
+  -- against the closing pipe. Asserting buffer contents after typing proves the landing spot
+  -- without the harness needing to inspect the cursor.
+  {
+    name = "<A-j> lands at the start of an empty table cell",
+    priority = "P1",
+    lines = {
+      "| H1 | H2 |",
+      "| -- | -- |",
+      "|    |    |",
+    },
+    cursor = { 1, 2 },
+    keys = "i<A-j>x<Esc>",
+    expected = {
+      "| H1 | H2 |",
+      "| -- | -- |",
+      "| x   |    |",
+    },
+  },
+  {
+    name = "<A-l> lands at the start of the next empty table cell",
+    priority = "P1",
+    lines = {
+      "| H1 | H2 |",
+      "| -- | -- |",
+      "|    |    |",
+    },
+    cursor = { 3, 2 },
+    keys = "i<A-l>x<Esc>",
+    expected = {
+      "| H1 | H2 |",
+      "| -- | -- |",
+      "|    | x   |",
+    },
+  },
+
   -- ---------------------------------------------------------------- P2: documented reach
   {
     name = "'- [a]' reads as checkbox state 'a' (pre-existing, deliberate)",


### PR DESCRIPTION
Moving between table cells in insert mode dropped the cursor at the end of a whitespace-only cell, right against the closing pipe, so typing landed in the wrong place. Non-empty cells were fine.

Before, moving down into the empty row (`*` is the cursor):

```
| Header 1 | Header 2 | Header 3 |
| -------- | -------- | -------- |
|         *|          |          |
```

After:

```
| Header 1 | Header 2 | Header 3 |
| -------- | -------- | -------- |
| *        |          |          |
```

`find_cell_start_col` skipped whitespace after the opening pipe with no stop condition, so an all-whitespace cell ran straight past the end and stopped on the closing pipe. The scan is now bounded to the cell interior: first non-whitespace column if there is one, otherwise one padding space in, clamped so a zero-width `||` cell stays inside itself.

The same function had a second bug I found while in there. It tested `vim.trim(line):match("^|")` but then indexed the *untrimmed* line from column 1, so indented tables landed on the pipe itself. It now locates the pipe's real column.

The second commit is cleanup I hit on the way. `table.auto_format` was annotated as "format on edit" but nothing in `lua/` ever read it. I deliberately didn't wire it up: `format_table` is the only buffer write path for structural ops like `insert_column` and `clear_cell`, so gating it would turn those into silent no-ops. Instead the annotation describes what actually happens, and `:checkhealth` warns if you've set it to `false` expecting behavior.

Tested with 12 new specs asserting exact landing columns — the existing nav specs only asserted relative movement, which is why this slipped through — plus 2 e2e cases driving real `<A-j>`/`<A-l>` keypresses. I verified both e2e cases fail against the pre-fix code.
