### PR TITLE
chore(ci): configure separate Copilot environments

### DIFF
--- a/.github/workflows/copilot-code-review.yml
+++ b/.github/workflows/copilot-code-review.yml
@@ -1,0 +1,21 @@
+name: "Copilot Code Review Setup"
+
+# Keep code review independent of the cloud agent's gh-aw installation.
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-code-review.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,6 +1,6 @@
 name: "Copilot Setup Steps"
 
-# This workflow configures the environment for GitHub Copilot Agent with gh-aw MCP server
+# Prepare the cloud agent to run make check and use gh-aw tooling.
 on:
   workflow_dispatch:
   push:
@@ -22,6 +22,57 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Install Neovim
+        uses: folke/github/neovim@d1cb00f0473c256299c7b35b6e199559366e56bc # main
+        with:
+          version: v0.12.5
+
+      - name: Install Luacheck
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends lua5.1 liblua5.1-0-dev luarocks unzip
+          sudo luarocks --lua-version=5.1 install luacheck 1.2.0-1
+
+      - name: Install StyLua
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --fail --location --retry 3 \
+            https://github.com/JohnnyMorganz/StyLua/releases/download/v2.5.2/stylua-linux-x86_64.zip \
+            --output "$RUNNER_TEMP/stylua.zip"
+          printf '%s  %s\n' \
+            bcb0d855e91f102f28a370e850f8566b3b44b79e6274d806ea5246837c0fd5ab \
+            "$RUNNER_TEMP/stylua.zip" | sha256sum --check
+          unzip -q "$RUNNER_TEMP/stylua.zip" -d "$RUNNER_TEMP/stylua"
+          mkdir -p "$HOME/.local/bin"
+          install -m 0755 "$RUNNER_TEMP/stylua/stylua" "$HOME/.local/bin/stylua"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install Plenary
+        shell: bash
+        run: |
+          set -euo pipefail
+          PLENARY_DIR="$RUNNER_TEMP/plenary.nvim"
+          git init "$PLENARY_DIR"
+          git -C "$PLENARY_DIR" remote add origin https://github.com/nvim-lua/plenary.nvim.git
+          git -C "$PLENARY_DIR" fetch --depth 1 origin 74b06c6c75e4eeb3108ec01852001636d85a932b
+          git -C "$PLENARY_DIR" checkout --detach FETCH_HEAD
+          echo "PLENARY_DIR=$PLENARY_DIR" >> "$GITHUB_ENV"
+
+      - name: Verify development tools
+        shell: bash
+        run: |
+          set -euo pipefail
+          nvim --version
+          stylua --version
+          luacheck --version
+          nvim --headless --noplugin -u spec/minimal_init.lua -l - <<'LUA'
+          require("plenary.busted")
+          LUA
+
       - name: Install gh-aw extension
         uses: github/gh-aw-actions/setup-cli@v0.88.3
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,18 @@ git clone https://github.com/nvim-lua/plenary.nvim \
   ~/.local/share/nvim/site/pack/vendor/start/plenary.nvim
 ```
 
+### Copilot Cloud Agent
+
+`.github/workflows/copilot-setup-steps.yml` preinstalls pinned versions of Neovim,
+Plenary, StyLua, and Luacheck so the cloud coding agent can run `make check`.
+It exports `PLENARY_DIR` for the test harness and retains the existing `gh-aw`
+installation. The setup checks tool availability without requiring the tests to
+pass before the agent starts working.
+
+Copilot code review uses the separate, checkout-only
+`.github/workflows/copilot-code-review.yml`; it does not inherit these installations.
+When updating the tool pins, update the StyLua archive checksum as well.
+
 ### Project Structure
 
 ```


### PR DESCRIPTION
## Description
Prepare the Copilot cloud coding agent to use the plugin's development tools, while keeping code review on a separate checkout-only setup.

- Install pinned Neovim, Plenary, StyLua, and Luacheck; verify the StyLua archive checksum and export `PLENARY_DIR` for the test harness.
- Preserve the existing gh-aw setup for the cloud agent without inheriting it in `copilot-code-review.yml`.
- Document the two environments in `CONTRIBUTING.md`.

This is environment isolation and development-tool provisioning, **not a confirmed fix** for the hosted review failure. No failing runner trace established gh-aw as the cause. Hosted provisioning and review behavior still need verification.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

Development workflow configuration.

## Related Issues
No linked issue. Follow-up to the Copilot review failure on #414.

## Testing
- [x] Tested manually
- [ ] Added/updated tests (if applicable)

Validated YAML structure with the existing `yq`/`jq` tools and embedded shell syntax with `bash -n`. Confirmed the StyLua download checksum, pinned tool references, and successful local tool/Plenary smoke check. Ran `make check` successfully with matching Neovim, StyLua, Luacheck, and Plenary versions/revision.

No new test suite was needed for this setup-only change. `actionlint` was unavailable; no new validator was installed. Linux provisioning and hosted Copilot execution were not exercised locally.

## Checklist
- [x] Code follows project style
- [x] Self-reviewed my code
- [x] Commented complex logic
- [x] Updated documentation (if needed)
- [x] No new warnings generated